### PR TITLE
Don't try to load submissions if there's not an email and password

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -285,6 +285,8 @@ class Home extends React.Component {
           isPasswordRevealed: true,
         });
       });
+    } else if (this.state.email) {
+      this.loadPreviousSubmissions();
     }
 
     // Allow users to paste image data
@@ -309,8 +311,6 @@ class Home extends React.Component {
       (beforeUnloadEvent || window.event).returnValue = confirmationMessage; // Gecko + IE
       return confirmationMessage; // Webkit, Safari, Chrome etc.
     });
-
-    this.loadPreviousSubmissions();
 
     this.forceUpdate(); // force "Create/Edit User" fields to render persisted value after load
   }


### PR DESCRIPTION
From https://reportedcab.slack.com/archives/C9VNM3DL4/p1574038397020500?thread_ts=1573741405.017800&cid=C9VNM3DL4:

> oh, i think it's because I made it automatically load previous
> submissions when you open the page, but that isn't checking to see
> whether or not the username and password are present (to be able to log
> in in the first place)