### PR TITLE
When offline, show big link to reload

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,18 @@
 // Derived from https://github.com/pwa-builder/serviceworkers/blob/5b9128ec9232556171f0969bc2aa9c6039054ed6/serviceWorker1/pwabuilder-sw.js
 
-const offlineBody = 'You need to be online to use Reported.';
+const offlineBody = `
+  <h1>
+    <a href=".">
+      You need to be online to use Reported.
+      <br/>
+      Click here to retry.
+    </a>
+  </h1>
+`;
+
+const offlineHeaders = {
+  headers: { 'Content-Type': 'text/html' },
+};
 
 // If any fetch fails, it will show `offlineBody`
 // Maybe this should be limited to HTML documents?
@@ -21,7 +33,7 @@ self.addEventListener('fetch', event => {
         message: `[PWA Builder] Network request Failed. Serving offline page ${error}`,
         event,
       });
-      return new Response(offlineBody);
+      return new Response(offlineBody, offlineHeaders);
     }),
   );
 });


### PR DESCRIPTION
This makes it a little more obvious how to "retry" when on a spotty
connection. Before, you had to either close the app and re-open it, or
know to pull down on the screen.

References:
* Link to reload current page: https://stackoverflow.com/questions/8174282/link-to-reload-current-page/12108553#12108553
* Creating a HTML response using a string inside a service worker's fetch event: https://stackoverflow.com/questions/38230658/creating-a-html-response-using-a-string-inside-a-service-workers-fetch-event/38232302#38232302