### PR TITLE
electricitibikes: Poll API every 10 seconds

### DIFF
--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -35,7 +35,13 @@ class ElectriCitibikes extends React.Component {
   };
 
   componentDidMount() {
-    this.updateData();
+    const pollInterval = 10000;
+    const doPoll = function() {
+      this.updateData();
+      setTimeout(doPoll, pollInterval);
+    }.bind(this);
+
+    doPoll();
 
     fetch(
       'https://services5.arcgis.com/GfwWNkhOj9bNBqoJ/arcgis/rest/services/nybb/FeatureServer/0/query?where=1=1&outFields=*&outSR=4326&f=geojson',

--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -36,10 +36,10 @@ class ElectriCitibikes extends React.Component {
 
   componentDidMount() {
     const pollInterval = 10000;
-    const doPoll = function() {
+    const doPoll = () => {
       this.updateData();
       setTimeout(doPoll, pollInterval);
-    }.bind(this);
+    };
 
     doPoll();
 


### PR DESCRIPTION
This fixes https://github.com/josephfrazier/Reported-Web/issues/115
but keeps the Refresh button in case the user wants to be even more sure
that their data is fresh. Showing a relative `updatedAt` timestamp
(e.g. "5 seconds ago") could help alleviate this.