### PR TITLE
When plate/location/date extraction fails, show full error stack

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -512,10 +512,10 @@ class Home extends React.Component {
               Please enter/confirm any missing values manually.
             </p>
 
-            <p>(Error message: {err.message})</p>
+            <p style={{ whiteSpace: 'pre-wrap' }}>{err.stack}</p>
           </React.Fragment>,
         );
-        console.error(`Error: ${err.message}`);
+        console.error(err.stack);
       }
     }
   };


### PR DESCRIPTION
(related to https://github.com/josephfrazier/Reported-Web/issues/251)

See conversation at https://reportedcab.slack.com/archives/C9VNM3DL4/p1614782620005400?thread_ts=1614571624.001400&cid=C9VNM3DL4:

> ah yeah, it looks like it currently tries to extract both the location
> and the date, and only if both succeed will it set them on the page.
> I'll try to add some more info to the error message to confirm the error
> is happening where I think it is

It should look something like this now:

![image](https://user-images.githubusercontent.com/6473925/109826043-691ca680-7c08-11eb-8a04-6bc4667cd6cc.png)
