### PR TITLE
Correct OpenALPR omitting the 'T' in TLC plates, e.g. 736347C -> T736347C

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -451,6 +451,11 @@ class Home extends React.Component {
               plate: plate.replace('1', 'T'),
               licenseState,
             });
+          } else if (plate.match(/^\d\d\d\d\d\dC$/)) {
+            this.setLicensePlate({
+              plate: `T${plate}`,
+              licenseState,
+            });
           } else if (licenseState !== 'NY') {
             this.setLicensePlate({
               plate,


### PR DESCRIPTION
Addresses https://github.com/josephfrazier/Reported-Web/issues/131#issuecomment-448844175