### PR TITLE
electricitibikes: Show approx. # blocks with distance

### DIFF
--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -154,7 +154,8 @@ export function ElectriCitibikeList({ data, latitude, longitude, updatedAt }) {
               {station.name}
             </a>
             <br />
-            ({station.dist} (~{Math.ceil(station.distMeters / 80)} blocks) away)
+            ({station.dist} away, about {Math.ceil(station.distMeters / 80)}{' '}
+            blocks)
           </summary>
           <ul>
             {station.ebikes &&

--- a/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
+++ b/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
@@ -25,9 +25,10 @@ Array [
       <br />
       (
       1.6 mi
-       (~
+       away, about 
       33
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul />
   </details>,
@@ -51,9 +52,10 @@ Array [
       <br />
       (
       2.1 mi
-       (~
+       away, about 
       42
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -84,9 +86,10 @@ Array [
       <br />
       (
       2.1 mi
-       (~
+       away, about 
       42
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -117,9 +120,10 @@ Array [
       <br />
       (
       2.2 mi
-       (~
+       away, about 
       44
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -150,9 +154,10 @@ Array [
       <br />
       (
       2.7 mi
-       (~
+       away, about 
       54
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -183,9 +188,10 @@ Array [
       <br />
       (
       2.9 mi
-       (~
+       away, about 
       60
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -216,9 +222,10 @@ Array [
       <br />
       (
       3 mi
-       (~
+       away, about 
       61
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -249,9 +256,10 @@ Array [
       <br />
       (
       3.5 mi
-       (~
+       away, about 
       70
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -282,9 +290,10 @@ Array [
       <br />
       (
       3.6 mi
-       (~
+       away, about 
       72
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul />
   </details>,
@@ -308,9 +317,10 @@ Array [
       <br />
       (
       4.1 mi
-       (~
+       away, about 
       83
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -341,9 +351,10 @@ Array [
       <br />
       (
       4.7 mi
-       (~
+       away, about 
       95
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -374,9 +385,10 @@ Array [
       <br />
       (
       4.8 mi
-       (~
+       away, about 
       97
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul />
   </details>,
@@ -400,9 +412,10 @@ Array [
       <br />
       (
       5.3 mi
-       (~
+       away, about 
       107
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -433,9 +446,10 @@ Array [
       <br />
       (
       5.6 mi
-       (~
+       away, about 
       112
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>
@@ -466,9 +480,10 @@ Array [
       <br />
       (
       5.9 mi
-       (~
+       away, about 
       119
-       blocks) away)
+       
+      blocks)
     </summary>
     <ul>
       <li>


### PR DESCRIPTION
Fixes https://github.com/josephfrazier/Reported-Web/issues/78

From https://en.wikipedia.org/wiki/City_block:

> The standard block in Manhattan is about 264 by 900 feet (80 m × 274 m)