### PR TITLE
Update metadata extraction error text to indicate that if multiple images are submitted, another one may have the required data

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -514,11 +514,17 @@ class Home extends React.Component {
           extractLocationDate({ attachmentFile }).then(this.setLocationDate),
         ]);
       } catch (err) {
+        const hasMultipleAttachments = attachmentData.length > 1;
+        const fileCopy = hasMultipleAttachments
+          ? 'one of the files, but they may have been found in other files.'
+          : 'the file.';
+
         this.alert(
           <React.Fragment>
             <p>
-              Could not extract plate/location/date from image. Please
-              enter/confirm them manually.
+              Could not extract plate and/or location and/or date from{' '}
+              {fileCopy}
+              Please enter/confirm any missing values manually.
             </p>
 
             <p>(Error message: {err.message})</p>


### PR DESCRIPTION
From my conversation with Rich at https://reportedcab.slack.com/archives/C9VNM3DL4/p1612717445004500?thread_ts=1610546281.002400&cid=C9VNM3DL4:

> Ohhhh, you've stumbled across a quirk in how the error-handling is implemented, if I remember correctly: When I was first developing this, only one image was supported, so if it didn't find either the plate, date, or the location data, it would show the error message. Then, when I added support for multiple images, I didn't update the logic to take into account how many images there are.
>
> So, I'm guessing what happened here is that it couldn't find the plate in the second image, and showed the error message instead of waiting for the plate to be found in the first image.
>
> I'll update the error text to indicate that if multiple images are submitted, another one may have the required data, but there's a couple of bigger improvements that could be made:
>
> 1. Have the error message indicate which fields couldn't be found, instead of just saying "plate/location/date".
> 2. If there are multiple images, check all of them before showing the error message.