### PR TITLE
Correct OpenALPR reading 'T' as '1', e.g. 1736347C -> T736347C

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -439,6 +439,13 @@ class Home extends React.Component {
               usStateNames[licenseState]
             }`,
           });
+
+          if (plate.match(/1\d\d\d\d\d\dC/)) {
+            this.setLicensePlate({
+              plate: plate.replace('1', 'T'),
+              licenseState,
+            });
+          }
         }
       });
   };


### PR DESCRIPTION
Partially addresses https://github.com/josephfrazier/Reported-Web/issues/131