### PR TITLE
heroku: Uninstall devDependencies after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "clean": "babel-node tools/run clean",
     "copy": "babel-node tools/run copy",
     "bundle": "babel-node tools/run bundle",
-    "heroku-postbuild": "yarn run build --release",
+    "heroku-postbuild": "yarn run build --release && yarn install --production --ignore-scripts --prefer-offline",
     "build": "babel-node tools/run build",
     "build-stats": "yarn run build --release --analyse",
     "deploy": "babel-node tools/run deploy",


### PR DESCRIPTION
This should help reduce the size of the slug. From https://dashboard.heroku.com/apps/reported-web/activity/builds/c343e368-6f2d-454f-97b1-de7c67723b88:

     !     Warning: Your slug size (307 MB) exceeds our soft limit (300 MB) which may affect boot time.

See https://devcenter.heroku.com/changelog-items/1145
and https://github.com/yarnpkg/yarn/issues/696#issuecomment-258418656