### PR TITLE
/getVehicleType: Use findbyplate.com instead of searchquarry.com

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -518,10 +518,9 @@ app.use('/getVehicleType/:licensePlate/:licenseState?', (req, res) => {
       const vehicleSummary = data
         .match(/<h2 class="vehicle-modal">(.+?)</s)[1]
         .trim();
-      const [vehicleYear, vehicleMake, vehicleModel] = vehicleSummary.split(
-        ' ',
-        3,
-      );
+      const components = vehicleSummary.split(' ');
+      const [vehicleYear, vehicleMake] = components;
+      const vehicleModel = components.slice(2).join(' ');
       let vehicleBody;
 
       try {

--- a/src/server.js
+++ b/src/server.js
@@ -508,35 +508,38 @@ app.use('/openalpr', upload.single('attachmentFile'), (req, res) => {
 // ported from https://github.com/jeffrono/Reported/blob/19b588171315a3093d53986f9fb995059f5084b4/v2/enrich_functions.rb#L325-L346
 app.use('/getVehicleType/:licensePlate/:licenseState?', (req, res) => {
   const { licensePlate = 'GNS7685', licenseState = 'NY' } = req.params;
-  const url = `https://www.searchquarry.com/vehicle_records/lregister-new?sqtb=license_plate&license_plates=${licensePlate}&trackstat=homepage-&state=${licenseState}`;
+  const url = `https://findbyplate.com/US/${licenseState}/${licensePlate}/`;
 
   console.time(url); // eslint-disable-line no-console
   axios
     .get(url)
     .then(({ data }) => {
       console.timeEnd(url); // eslint-disable-line no-console
-      const vehicleYear = data.match(/>Year:.+?<span>(.+?)</s)[1].trim();
-      const vehicleMake = data.match(/>Make:.+?<span>(.+?)</s)[1].trim();
-      const vehicleModel = data.match(/>Model:.+?<span>(.+?)</s)[1].trim();
-      let vehicleBody;
+      // const vehicleYear = data.match(/>Year:.+?<span>(.+?)</s)[1].trim();
+      // const vehicleMake = data.match(/>Make:.+?<span>(.+?)</s)[1].trim();
+      // const vehicleModel = data.match(/>Model:.+?<span>(.+?)</s)[1].trim();
+      const vehicleModel = data
+        .match(/<h2 class="vehicle-modal">(.+?)</s)[1]
+        .trim();
+      // let vehicleBody;
 
-      try {
-        vehicleBody = data.match(/>Body:.+?><span>(.+?)</s)[1].trim();
-      } catch (err) {
-        console.error('no vehicle body');
-      }
+      // try {
+      //   vehicleBody = data.match(/>Body:.+?><span>(.+?)</s)[1].trim();
+      // } catch (err) {
+      //   console.error('no vehicle body');
+      // }
 
-      if (vehicleYear === 'Try Members Area') {
-        const message = 'not found';
-        throw { message, licensePlate, licenseState }; // eslint-disable-line no-throw-literal
-      }
+      // if (vehicleYear === 'Try Members Area') {
+      //   const message = 'not found';
+      //   throw { message, licensePlate, licenseState }; // eslint-disable-line no-throw-literal
+      // }
 
       res.json({
         result: {
-          vehicleYear,
-          vehicleMake,
+          // vehicleYear,
+          // vehicleMake,
           vehicleModel,
-          vehicleBody,
+          // vehicleBody,
           licensePlate,
           licenseState,
         },

--- a/src/server.js
+++ b/src/server.js
@@ -518,9 +518,10 @@ app.use('/getVehicleType/:licensePlate/:licenseState?', (req, res) => {
       const vehicleSummary = data
         .match(/<h2 class="vehicle-modal">(.+?)</s)[1]
         .trim();
-      const components = vehicleSummary.split(' ');
-      const [vehicleYear, vehicleMake] = components;
-      const vehicleModel = components.slice(2).join(' ');
+      const [vehicleYear, vehicleMake, vehicleModel] = vehicleSummary.split(
+        ' ',
+        3,
+      );
       let vehicleBody;
 
       try {

--- a/src/server.js
+++ b/src/server.js
@@ -515,19 +515,21 @@ app.use('/getVehicleType/:licensePlate/:licenseState?', (req, res) => {
     .get(url)
     .then(({ data }) => {
       console.timeEnd(url); // eslint-disable-line no-console
-      // const vehicleYear = data.match(/>Year:.+?<span>(.+?)</s)[1].trim();
-      // const vehicleMake = data.match(/>Make:.+?<span>(.+?)</s)[1].trim();
-      // const vehicleModel = data.match(/>Model:.+?<span>(.+?)</s)[1].trim();
-      const vehicleModel = data
+      const vehicleSummary = data
         .match(/<h2 class="vehicle-modal">(.+?)</s)[1]
         .trim();
-      // let vehicleBody;
+      const components = vehicleSummary.split(' ');
+      const [vehicleYear, vehicleMake] = components;
+      const vehicleModel = components.slice(2).join(' ');
+      let vehicleBody;
 
-      // try {
-      //   vehicleBody = data.match(/>Body:.+?><span>(.+?)</s)[1].trim();
-      // } catch (err) {
-      //   console.error('no vehicle body');
-      // }
+      try {
+        vehicleBody = data
+          .match(/<div class="cell" data-title="BodyClass">(.+?)</s)[1]
+          .trim();
+      } catch (err) {
+        console.error('no vehicle body');
+      }
 
       // if (vehicleYear === 'Try Members Area') {
       //   const message = 'not found';
@@ -536,10 +538,10 @@ app.use('/getVehicleType/:licensePlate/:licenseState?', (req, res) => {
 
       res.json({
         result: {
-          // vehicleYear,
-          // vehicleMake,
+          vehicleYear,
+          vehicleMake,
           vehicleModel,
-          // vehicleBody,
+          vehicleBody,
           licensePlate,
           licenseState,
         },


### PR DESCRIPTION
Test with e.g. http://localhost:3000/getVehicleType/T754496C/NY:

```json
{"result":{"vehicleYear":"2017","vehicleMake":"INFINITI","vehicleModel":"QX60","vehicleBody":"Wagon","licensePlate":"T754496C","licenseState":"NY"}}
```

or http://localhost:3000/getVehicleType/HUX1752/NY:

```json
{"result":{"vehicleYear":"2017","vehicleMake":"Lexus","vehicleModel":"RX 350","licensePlate":"HUX1752","licenseState":"NY"}}
```

Fixes https://github.com/josephfrazier/Reported-Web/issues/193
and https://www.pivotaltracker.com/story/show/168823274