### PR TITLE
Add/use /api/validate_location endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,12 @@
+# geoclient keys
+# go here and register: https://developer.cityofnewyork.us/api/geoclient-api
+# https://developer.cityofnewyork.us/ for more info
+GEO_APP_ID=
+GEO_APP_KEY=
+
+# go to https://developers.google.com/maps/documentation/geocoding/start?hl=en_US#get-a-key
+GOOGLE_API_KEY=
+
 # HEROKU_APP_NAME must be set on Heroku, but not locally,
 # as described in https://devcenter.heroku.com/articles/dyno-metadata
 # HEROKU_APP_NAME='reported-web'

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -49,10 +49,11 @@ import { isImage, isVideo } from '../../isImage.js';
 
 const GOOGLE_MAPS_API_KEY = 'AIzaSyDlwm2ykA0ohTXeVepQYvkcmdjz2M2CKEI';
 
-const debouncedReverseGeocode = debounce(async ({ latitude, longitude }) => {
-  const { data } = await axios.get(
-    `https://maps.googleapis.com/maps/api/geocode/json?latlng=${latitude},${longitude}&key=${GOOGLE_MAPS_API_KEY}`,
-  );
+const debouncedValidateLocation = debounce(async ({ latitude, longitude }) => {
+  const { data } = await axios.post('/api/validate_location', {
+    lat: latitude,
+    long: longitude,
+  });
   return data;
 }, 500);
 
@@ -329,8 +330,10 @@ class Home extends React.Component {
       longitude,
       formatted_address: 'Finding Address...',
     });
-    debouncedReverseGeocode({ latitude, longitude }).then(data => {
-      this.setState({ formatted_address: data.results[0].formatted_address });
+    debouncedValidateLocation({ latitude, longitude }).then(data => {
+      this.setState({
+        formatted_address: data.google_response.results[0].formatted_address,
+      });
     });
   };
 

--- a/src/server.js
+++ b/src/server.js
@@ -50,6 +50,9 @@ const {
   PARSE_SERVER_URL,
   HEROKU_RELEASE_VERSION,
   OPENALPR_SECRET_KEY,
+  GEO_APP_ID,
+  GEO_APP_KEY,
+  GOOGLE_API_KEY,
 } = process.env;
 
 require('heroku-self-ping')(config.api.serverUrl, {
@@ -211,6 +214,93 @@ app.use('/api/categories', (req, res) => {
       }));
       res.json({ categories });
     })
+    .catch(handlePromiseRejection(res));
+});
+
+// ported from https://github.com/jeffrono/Reported/blob/19b588171315a3093d53986f9fb995059f5084b4/v2/enrich_functions.rb#L149-L154
+async function getCbData(id) {
+  const url =
+    'https://raw.githubusercontent.com/codebutler/59boards/master/frontend/src/shared/data/districts-info.json';
+  const { data: response } = await axios.get(url);
+  return response[id];
+}
+
+// takes lat long
+// returns hash with google response, geoclient response, and status
+// ported from https://github.com/jeffrono/Reported/blob/19b588171315a3093d53986f9fb995059f5084b4/v2/enrich_functions.rb#L91-L146
+async function validateLocation({ lat, long }) {
+  const response = { lat, long };
+  const GOOGLE_MAP_URL =
+    'https://maps.googleapis.com/maps/api/geocode/json?latlng=';
+  const url = `${GOOGLE_MAP_URL +
+    lat},${long}&result_type=street_address&key=${GOOGLE_API_KEY}`;
+  const { data: googleResponse } = await axios.get(url);
+
+  // check if zero results
+  if (googleResponse.status === 'ZERO_RESULTS') {
+    console.log('zero results!'); // eslint-disable-line no-console
+    response.google_response = googleResponse;
+    response.geoclient_response = null;
+    response.valid = false;
+    return response;
+  }
+
+  const address = googleResponse.results[0];
+  const building = address.address_components[0].short_name;
+  const street = address.address_components[1].short_name;
+  let borough;
+
+  if (
+    ['Brooklyn', 'Manhattan', 'Staten Island', 'Bronx', 'Queens'].includes(
+      address.address_components[3].short_name,
+    )
+  ) {
+    borough = address.address_components[3].short_name.toUpperCase();
+  } else if (
+    ['Brooklyn', 'Manhattan', 'Staten Island', 'Bronx', 'Queens'].includes(
+      address.address_components[2].short_name,
+    )
+  ) {
+    borough = address.address_components[2].short_name.toUpperCase();
+  } else {
+    borough = 'MANHATTAN';
+  }
+
+  const { data: geoclientResponse } = await axios.get(
+    'https://api.cityofnewyork.us/geoclient/v1/address.json',
+    {
+      params: {
+        houseNumber: building,
+        street,
+        borough,
+        app_id: GEO_APP_ID,
+        app_key: GEO_APP_KEY,
+      },
+    },
+  );
+
+  response.google_response = googleResponse;
+  response.geoclient_response = geoclientResponse;
+
+  if (geoclientResponse.address.message) {
+    // then geoclient returned invalid data
+    response.valid = false;
+    console.log('not a valid address'); // eslint-disable-line no-console
+  } else {
+    // then geoclient returned VALID data!!
+    response.valid = true;
+    // get community board meta data
+    const cbid = geoclientResponse.address.communityDistrict;
+    response.cb_data = await getCbData(cbid);
+  }
+
+  return response;
+}
+
+app.use('/api/validate_location', (req, res) => {
+  const { lat, long } = req.body;
+  validateLocation({ lat, long })
+    .then(body => res.json(body))
     .catch(handlePromiseRejection(res));
 });
 


### PR DESCRIPTION
Add/use /api/validate_location endpoint

Test with e.g.

    http localhost:3000/api/validate_location lat=40.751230 long=-73.971510

Using [http]

[http]: https://httpie.org/

This is used by the client so that the geoclient and CB data shows up in
the network reponses, even though we're not using them here. This lets
them be more easily tested out by e.g. @jeffrono.