### PR TITLE
Normalize email domains to lowercase

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -521,7 +521,16 @@ class Home extends React.Component {
                       autoComplete="email"
                       value={this.state.email}
                       name="email"
-                      onChange={this.handleInputChange}
+                      onChange={event => {
+                        this.handleInputChange({
+                          target: {
+                            name: event.target.name,
+                            value: event.target.value.replace(/@.*/, atDomain =>
+                              atDomain.toLowerCase(),
+                            ),
+                          },
+                        });
+                      }}
                     />
                   </label>
 


### PR DESCRIPTION
This fixes https://github.com/josephfrazier/Reported-Web/issues/30

However, note that it causes the cursor to jump when inserting an
uppercase character into the middle of a pre-existing domain.
(This is already a problem for the license plate field, but with
lowercase characters).