### PR TITLE
Use json-stringify-safe for promise rejection HTTP responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "humanize-string": "^1.0.2",
     "image-extensions": "^1.1.0",
     "isomorphic-style-loader": "^4.0.0",
+    "json-stringify-safe": "^5.0.1",
     "lodash.sortby": "^4.7.0",
     "marx-css": "^3.0.3",
     "mp4box": "https://github.com/josephfrazier/mp4box.js#commonjs",

--- a/src/server.js
+++ b/src/server.js
@@ -23,6 +23,7 @@ import fileType from 'file-type-es5';
 import sharp from 'sharp';
 import axios from 'axios';
 import multer from 'multer';
+import stringify from 'json-stringify-safe';
 
 import { isImage, isVideo } from './isImage.js';
 
@@ -108,7 +109,7 @@ app.use(bodyParser.json({ limit: '80mb' }));
 
 const handlePromiseRejection = res => error => {
   console.error({ error });
-  res.status(500).json({ error });
+  res.status(500).json(JSON.parse(stringify({ error })));
 };
 
 async function logIn({ email, password }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6797,7 +6797,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 


### PR DESCRIPTION
**EDIT: Note that this exposes the Google API key in the example below. That's available client-side anyway, but this sort of thing should be considered when approaching general error-handling.**

This prevents crashes like the following when visiting
/api/validate_location in a browser (see https://github.com/josephfrazier/Reported-Web/pull/57)

    Unhandled Rejection at: Promise {
      <rejected> TypeError: Converting circular structure to JSON
        at JSON.stringify (<anonymous>)
        at stringify (/home/josephfrazier/workspace/reported-web/node_modules/express/lib/response.js:1119:12)
        at ServerResponse.json (/home/josephfrazier/workspace/reported-web/node_modules/express/lib/response.js:260:14)
        at /home/josephfrazier/workspace/reported-web/src/server.js:111:1
        at process._tickCallback (internal/process/next_tick.js:68:7) } reason: TypeError: Converting circular structure to JSON
        at JSON.stringify (<anonymous>)
        at stringify (/home/josephfrazier/workspace/reported-web/node_modules/express/lib/response.js:1119:12)
        at ServerResponse.json (/home/josephfrazier/workspace/reported-web/node_modules/express/lib/response.js:260:14)
        at /home/josephfrazier/workspace/reported-web/src/server.js:111:1
        at process._tickCallback (internal/process/next_tick.js:68:7)
    TypeError: Converting circular structure to JSON
        at JSON.stringify (<anonymous>)
        at stringify (/home/josephfrazier/workspace/reported-web/node_modules/express/lib/response.js:1119:12)
        at ServerResponse.json (/home/josephfrazier/workspace/reported-web/node_modules/express/lib/response.js:260:14)
        at /home/josephfrazier/workspace/reported-web/src/server.js:111:1
        at process._tickCallback (internal/process/next_tick.js:68:7)