### PR TITLE
Travis: Upgrade `yarn` to 1.19.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
       - g++-4.8
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.0
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.2
   - export PATH=$HOME/.yarn/bin:$PATH
 cache: yarn
 script:


### PR DESCRIPTION
Hoping this will fix the following error at e.g. https://travis-ci.org/josephfrazier/Reported-Web/builds/630442870:

> Incorrect integrity when fetching from the cache

See https://github.com/yarnpkg/yarn/issues/7584#issuecomment-539551761