### PR TITLE
Revert "heroku: Uninstall devDependencies after build"

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "clean": "babel-node tools/run clean",
     "copy": "babel-node tools/run copy",
     "bundle": "babel-node tools/run bundle",
-    "heroku-postbuild": "yarn run build --release && yarn install --production --ignore-scripts --prefer-offline",
+    "heroku-postbuild": "yarn run build --release",
     "build": "babel-node tools/run build",
     "build-stats": "yarn run build --release --analyse",
     "deploy": "babel-node tools/run deploy",


### PR DESCRIPTION
Reverts josephfrazier/Reported-Web#198

It didn't actually help, according to https://dashboard.heroku.com/apps/reported-web/activity/builds/f415ccb0-df01-4339-8d58-ef3c4fa60da3:

     !     Warning: Your slug size (307 MB) exceeds our soft limit (300 MB) which may affect boot time.

This is likely because heroku does it already: https://devcenter.heroku.com/articles/nodejs-support#package-installation