### PR TITLE
Add `location` GeoPoint to submission

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -415,6 +415,7 @@ app.use('/submit', (req, res) => {
           longitude: longitude.toString(),
           latitude1: latitude,
           longitude1: longitude,
+          location: new Parse.GeoPoint({ latitude, longitude }),
           loc1_address: formatted_address,
           timeofreport,
           timeofreported,


### PR DESCRIPTION
Adapted from https://github.com/josephfrazier/Reported-Web/pull/145/commits/cab77a0687be67b7e29debf37c9c0ab66d3fee14

This preserves `latitude1` and `longitude1` for backward compatibility.