### PR TITLE
Upgrade Node.js from v12 to v14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:14-alpine
 
 # Set a working directory
 WORKDIR /usr/src/app

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": "12",
+    "node": "14",
     "npm": ">=3.10.10"
   },
   "browserslist": [


### PR DESCRIPTION
Hoping this helps with segfaults

See https://reportedcab.slack.com/archives/C9VNM3DL4/p1613245913039100?thread_ts=1610546281.002400&cid=C9VNM3DL4:

> wait, that's not quite right, it looks like it's something to do with the HEIC metadata extraction process (seeing libheif tipped me off):
>
>     2021-02-13T19:47:42.216774+00:00 app[web.1]: 2: fromWireType [0x1d2930eee611] [/app/node_modules/libheif-js/libheif/libheif.js:1] [bytecode=0x2e861bfc8f99 offset=108](this=0x1d2930edfa29 <Object map = 0x3f782e9ac219>,43835008)
>     2021-02-13T19:47:42.216777+00:00 app[web.1]: 3: simpleReadValueFromPointer [0x1d6177f76961] [/app/node_modules/libheif-j...

> maybe I'll upgrade Node.js from v12 to v14 and see if that helps