### PR TITLE
Service Worker: Make reload link work on `/electricitibikes`

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
 
 const offlineBody = `
   <h1>
-    <a href=".">
+    <a href="javascript:window.location.reload()">
       You need to be online to use Reported.
       <br/>
       Click here to retry.


### PR DESCRIPTION
Before, `href="."` would just go back to `/`, so let's use
`location.reload()` instead.