### PR TITLE
electricitibikes: Show compass bearing of stations

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "file-type-es5": "^6.2.1",
     "force-ssl-heroku": "^1.0.2",
     "geodist": "^0.2.1",
+    "geolib": "^2.0.24",
     "global": "^4.3.2",
     "heroku-self-ping": "^1.1.4",
     "history": "^4.7.2",

--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -15,6 +15,7 @@ import geodist from 'geodist';
 import 'intl/locale-data/jsonp/en.js'; // https://github.com/andyearnshaw/Intl.js/issues/271#issuecomment-292233493
 import strftime from 'strftime';
 import PolygonLookup from 'polygon-lookup';
+import geolib from 'geolib';
 
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './ElectriCitibikes.css';
@@ -143,9 +144,11 @@ export function ElectriCitibikeList({
     };
     let dist = 'unknown distance';
     let distMeters;
+    let compassBearing;
     if (start.latitude && start.longitude) {
       dist = humanizeDistance(start, end, 'en-US', 'us');
       distMeters = geodist(start, end, { unit: 'meters', exact: true });
+      compassBearing = geolib.getCompassDirection(start, end).exact;
     }
 
     const boroughPolygon = lookup.search(end.longitude, end.latitude);
@@ -157,6 +160,7 @@ export function ElectriCitibikeList({
       dist,
       distMeters,
       boroughPolygon,
+      compassBearing,
     };
   });
 
@@ -185,8 +189,8 @@ export function ElectriCitibikeList({
               {station.name}, {station.boroughPolygon.properties.BoroName}
             </a>
             <br />
-            ({station.dist} away, about {Math.ceil(station.distMeters / 80)}{' '}
-            blocks)
+            ({station.dist} {station.compassBearing} from you, about{' '}
+            {Math.ceil(station.distMeters / 80)} blocks)
           </summary>
           <ul>
             {station.ebikes &&

--- a/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
+++ b/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
@@ -27,10 +27,12 @@ Array [
       <br />
       (
       1.6 mi
-       away, about 
-      33
        
-      blocks)
+      N
+       from you, about
+       
+      33
+       blocks)
     </summary>
     <ul />
   </details>,
@@ -56,10 +58,12 @@ Array [
       <br />
       (
       2.1 mi
-       away, about 
-      42
        
-      blocks)
+      SE
+       from you, about
+       
+      42
+       blocks)
     </summary>
     <ul>
       <li>
@@ -92,10 +96,12 @@ Array [
       <br />
       (
       2.1 mi
-       away, about 
-      42
        
-      blocks)
+      SE
+       from you, about
+       
+      42
+       blocks)
     </summary>
     <ul>
       <li>
@@ -128,10 +134,12 @@ Array [
       <br />
       (
       2.2 mi
-       away, about 
-      44
        
-      blocks)
+      ESE
+       from you, about
+       
+      44
+       blocks)
     </summary>
     <ul>
       <li>
@@ -164,10 +172,12 @@ Array [
       <br />
       (
       2.7 mi
-       away, about 
-      54
        
-      blocks)
+      NNE
+       from you, about
+       
+      54
+       blocks)
     </summary>
     <ul>
       <li>
@@ -200,10 +210,12 @@ Array [
       <br />
       (
       2.9 mi
-       away, about 
-      60
        
-      blocks)
+      ENE
+       from you, about
+       
+      60
+       blocks)
     </summary>
     <ul>
       <li>
@@ -236,10 +248,12 @@ Array [
       <br />
       (
       3 mi
-       away, about 
-      61
        
-      blocks)
+      E
+       from you, about
+       
+      61
+       blocks)
     </summary>
     <ul>
       <li>
@@ -272,10 +286,12 @@ Array [
       <br />
       (
       3.5 mi
-       away, about 
-      70
        
-      blocks)
+      ESE
+       from you, about
+       
+      70
+       blocks)
     </summary>
     <ul>
       <li>
@@ -308,10 +324,12 @@ Array [
       <br />
       (
       3.6 mi
-       away, about 
-      72
        
-      blocks)
+      SSE
+       from you, about
+       
+      72
+       blocks)
     </summary>
     <ul />
   </details>,
@@ -337,10 +355,12 @@ Array [
       <br />
       (
       4.1 mi
-       away, about 
-      83
        
-      blocks)
+      NNE
+       from you, about
+       
+      83
+       blocks)
     </summary>
     <ul>
       <li>
@@ -373,10 +393,12 @@ Array [
       <br />
       (
       4.7 mi
-       away, about 
-      95
        
-      blocks)
+      NE
+       from you, about
+       
+      95
+       blocks)
     </summary>
     <ul>
       <li>
@@ -409,10 +431,12 @@ Array [
       <br />
       (
       4.8 mi
-       away, about 
-      97
        
-      blocks)
+      NNE
+       from you, about
+       
+      97
+       blocks)
     </summary>
     <ul />
   </details>,
@@ -438,10 +462,12 @@ Array [
       <br />
       (
       5.3 mi
-       away, about 
-      107
        
-      blocks)
+      NNE
+       from you, about
+       
+      107
+       blocks)
     </summary>
     <ul>
       <li>
@@ -474,10 +500,12 @@ Array [
       <br />
       (
       5.6 mi
-       away, about 
-      112
        
-      blocks)
+      NNE
+       from you, about
+       
+      112
+       blocks)
     </summary>
     <ul>
       <li>
@@ -510,10 +538,12 @@ Array [
       <br />
       (
       5.9 mi
-       away, about 
-      119
        
-      blocks)
+      NNE
+       from you, about
+       
+      119
+       blocks)
     </summary>
     <ul>
       <li>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5199,6 +5199,10 @@ geodist@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/geodist/-/geodist-0.2.1.tgz#9619a5d935529335716faafad32228c29dc0b920"
 
+geolib@^2.0.24:
+  version "2.0.24"
+  resolved "https://registry.yarnpkg.com/geolib/-/geolib-2.0.24.tgz#eb3d7fbc65f5ea3354a5af6054563ebe9f33e5f4"
+
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"


### PR DESCRIPTION
This uses [geolib.getCompassDirection] to show which way each station is.

[geolib.getCompassDirection]: https://github.com/manuelbieh/Geolib/tree/ead32d0b0dbc41d3bbea56916df016f1dedf24e5#geolibgetcompassdirectionobject-originll-object-destll-string-bearingmode-optional

Fixes https://github.com/josephfrazier/Reported-Web/issues/85