### PR TITLE
Use `<input type=search>` instead of Clear `<button>`

### DIFF
--- a/src/routes/home/Home.css
+++ b/src/routes/home/Home.css
@@ -32,3 +32,11 @@ label {
   display: block;
   margin: 1em 0;
 }
+
+input[type='search'] {
+  -webkit-appearance: searchfield;
+}
+
+input[type='search']::-webkit-search-cancel-button {
+  -webkit-appearance: searchfield-cancel-button;
+}

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -977,7 +977,7 @@ class Home extends React.Component {
                   <div style={{ display: 'flex' }}>
                     <input
                       required
-                      type="text"
+                      type="search"
                       value={this.state.plate}
                       list="plateSuggestion"
                       ref={this.plateRef}
@@ -1010,15 +1010,6 @@ class Home extends React.Component {
                         </option>
                       ))}
                     </select>
-                    &nbsp;
-                    <button
-                      type="button"
-                      onClick={() => {
-                        this.setLicensePlate({ plate: '', licenseState: 'NY' });
-                      }}
-                    >
-                      Clear
-                    </button>
                   </div>
                   {this.state.vehicleInfoComponent}
                 </label>

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -328,7 +328,7 @@ exports[`Home renders children correctly 1`] = `
                 onChange={[Function]}
                 placeholder=""
                 required={true}
-                type="text"
+                type="search"
                 value=""
               />
               <datalist
@@ -593,13 +593,6 @@ exports[`Home renders children correctly 1`] = `
                   Wyoming
                 </option>
               </select>
-               
-              <button
-                onClick={[Function]}
-                type="button"
-              >
-                Clear
-              </button>
             </div>
             <br />
           </label>


### PR DESCRIPTION
This makes the UI a little cleaner.

References:

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search
* https://stackoverflow.com/questions/32312348/how-to-show-x-clear-in-chrome-input-with-type-number/35359851#35359851