### PR TITLE
Revert "Configure `yarn run deploy` for Heroku"

### DIFF
--- a/tools/deploy.js
+++ b/tools/deploy.js
@@ -14,21 +14,21 @@ import { makeDir, moveDir, cleanDir } from './lib/fs';
 import run from './run';
 
 // GitHub Pages
-// const remote = {
-//   name: 'github',
-//   url: 'https://github.com/<user>/<repo>.git',
-//   branch: 'gh-pages',
-//   website: 'https://<user>.github.io/<repo>/',
-//   static: true,
-// };
+const remote = {
+  name: 'github',
+  url: 'https://github.com/<user>/<repo>.git',
+  branch: 'gh-pages',
+  website: 'https://<user>.github.io/<repo>/',
+  static: true,
+};
 
 // Heroku
-const remote = {
-  name: 'heroku',
-  url: 'https://git.heroku.com/reported-web.git',
-  branch: 'master',
-  website: 'https://reported-web.herokuapp.com',
-};
+// const remote = {
+//   name: 'heroku',
+//   url: 'https://git.heroku.com/<app>.git',
+//   branch: 'master',
+//   website: 'https://<app>.herokuapp.com',
+// };
 
 // Azure Web Apps
 // const remote = {


### PR DESCRIPTION
Now that Heroku deploys upon push (https://github.com/josephfrazier/Reported-Web/pull/47),
we don't need/want it to be configured in the deploy script.

This reverts commit fec2d65e5aaeeb6615bd160f105e6b2d30829ac4.