### PR TITLE
WIP Show tasks associated with each submission

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -143,7 +143,7 @@ class SubmissionDetails extends React.Component {
               <dt>{humanizeString(task.action)}:</dt>
               <dd>
                 {task.action === 'tweet report'
-                  ? JSON.stringify(task)
+                  ? <a href={task.tweet_url} target="_blank" rel="noopener noreferrer">{task.message}</a>
                   : srStatusOrDeleteButton(task)}
               </dd>
             </React.Fragment>

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -119,6 +119,30 @@ class SubmissionDetails extends React.Component {
         </button>
       );
 
+    const LoadableTasks = Loadable({
+      loader: () =>
+        axios.get(`/api/tasks/${objectId}`).then(({ data }) => () => {
+          const tasks = data;
+          // if (error) {
+          //   const { errorMessage, errorCode } = error;
+          //   return `${errorMessage} (error code ${errorCode})`;
+          // }
+
+          const items = tasks.map(
+            (task) => (
+              <React.Fragment key={task.action}>
+                <dt>{humanizeString(task.action)}:</dt>
+                <dd>
+                  {JSON.stringify(task)}
+                </dd>
+              </React.Fragment>
+            ),
+          );
+          return <dl>{items}</dl>;
+        }),
+      loading: () => 'Loading Tasks...',
+    });
+
     return (
       <details
         open={this.state.isDetailsOpen}
@@ -141,7 +165,7 @@ class SubmissionDetails extends React.Component {
             <p>{reportDescription}</p>
             <ImagesAndVideos />
 
-            {srStatusOrDeleteButton()}
+            <LoadableTasks />
           </React.Fragment>
         )}
       </details>

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -129,14 +129,14 @@ class SubmissionDetails extends React.Component {
           // }
 
           const items = tasks.map(
-            (task) => (
-              <React.Fragment key={task.action}>
+            (task) => {
+              return <React.Fragment key={task.action}>
                 <dt>{humanizeString(task.action)}:</dt>
                 <dd>
-                  {JSON.stringify(task)}
+                  {task.action === 'submit 311 complaint' ? srStatusOrDeleteButton() : JSON.stringify(task)}
                 </dd>
               </React.Fragment>
-            ),
+            }
           );
           return <dl>{items}</dl>;
         }),

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -77,9 +77,7 @@ class SubmissionDetails extends React.Component {
       }
 
       render() {
-        const {
-          case_id,
-        } = this.props;;
+        const { case_id } = this.props;
 
         const LoadableServiceRequestStatus = Loadable({
           loader: () =>
@@ -95,7 +93,9 @@ class SubmissionDetails extends React.Component {
                   <React.Fragment key={key}>
                     <dt>{humanizeString(key)}:</dt>
                     <dd>
-                      {key.endsWith('Date') ? new Date(value).toString() : value}
+                      {key.endsWith('Date')
+                        ? new Date(value).toString()
+                        : value}
                     </dd>
                   </React.Fragment>
                 ),
@@ -105,14 +105,14 @@ class SubmissionDetails extends React.Component {
           loading: () => 'Loading Service Request Status...',
         });
 
-        return <LoadableServiceRequestStatus />
+        return <LoadableServiceRequestStatus />;
       }
     }
 
