### PR TITLE
SubmissionDetails: Show `reportDescription` when expanded

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -22,6 +22,7 @@ class SubmissionDetails extends React.Component {
       typeofcomplaint,
       loc1_address, // eslint-disable-line camelcase
       timeofreport,
+      reportDescription,
 
       photoData0,
       photoData1,
@@ -109,6 +110,7 @@ class SubmissionDetails extends React.Component {
 
         {this.state.isDetailsOpen && (
           <React.Fragment>
+            <p>{reportDescription}</p>
             <ImagesAndVideos />
 
             {!reqnumber.startsWith('N/A') && (
@@ -131,6 +133,7 @@ SubmissionDetails.propTypes = {
     typeofcomplaint: PropTypes.string,
     loc1_address: PropTypes.string,
     timeofreport: PropTypes.string,
+    reportDescription: PropTypes.string,
 
     photoData0: PropTypes.object,
     photoData1: PropTypes.object,

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -18,6 +18,7 @@ describe('SubmissionDetails', () => {
       typeofcomplaint: 'typeofcomplaint',
       loc1_address: '82 Reade St, New York, NY 10007, USA',
       timeofreport: new Date(Date.now()).toISOString(),
+      reportDescription: 'reportDescription',
 
       photoData0: { url: 'photoData0.url' },
       photoData1: { url: 'photoData1.url' },

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -18,6 +18,9 @@ exports[`SubmissionDetails renders children correctly 1`] = `
     TLC Service Request Number: 
     reqnumber
   </summary>
+  <p>
+    reportDescription
+  </p>
   <a
     href="photoData0.url"
     rel="noopener noreferrer"


### PR DESCRIPTION
This makes it easier to find what you had originally submitted.