### PR TITLE
Reset progress bar after submission completes

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -849,6 +849,8 @@ class Home extends React.Component {
                   .then(() => {
                     this.setState({
                       isSubmitting: false,
+                      submitProgressValue: null,
+                      submitProgressMax: null,
                     });
                   });
               }}


### PR DESCRIPTION
This was making the next submission look like it was already done,
even if it hadn't started yet.

Fixes https://github.com/josephfrazier/Reported-Web/issues/44