### PR TITLE
Show correct Toyota logo

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -445,6 +445,8 @@ class Home extends React.Component {
   getVehicleMakeLogoUrl = function({ vehicleMake }) {
     if (vehicleMake === 'Nissan') {
       return 'https://logo.clearbit.com/Nissanusa.com';
+    } else if (vehicleMake === 'Toyota') {
+      return 'https://logo.clearbit.com/toyota.com';
     }
     return `https://logo.clearbit.com/${vehicleMake}.com`;
   };


### PR DESCRIPTION
Using `Toyota.com` shows an office building instead of the logo. Test with plate `T699697C`