### PR TITLE
Use non-vulgar wordlist for generating passphrases

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "mem": "^4.0.0",
     "mp4box": "https://github.com/josephfrazier/mp4box.js#commonjs",
     "multer": "^1.3.0",
-    "niceware": "^1.0.5",
     "node-fetch": "^2.2.0",
     "normalize.css": "^8.0.0",
     "object-to-formdata": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "datasets-us-states-abbr-names": "^1.0.0",
     "debounce-promise": "^3.1.0",
     "degrees-to-direction": "^1.1.1",
+    "diceware-generator": "^3.0.1",
+    "diceware-wordlist-en-eff": "^1.0.1",
     "dotenv": "^5.0.1",
     "execall": "^1.0.0",
     "exif": "https://github.com/josephfrazier/node-exif#isbuffer",

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -37,7 +37,8 @@ import bufferToArrayBuffer from 'buffer-to-arraybuffer';
 import objectToFormData from 'object-to-formdata';
 import usStateNames from 'datasets-us-states-abbr-names';
 import fileExtension from 'file-extension';
-import niceware from 'niceware';
+const dwGen = require('diceware-generator');
+const enEFF = require('diceware-wordlist-en-eff');
 import Modal from 'react-modal';
 import Dropzone from '@josephfrazier/react-dropzone';
 
@@ -280,8 +281,13 @@ class Home extends React.Component {
     if (!this.state.password) {
       // async so that test snapshots don't change
       setTimeout(() => {
+        const options = {
+          language: enEFF,
+          wordcount: 6,
+          format: 'string'
+        }
         this.setState({
-          password: niceware.generatePassphrase(10).join(' '),
+          password: dwGen(options),
           isPasswordRevealed: true,
         });
       });

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -37,8 +37,8 @@ import bufferToArrayBuffer from 'buffer-to-arraybuffer';
 import objectToFormData from 'object-to-formdata';
 import usStateNames from 'datasets-us-states-abbr-names';
 import fileExtension from 'file-extension';
-import dwGen from 'diceware-generator';
-import enEFF from 'diceware-wordlist-en-eff';
+import diceware from 'diceware-generator';
+import wordlist from 'diceware-wordlist-en-eff';
 import Modal from 'react-modal';
 import Dropzone from '@josephfrazier/react-dropzone';
 
@@ -282,12 +282,12 @@ class Home extends React.Component {
       // async so that test snapshots don't change
       setTimeout(() => {
         const options = {
-          language: enEFF,
+          language: wordlist,
           wordcount: 6,
           format: 'string',
         };
         this.setState({
-          password: dwGen(options),
+          password: diceware(options),
           isPasswordRevealed: true,
         });
       });

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -37,8 +37,8 @@ import bufferToArrayBuffer from 'buffer-to-arraybuffer';
 import objectToFormData from 'object-to-formdata';
 import usStateNames from 'datasets-us-states-abbr-names';
 import fileExtension from 'file-extension';
-const dwGen = require('diceware-generator');
-const enEFF = require('diceware-wordlist-en-eff');
+import dwGen from 'diceware-generator';
+import enEFF from 'diceware-wordlist-en-eff';
 import Modal from 'react-modal';
 import Dropzone from '@josephfrazier/react-dropzone';
 
@@ -284,8 +284,8 @@ class Home extends React.Component {
         const options = {
           language: enEFF,
           wordcount: 6,
-          format: 'string'
-        }
+          format: 'string',
+        };
         this.setState({
           password: dwGen(options),
           isPasswordRevealed: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,10 +2065,6 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
-binary-search@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/binary-search/-/binary-search-1.3.3.tgz#b5adb6fb279a197be51b1ee8b0fb76fcdc61b429"
-
 bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
@@ -8069,13 +8065,6 @@ nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
 
-niceware@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/niceware/-/niceware-1.0.5.tgz#2b5c43604a7458c3f6fd5ddc74140df978090281"
-  dependencies:
-    binary-search "^1.3.3"
-    randombytes "^2.0.6"
-
 node-abi@^2.2.0:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.3.tgz#43666b7b17e57863e572409edbb82115ac7af28b"
@@ -9993,7 +9982,7 @@ randomatic@^3.0.0:
     kind-of "^6.0.0"
     math-random "^1.0.1"
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.0.6:
+randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.6.tgz#d302c522948588848a8d300c932b44c24231da80"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,6 +3582,18 @@ dicer@0.2.5:
     readable-stream "1.1.x"
     streamsearch "0.1.2"
 
+diceware-generator@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/diceware-generator/-/diceware-generator-3.0.1.tgz#e69e0a10dc5149ea85815f0b4ae29e2f80dde58a"
+  integrity sha1-5p4KENxRSeqFgV8LSuKeL4Dd5Yo=
+  dependencies:
+    secure-random "^1.1.1"
+
+diceware-wordlist-en-eff@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/diceware-wordlist-en-eff/-/diceware-wordlist-en-eff-1.0.1.tgz#35a8971060fb66dd28ee599720ce8b14023ae59b"
+  integrity sha1-NaiXEGD7Zt0o7lmXIM6LFAI65Zs=
+
 diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
@@ -10857,6 +10869,11 @@ schema-utils@^1.0.0:
 scriptjs@^2.5.8:
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.8.tgz#d0c43955c2e6bad33b6e4edf7b53b8965aa7ca5f"
+
+secure-random@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/secure-random/-/secure-random-1.1.2.tgz#ed103b460a851632d420d46448b2a900a41e7f7c"
+  integrity sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ==
 
 seek-bzip@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Someone reported that their generated passphrase contained the word
"lynching", so this change should avoid that sort of thing going forward.

See https://www.eff.org/deeplinks/2016/07/new-wordlists-random-passphrases
and https://github.com/diracdeltas/niceware/issues/5
and https://reportedcab.slack.com/archives/D9PBWU0DU/p1582180581003700