### PR TITLE
Include `photoData` in photos shown

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -25,6 +25,7 @@ class SubmissionDetails extends React.Component {
       reportDescription,
       status,
 
+      photoData,
       photoData0,
       photoData1,
       photoData2,
@@ -39,10 +40,10 @@ class SubmissionDetails extends React.Component {
     const humanTimeString = new Date(timeofreport).toLocaleString();
 
     const ImagesAndVideos = () => {
-      const images = [photoData0, photoData1, photoData2]
+      const images = [photoData, photoData0, photoData1, photoData2]
         .filter(item => !!item)
-        .map((photoData, i) => {
-          const { url } = photoData;
+        .map((photoDataItem, i) => {
+          const { url } = photoDataItem;
           return (
             <a key={url} href={url} target="_blank" rel="noopener noreferrer">
               <img src={url} alt={`#${i}`} />
@@ -160,6 +161,7 @@ SubmissionDetails.propTypes = {
     reportDescription: PropTypes.string,
     status: PropTypes.number,
 
+    photoData: PropTypes.object,
     photoData0: PropTypes.object,
     photoData1: PropTypes.object,
     photoData2: PropTypes.object,

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -21,6 +21,7 @@ describe('SubmissionDetails', () => {
       reportDescription: 'reportDescription',
       status: 1,
 
+      photoData: { url: 'photoData.url' },
       photoData0: { url: 'photoData0.url' },
       photoData1: { url: 'photoData1.url' },
       photoData2: { url: 'photoData2.url' },
@@ -55,6 +56,7 @@ describe('SubmissionDetails', () => {
       reportDescription: 'reportDescription',
       status: 0,
 
+      photoData: { url: 'photoData.url' },
       photoData0: { url: 'photoData0.url' },
       photoData1: { url: 'photoData1.url' },
       photoData2: { url: 'photoData2.url' },

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -22,12 +22,22 @@ exports[`SubmissionDetails renders children correctly 1`] = `
     reportDescription
   </p>
   <a
-    href="photoData0.url"
+    href="photoData.url"
     rel="noopener noreferrer"
     target="_blank"
   >
     <img
       alt="#0"
+      src="photoData.url"
+    />
+  </a>
+  <a
+    href="photoData0.url"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <img
+      alt="#1"
       src="photoData0.url"
     />
   </a>
@@ -37,7 +47,7 @@ exports[`SubmissionDetails renders children correctly 1`] = `
     target="_blank"
   >
     <img
-      alt="#1"
+      alt="#2"
       src="photoData1.url"
     />
   </a>
@@ -47,7 +57,7 @@ exports[`SubmissionDetails renders children correctly 1`] = `
     target="_blank"
   >
     <img
-      alt="#2"
+      alt="#3"
       src="photoData2.url"
     />
   </a>
@@ -109,12 +119,22 @@ exports[`SubmissionDetails renders delete button correctly 1`] = `
     reportDescription
   </p>
   <a
-    href="photoData0.url"
+    href="photoData.url"
     rel="noopener noreferrer"
     target="_blank"
   >
     <img
       alt="#0"
+      src="photoData.url"
+    />
+  </a>
+  <a
+    href="photoData0.url"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <img
+      alt="#1"
       src="photoData0.url"
     />
   </a>
@@ -124,7 +144,7 @@ exports[`SubmissionDetails renders delete button correctly 1`] = `
     target="_blank"
   >
     <img
-      alt="#1"
+      alt="#2"
       src="photoData1.url"
     />
   </a>
@@ -134,7 +154,7 @@ exports[`SubmissionDetails renders delete button correctly 1`] = `
     target="_blank"
   >
     <img
-      alt="#2"
+      alt="#3"
       src="photoData2.url"
     />
   </a>


### PR DESCRIPTION
From https://reportedcab.slack.com/archives/C9VNM3DL4/p1572994459014100:

> Ah, it looks like your submissions are showing up with only one
> `photoData` field, rather than `photoData0`, `photoData1`, `photoData2`.
> I think different apps have different conventions for this,
> unfortunately, and we might need to do some work to normalize them on
> the server-side. You use the android app, right?
>
> I think I should be able to work around this on the webapp, though, and
> show the `photoData` field as well. I'll keep you posted