### PR TITLE
/api/validate_location: Ensure lat/long are provided

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -299,6 +299,9 @@ async function validateLocation({ lat, long }) {
 
 app.use('/api/validate_location', (req, res) => {
   const { lat, long } = req.body;
+  if (!lat || !long) {
+    res.status(400).end();
+  }
   validateLocation({ lat, long })
     .then(body => res.json(body))
     .catch(handlePromiseRejection(res));


### PR DESCRIPTION
This prevents crashes when simply visiting the API endpoint URL