### PR TITLE
electricitibikes: Show max bike charge in station summary

### DIFF
--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -210,6 +210,11 @@ export function ElectriCitibikeList({
             <br />
             ({station.dist} {station.compassBearing} from you, about{' '}
             {Math.ceil(station.distMeters / 80)} blocks)
+            <br />
+            Max Charge:{' '}
+            {Math.max(
+              (station.ebikes || [{ charge: 0 }]).map(ebike => ebike.charge),
+            ) || '?'}/4
           </summary>
           <ul>
             {station.ebikes &&

--- a/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
+++ b/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
@@ -33,6 +33,11 @@ Array [
        
       33
        blocks)
+      <br />
+      Max Charge:
+       
+      ?
+      /4
     </summary>
     <ul />
   </details>,
@@ -64,6 +69,11 @@ Array [
        
       42
        blocks)
+      <br />
+      Max Charge:
+       
+      3
+      /4
     </summary>
     <ul>
       <li>
@@ -102,6 +112,11 @@ Array [
        
       42
        blocks)
+      <br />
+      Max Charge:
+       
+      3
+      /4
     </summary>
     <ul>
       <li>
@@ -140,6 +155,11 @@ Array [
        
       44
        blocks)
+      <br />
+      Max Charge:
+       
+      3
+      /4
     </summary>
     <ul>
       <li>
@@ -178,6 +198,11 @@ Array [
        
       54
        blocks)
+      <br />
+      Max Charge:
+       
+      4
+      /4
     </summary>
     <ul>
       <li>
@@ -216,6 +241,11 @@ Array [
        
       60
        blocks)
+      <br />
+      Max Charge:
+       
+      1
+      /4
     </summary>
     <ul>
       <li>
@@ -254,6 +284,11 @@ Array [
        
       61
        blocks)
+      <br />
+      Max Charge:
+       
+      3
+      /4
     </summary>
     <ul>
       <li>
@@ -292,6 +327,11 @@ Array [
        
       70
        blocks)
+      <br />
+      Max Charge:
+       
+      3
+      /4
     </summary>
     <ul>
       <li>
@@ -330,6 +370,11 @@ Array [
        
       72
        blocks)
+      <br />
+      Max Charge:
+       
+      ?
+      /4
     </summary>
     <ul />
   </details>,
@@ -361,6 +406,11 @@ Array [
        
       83
        blocks)
+      <br />
+      Max Charge:
+       
+      1
+      /4
     </summary>
     <ul>
       <li>
@@ -399,6 +449,11 @@ Array [
        
       95
        blocks)
+      <br />
+      Max Charge:
+       
+      3
+      /4
     </summary>
     <ul>
       <li>
@@ -437,6 +492,11 @@ Array [
        
       97
        blocks)
+      <br />
+      Max Charge:
+       
+      ?
+      /4
     </summary>
     <ul />
   </details>,
@@ -468,6 +528,11 @@ Array [
        
       107
        blocks)
+      <br />
+      Max Charge:
+       
+      1
+      /4
     </summary>
     <ul>
       <li>
@@ -506,6 +571,11 @@ Array [
        
       112
        blocks)
+      <br />
+      Max Charge:
+       
+      1
+      /4
     </summary>
     <ul>
       <li>
@@ -544,6 +614,11 @@ Array [
        
       119
        blocks)
+      <br />
+      Max Charge:
+       
+      1
+      /4
     </summary>
     <ul>
       <li>


### PR DESCRIPTION
This is so you don't have to click the dropdown to see the charge amount.

Fixes https://github.com/josephfrazier/Reported-Web/issues/110