### PR TITLE
electricitibikes: Fix coords in map links

### DIFF
--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -122,8 +122,8 @@ export function ElectriCitibikeList({ data, latitude, longitude, updatedAt }) {
 
     return {
       ...f.properties,
-      latitude,
-      longitude,
+      latitude: end.latitude,
+      longitude: end.longitude,
       dist,
       distMeters,
     };

--- a/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
+++ b/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
@@ -16,7 +16,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.7361967,-74.00859207"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -43,7 +43,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.689888,-73.981013"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -77,7 +77,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.69580705,-73.97355569"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -111,7 +111,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.69573398,-73.97129668"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -145,7 +145,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.7505853470215,-73.9946848154068"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -179,7 +179,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.72708584,-73.95299117"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -213,7 +213,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.71915571696044,-73.94885390996933"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -247,7 +247,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.69622937,-73.94371094"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -281,7 +281,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.663779,-73.98396846"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -308,7 +308,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.76915505,-73.98191841"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -342,7 +342,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.7689738,-73.95482273"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -376,7 +376,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.78057799010334,-73.98562431335449"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -403,7 +403,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.78499979,-73.97283406"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -437,7 +437,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.79025417330419,-73.97718340158461"
         rel="noopener noreferrer"
         target="_blank"
       >
@@ -471,7 +471,7 @@ Array [
       1
        @ 
       <a
-        href="https://www.google.com/maps?hl=en&q=40.7128,-74.006"
+        href="https://www.google.com/maps?hl=en&q=40.7937704,-73.971888"
         rel="noopener noreferrer"
         target="_blank"
       >


### PR DESCRIPTION
Commit 2e0107aee8bff92e73cbcef4f8f64ee110c102d2 made it so all the map
links went to the coordinates passed as props, rather than the station
coordinates from the Citibike API. This should fix that.