### PR TITLE
Fix prop type warning in tests

### DIFF
--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -32,7 +32,11 @@ describe('SubmissionDetails', () => {
     const wrapper = renderer
       .create(
         <App context={{ insertCss: () => {}, fetch: () => {}, pathname: '' }}>
-          <SubmissionDetails isDetailsOpen submission={submission} />
+          <SubmissionDetails
+            isDetailsOpen
+            submission={submission}
+            onDeleteSubmission={() => {}}
+          />
         </App>,
       )
       .toJSON();


### PR DESCRIPTION
From https://travis-ci.org/josephfrazier/Reported-Web/builds/462636521#L645

```
    Warning: Failed prop type: The prop `onDeleteSubmission` is marked as required in `SubmissionDetails`, but its value is `undefined`.
```

Reproduce locally with `CI=true yarn test`