### PR TITLE
Use modal for map instead of `<details>`

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -904,17 +904,22 @@ class Home extends React.Component {
                   </select>
                 </label>
 
-                <button
-                  type="button"
-                  onClick={() => this.setState({ isMapOpen: true })}
-                >
-                  Where: (click to edit)
+                <label>
+                  Where:
                   <br />
-                  {this.state.formatted_address
-                    .split(', ')
-                    .slice(0, 2)
-                    .join(', ')}
-                </button>
+                  <button
+                    type="button"
+                    onClick={() => this.setState({ isMapOpen: true })}
+                    style={{
+                      width: '100%',
+                    }}
+                  >
+                    {this.state.formatted_address
+                      .split(', ')
+                      .slice(0, 2)
+                      .join(', ')}
+                  </button>
+                </label>
 
                 <Modal
                   isOpen={this.state.isMapOpen}

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -240,6 +240,7 @@ class Home extends React.Component {
     const initialStatePersistent = {
       ...initialStatePerSubmission,
       isUserInfoOpen: true,
+      isMapOpen: false,
     };
 
     const initialStatePerSession = {
@@ -903,16 +904,27 @@ class Home extends React.Component {
                   </select>
                 </label>
 
-                <details>
-                  <summary>
-                    Where: (click to edit)
-                    <br />
-                    {this.state.formatted_address
-                      .split(', ')
-                      .slice(0, 2)
-                      .join(', ')}
-                  </summary>
+                <button
+                  type="button"
+                  onClick={() => this.setState({ isMapOpen: true })}
+                >
+                  Where: (click to edit)
+                  <br />
+                  {this.state.formatted_address
+                    .split(', ')
+                    .slice(0, 2)
+                    .join(', ')}
+                </button>
 
+                <Modal
+                  isOpen={this.state.isMapOpen}
+                  onRequestClose={() => this.setState({ isMapOpen: false })}
+                  style={{
+                    content: {
+                      padding: 0,
+                    },
+                  }}
+                >
                   <MyMapComponent
                     key="map"
                     position={{
@@ -950,7 +962,7 @@ class Home extends React.Component {
                       });
                     }}
                   />
-                </details>
+                </Modal>
 
                 <label>
                   When:{' '}
@@ -1171,7 +1183,7 @@ const MyMapComponent = compose(
   withProps({
     googleMapURL: `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&v=3.exp&libraries=geometry,drawing,places`,
     loadingElement: <div style={{ height: `100%` }} />,
-    containerElement: <div style={{ height: `75vh` }} />,
+    containerElement: <div style={{ height: `100%` }} />,
     mapElement: <div style={{ height: `100%` }} />,
   }),
   withScriptjs,

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -643,20 +643,14 @@ exports[`Home renders children correctly 1`] = `
               </option>
             </select>
           </label>
-          <details>
-            <summary>
-              Where: (click to edit)
-              <br />
-              
-            </summary>
-            <div
-              style={
-                Object {
-                  "height": "100%",
-                }
-              }
-            />
-          </details>
+          <button
+            onClick={[Function]}
+            type="button"
+          >
+            Where: (click to edit)
+            <br />
+            
+          </button>
           <label>
             When:
              

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -643,14 +643,21 @@ exports[`Home renders children correctly 1`] = `
               </option>
             </select>
           </label>
-          <button
-            onClick={[Function]}
-            type="button"
-          >
-            Where: (click to edit)
+          <label>
+            Where:
             <br />
-            
-          </button>
+            <button
+              onClick={[Function]}
+              style={
+                Object {
+                  "width": "100%",
+                }
+              }
+              type="button"
+            >
+              
+            </button>
+          </label>
           <label>
             When:
              


### PR DESCRIPTION
This makes it clearer that it scrolls independently of the rest of the app,
and also lets it be bigger on desktop screens.

However, it may not be obvious to some how to close it (clicking on the overlay).

Best viewed ignoring whitespace:

    git show -w