-    const srStatusOrDeleteButton = (case_id) =>
+    const srStatusOrDeleteButton = task =>
       (status !== 0 && (
         <div>
-          <ServiceRequestDetails case_id={case_id} />
+          <ServiceRequestDetails case_id={task.case_id} />
         </div>
       )) || (
         <button
@@ -137,16 +137,16 @@ class SubmissionDetails extends React.Component {
       loader: () =>
         axios.get(`/api/tasks/${objectId}`).then(({ data }) => () => {
           const tasks = data;
-          const items = tasks.map(
-            (task) => {
-              return <React.Fragment key={task.action}>
-                <dt>{humanizeString(task.action)}:</dt>
-                <dd>
-                  {task.action === 'tweet report' ? JSON.stringify(task) : srStatusOrDeleteButton(task.case_id)}
-                </dd>
-              </React.Fragment>
-            }
-          );
+          const items = tasks.map(task => (
+            <React.Fragment key={task.action}>
+              <dt>{humanizeString(task.action)}:</dt>
+              <dd>
+                {task.action === 'tweet report'
+                  ? JSON.stringify(task)
+                  : srStatusOrDeleteButton(task)}
+              </dd>
+            </React.Fragment>
+          ));
           return <dl>{items}</dl>;
         }),
       loading: () => 'Loading Tasks...',

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -16,6 +16,7 @@ class SubmissionDetails extends React.Component {
   }
 
   render() {
+    return JSON.stringify(this.props.submission, null, 2);
     const {
       reqnumber,
       medallionNo,

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -16,7 +16,6 @@ class SubmissionDetails extends React.Component {
   }
 
   render() {
-    return JSON.stringify(this.props.submission, null, 2);
     const {
       reqnumber,
       medallionNo,

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -73,26 +73,26 @@ class SubmissionDetails extends React.Component {
 
     const LoadableServiceRequestStatus = Loadable({
       loader: () =>
-        axios.get(`/srlookup/${reqnumber}`).then(({ data }) => () => {
-          const { error, threeOneOneSRLookupResponse } = data;
-          if (error) {
-            const { errorMessage, errorCode } = error;
-            return `${errorMessage} (error code ${errorCode})`;
-          }
+        axios.get(`/api/tasks/${objectId}`).then(({ data }) => () => {
+          const tasks = data;
+          // if (error) {
+          //   const { errorMessage, errorCode } = error;
+          //   return `${errorMessage} (error code ${errorCode})`;
+          // }
 
-          const items = Object.entries(threeOneOneSRLookupResponse[0]).map(
-            ([key, value]) => (
-              <React.Fragment key={key}>
-                <dt>{humanizeString(key)}:</dt>
+          const items = tasks.map(
+            (task) => (
+              <React.Fragment key={task.action}>
+                <dt>{humanizeString(task.action)}:</dt>
                 <dd>
-                  {key.endsWith('Date') ? new Date(value).toString() : value}
+                  {JSON.stringify(task)}
                 </dd>
               </React.Fragment>
             ),
           );
           return <dl>{items}</dl>;
         }),
-      loading: () => 'Loading Service Request Status...',
+      loading: () => 'Loading Tasks...',
     });
 
     const srStatusOrDeleteButton = () =>

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -77,7 +77,8 @@ class SubmissionDetails extends React.Component {
       }
 
       render() {
-        const { case_id } = this.props;
+        const { task } = this.props;
+        const { case_id } = task;
 
         const LoadableServiceRequestStatus = Loadable({
           loader: () =>
@@ -112,7 +113,7 @@ class SubmissionDetails extends React.Component {
     const srStatusOrDeleteButton = task =>
       (status !== 0 && (
         <div>
-          <ServiceRequestDetails case_id={task.case_id} />
+          <ServiceRequestDetails task={task} />
         </div>
       )) || (
         <button

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -73,26 +73,26 @@ class SubmissionDetails extends React.Component {
 
     const LoadableServiceRequestStatus = Loadable({
       loader: () =>
-        axios.get(`/api/tasks/${objectId}`).then(({ data }) => () => {
-          const tasks = data;
-          // if (error) {
-          //   const { errorMessage, errorCode } = error;
-          //   return `${errorMessage} (error code ${errorCode})`;
-          // }
+        axios.get(`/srlookup/${reqnumber}`).then(({ data }) => () => {
+          const { error, threeOneOneSRLookupResponse } = data;
+          if (error) {
+            const { errorMessage, errorCode } = error;
+            return `${errorMessage} (error code ${errorCode})`;
+          }
 
-          const items = tasks.map(
-            (task) => (
-              <React.Fragment key={task.action}>
-                <dt>{humanizeString(task.action)}:</dt>
+          const items = Object.entries(threeOneOneSRLookupResponse[0]).map(
+            ([key, value]) => (
+              <React.Fragment key={key}>
+                <dt>{humanizeString(key)}:</dt>
                 <dd>
-                  {JSON.stringify(task)}
+                  {key.endsWith('Date') ? new Date(value).toString() : value}
                 </dd>
               </React.Fragment>
             ),
           );
           return <dl>{items}</dl>;
         }),
-      loading: () => 'Loading Tasks...',
+      loading: () => 'Loading Service Request Status...',
     });
 
     const srStatusOrDeleteButton = () =>

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -142,7 +142,7 @@ class SubmissionDetails extends React.Component {
               return <React.Fragment key={task.action}>
                 <dt>{humanizeString(task.action)}:</dt>
                 <dd>
-                  {task.action === 'submit 311 complaint' ? srStatusOrDeleteButton(task.case_id) : JSON.stringify(task)}
+                  {task.action === 'tweet report' ? JSON.stringify(task) : srStatusOrDeleteButton(task.case_id)}
                 </dd>
               </React.Fragment>
             }

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -123,11 +123,6 @@ class SubmissionDetails extends React.Component {
       loader: () =>
         axios.get(`/api/tasks/${objectId}`).then(({ data }) => () => {
           const tasks = data;
-          // if (error) {
-          //   const { errorMessage, errorCode } = error;
-          //   return `${errorMessage} (error code ${errorCode})`;
-          // }
-
           const items = tasks.map(
             (task) => {
               return <React.Fragment key={task.action}>

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -95,7 +95,7 @@ class SubmissionDetails extends React.Component {
       loading: () => 'Loading Service Request Status...',
     });
 
-    const srStatusOrDeleteButton = () =>
+    const srStatusOrDeleteButton = (case_id) =>
       (status !== 0 && (
         <div>
           <LoadableServiceRequestStatus />
@@ -128,7 +128,7 @@ class SubmissionDetails extends React.Component {
               return <React.Fragment key={task.action}>
                 <dt>{humanizeString(task.action)}:</dt>
                 <dd>
-                  {task.action === 'submit 311 complaint' ? srStatusOrDeleteButton() : JSON.stringify(task)}
+                  {task.action === 'submit 311 complaint' ? srStatusOrDeleteButton(task.case_id) : JSON.stringify(task)}
                 </dd>
               </React.Fragment>
             }

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -71,34 +71,48 @@ class SubmissionDetails extends React.Component {
       );
     };
 
-    const LoadableServiceRequestStatus = Loadable({
-      loader: () =>
-        axios.get(`/srlookup/${reqnumber}`).then(({ data }) => () => {
-          const { error, threeOneOneSRLookupResponse } = data;
-          if (error) {
-            const { errorMessage, errorCode } = error;
-            return `${errorMessage} (error code ${errorCode})`;
-          }
+    class ServiceRequestDetails extends React.Component {
+      constructor(props) {
+        super(props);
+      }
 
-          const items = Object.entries(threeOneOneSRLookupResponse[0]).map(
-            ([key, value]) => (
-              <React.Fragment key={key}>
-                <dt>{humanizeString(key)}:</dt>
-                <dd>
-                  {key.endsWith('Date') ? new Date(value).toString() : value}
-                </dd>
-              </React.Fragment>
-            ),
-          );
-          return <dl>{items}</dl>;
-        }),
-      loading: () => 'Loading Service Request Status...',
-    });
+      render() {
+        const {
+          case_id,
+        } = this.props;;
+
+        const LoadableServiceRequestStatus = Loadable({
+          loader: () =>
+            axios.get(`/srlookup/${case_id}`).then(({ data }) => () => {
+              const { error, threeOneOneSRLookupResponse } = data;
+              if (error) {
+                const { errorMessage, errorCode } = error;
+                return `${errorMessage} (error code ${errorCode})`;
+              }
+
+              const items = Object.entries(threeOneOneSRLookupResponse[0]).map(
+                ([key, value]) => (
+                  <React.Fragment key={key}>
+                    <dt>{humanizeString(key)}:</dt>
+                    <dd>
+                      {key.endsWith('Date') ? new Date(value).toString() : value}
+                    </dd>
+                  </React.Fragment>
+                ),
+              );
+              return <dl>{items}</dl>;
+            }),
+          loading: () => 'Loading Service Request Status...',
+        });
+
+        return <LoadableServiceRequestStatus />
+      }
+    }
 
     const srStatusOrDeleteButton = (case_id) =>
       (status !== 0 && (
         <div>
-          <LoadableServiceRequestStatus />
+          <ServiceRequestDetails case_id={case_id} />
         </div>
       )) || (
         <button

--- a/src/server.js
+++ b/src/server.js
@@ -227,14 +227,14 @@ app.use('/api/process_validation', (req, res) => {
 
 async function getSubmissions(req) {
   return saveUser(req.body).then(user => {
-    const Submission = Parse.Object.extend('submission');
+    const Submission = Parse.Object.extend('tasks');
     const query = new Parse.Query(Submission);
     // Search by "Username" (email address) to show submissions made by all
     // users with the same email, since the web and mobile clients create
     // separate users
-    query.equalTo('Username', user.get('username'));
-    query.descending('timeofreport');
-    query.limit(Number.MAX_SAFE_INTEGER);
+    // query.equalTo('Username', user.get('username'));
+    query.descending('createdAt');
+    query.limit(10);
     return query.find();
   });
 }

--- a/src/server.js
+++ b/src/server.js
@@ -281,6 +281,32 @@ app.get('/srlookup/:reqnumber', (req, res) => {
     .catch(handlePromiseRejection(res));
 });
 
+async function getTasks({ body, submissionId }) {
+  // return saveUser(req.body).then(user => {
+    const Task = Parse.Object.extend('tasks');
+    const query = new Parse.Query(Task);
+
+    // TODO ensure that the user owns the submission
+    // query.equalTo('Username', user.get('username'));
+
+    // see https://designingforscale.com/query-on-a-parse-pointer/
+    query.equalTo('submission', { "__type": "Pointer", "className": "submission", "objectId": submissionId });
+    query.descending('createdAt');
+    query.limit(Number.MAX_SAFE_INTEGER);
+    return query.find()
+  // });
+}
+
+app.get('/api/tasks/:submissionId', (req, res) => {
+  const { submissionId } = req.params;
+
+  getTasks({ submissionId })
+    .then(tasks => {
+      res.json(tasks);
+    })
+    .catch(handlePromiseRejection(res));
+});
+
 app.use('/requestPasswordReset', (req, res) => {
   const { email } = req.body;
 

--- a/src/server.js
+++ b/src/server.js
@@ -227,14 +227,14 @@ app.use('/api/process_validation', (req, res) => {
 
 async function getSubmissions(req) {
   return saveUser(req.body).then(user => {
-    const Submission = Parse.Object.extend('tasks');
+    const Submission = Parse.Object.extend('submission');
     const query = new Parse.Query(Submission);
     // Search by "Username" (email address) to show submissions made by all
     // users with the same email, since the web and mobile clients create
     // separate users
-    // query.equalTo('Username', user.get('username'));
-    query.descending('createdAt');
-    query.limit(10);
+    query.equalTo('Username', user.get('username'));
+    query.descending('timeofreport');
+    query.limit(Number.MAX_SAFE_INTEGER);
     return query.find();
   });
 }


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/GMB2JT5UK/p1574782978028900

So far, this just shows the most recent 10 tasks regardless of
user/submission. The next step will be to build an endpoint similar to
srlookup that takes the submission id and finds all the tasks associated
with it. Then we can render a list of tasks instead of the srlookup
info.

WIP Add /api/tasks/:submissionId endpoint

See https://reportedcab.slack.com/archives/GMB2JT5UK/p1574811805034500?thread_ts=1574782978.028900&cid=GMB2JT5UK

Revert "WIP Show tasks associated with each submission"

This reverts commit 94e4a07885d1e865be02de24c0d419e2b1a1454e.

WIP LoadableServiceRequestStatus: Show tasks instead of srlookup stuff

Add/use separate LoadableTasks component

Revert "WIP LoadableServiceRequestStatus: Show tasks instead of srlookup stuff"

This reverts commit 3e19ad3c521cf773d156f8e32bb36d36da9db51d.

Render `srStatusOrDeleteButton()` instead of JSON for 311 TLC submission

remove stale comment

WIP pass case_id (reqnumber) to LoadableServiceRequestStatus

fixup! WIP pass case_id (reqnumber) to LoadableServiceRequestStatus

show srlookup info for 311 nypd submissions as well

pass task to srStatusOrDeleteButton

Pass entire task to ServiceRequestDetails

Render tweet task as link to tweet