### PR TITLE
Show TLC SR# in "Previous Submissions" dropdown

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -103,6 +103,8 @@ class SubmissionDetails extends React.Component {
           {medallionNo} {typeofcomplaint} near{' '}
           {/* eslint-disable-next-line camelcase */}
           {(loc1_address || '').split(',')[0]} on {humanTimeString}
+          <br />
+          TLC Service Request Number: {reqnumber}
         </summary>
 
         {this.state.isDetailsOpen && (

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -14,6 +14,9 @@ exports[`SubmissionDetails renders children correctly 1`] = `
     82 Reade St
      on 
     Mockday 2016-11-18T00:00:00.000Z GMT-0500 (MockDate)
+    <br />
+    TLC Service Request Number: 
+    reqnumber
   </summary>
   <a
     href="photoData0.url"


### PR DESCRIPTION
This addresses the following suggestion from https://reportedcab.slack.com/messages/C9XA8EFEJ/p1535725560000100:

> One suggestion for the app… Be able to search by complaint number.
> Ideally it would be a contains search, so just a few numbers need to be
> entered. (LIKE "% … %")