### PR TITLE
electricitibikes: Print `new PolygonLookup` time to console

### DIFF
--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -142,7 +142,9 @@ export function ElectriCitibikeList({
 }) {
   let lookup;
   if (boroughBoundariesFeatureCollection) {
+    console.time('new PolygonLookup'); // eslint-disable-line no-console
     lookup = new PolygonLookup(boroughBoundariesFeatureCollection);
+    console.timeEnd('new PolygonLookup'); // eslint-disable-line no-console
   }
 
   const stations = data.features.map(f => {


### PR DESCRIPTION
Might be useful for diagnosing mobile slowness