### PR TITLE
submit_311_illegal_parking_report: Write spaces before JSON to extend 30s timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "global": "^4.3.2",
     "heroku-self-ping": "^1.1.4",
     "history": "^4.7.2",
+    "http-delayed-response": "^0.0.4",
     "humanize-distance": "^1.0.9",
     "humanize-string": "^1.0.2",
     "image-extensions": "^1.1.0",

--- a/src/311.js
+++ b/src/311.js
@@ -247,7 +247,6 @@ async function submit_311_illegal_parking_report({
   // https://reportedcab.slack.com/archives/C85007FUY/p1534693301000100
   // https://github.com/GoogleChrome/puppeteer/issues/331#issuecomment-323018788
   const bodyHtml = await page.evaluate(() => document.body.innerHTML);
-  console.info({ bodyHtml });
 
   let serviceRequestNumber = bodyHtml.match(/\d-\d-\d{10}/);
   serviceRequestNumber =

--- a/src/server.js
+++ b/src/server.js
@@ -25,6 +25,7 @@ import sharp from 'sharp';
 import axios from 'axios';
 import multer from 'multer';
 import stringify from 'json-stringify-safe';
+import DelayedResponse from 'http-delayed-response';
 
 import { isImage, isVideo } from './isImage.js';
 import { validateLocation, processValidation } from './geoclient.js';
@@ -566,9 +567,12 @@ app.use('/getVehicleType/:licensePlate/:licenseState?', (req, res) => {
 });
 
 app.use('/api/submit_311_illegal_parking_report', (req, res) => {
+  const delayed = new DelayedResponse(req, res);
+  delayed.json();
+  const delayedCallback = delayed.start();
   submit_311_illegal_parking_report(req.body)
     .then(result => {
-      res.json({ result });
+      delayedCallback(null, { result });
     })
     .catch(handlePromiseRejection(res));
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5662,6 +5662,10 @@ htmlparser2@~3.3.0:
     domutils "1.1"
     readable-stream "1.0"
 
+http-delayed-response@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/http-delayed-response/-/http-delayed-response-0.0.4.tgz#6ffabdb055faa4fdb39d0de7d28cfdbffbb4920b"
+
 http-errors@1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"


### PR DESCRIPTION
See https://spin.atomicobject.com/2018/05/15/extending-heroku-timeout-node/
and https://reportedcab.slack.com/messages/C85007FUY/p1535827878000100?thread_ts=1534697704.000100&cid=C85007FUY