### PR TITLE
electricitibikes: Don't show miles/yards/etc, only blocks

### DIFF
--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -208,8 +208,8 @@ export function ElectriCitibikeList({
               {station.name}, {station.BoroName}
             </a>
             <br />
-            ({station.dist} {station.compassBearing} from you, about{' '}
-            {Math.ceil(station.distMeters / 80)} blocks)
+            (about {Math.ceil(station.distMeters / 80)} blocks{' '}
+            {station.compassBearing} of you)
             <br />
             Max Charge:{' '}
             {Math.max(

--- a/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
+++ b/src/routes/electricitibikes/__snapshots__/ElectriCitibikes.test.js.snap
@@ -25,14 +25,12 @@ Array [
         Manhattan
       </a>
       <br />
-      (
-      1.6 mi
+      (about 
+      33
+       blocks
        
       "Manhattan NW"
-       from you, about
-       
-      33
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -61,14 +59,12 @@ Array [
         Brooklyn
       </a>
       <br />
-      (
-      2.1 mi
+      (about 
+      42
+       blocks
        
       SE
-       from you, about
-       
-      42
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -104,14 +100,12 @@ Array [
         Brooklyn
       </a>
       <br />
-      (
-      2.1 mi
+      (about 
+      42
+       blocks
        
       SE
-       from you, about
-       
-      42
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -147,14 +141,12 @@ Array [
         Brooklyn
       </a>
       <br />
-      (
-      2.2 mi
+      (about 
+      44
+       blocks
        
       ESE
-       from you, about
-       
-      44
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -190,14 +182,12 @@ Array [
         Manhattan
       </a>
       <br />
-      (
-      2.7 mi
+      (about 
+      54
+       blocks
        
       "Manhattan N"
-       from you, about
-       
-      54
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -233,14 +223,12 @@ Array [
         Brooklyn
       </a>
       <br />
-      (
-      2.9 mi
+      (about 
+      60
+       blocks
        
       ENE
-       from you, about
-       
-      60
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -276,14 +264,12 @@ Array [
         Brooklyn
       </a>
       <br />
-      (
-      3 mi
+      (about 
+      61
+       blocks
        
       E
-       from you, about
-       
-      61
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -319,14 +305,12 @@ Array [
         Brooklyn
       </a>
       <br />
-      (
-      3.5 mi
+      (about 
+      70
+       blocks
        
       ESE
-       from you, about
-       
-      70
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -362,14 +346,12 @@ Array [
         Brooklyn
       </a>
       <br />
-      (
-      3.6 mi
+      (about 
+      72
+       blocks
        
       SSE
-       from you, about
-       
-      72
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -398,14 +380,12 @@ Array [
         Manhattan
       </a>
       <br />
-      (
-      4.1 mi
+      (about 
+      83
+       blocks
        
       "Manhattan N"
-       from you, about
-       
-      83
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -441,14 +421,12 @@ Array [
         Manhattan
       </a>
       <br />
-      (
-      4.7 mi
+      (about 
+      95
+       blocks
        
       "Manhattan N"
-       from you, about
-       
-      95
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -484,14 +462,12 @@ Array [
         Manhattan
       </a>
       <br />
-      (
-      4.8 mi
+      (about 
+      97
+       blocks
        
       "Manhattan N"
-       from you, about
-       
-      97
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -520,14 +496,12 @@ Array [
         Manhattan
       </a>
       <br />
-      (
-      5.3 mi
+      (about 
+      107
+       blocks
        
       "Manhattan N"
-       from you, about
-       
-      107
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -563,14 +537,12 @@ Array [
         Manhattan
       </a>
       <br />
-      (
-      5.6 mi
+      (about 
+      112
+       blocks
        
       "Manhattan N"
-       from you, about
-       
-      112
-       blocks)
+       of you)
       <br />
       Max Charge:
        
@@ -606,14 +578,12 @@ Array [
         Manhattan
       </a>
       <br />
-      (
-      5.9 mi
+      (about 
+      119
+       blocks
        
       "Manhattan N"
-       from you, about
-       
-      119
-       blocks)
+       of you)
       <br />
       Max Charge:
        


### PR DESCRIPTION
The other units aren't especially useful anyway, so let's just clean
this up.