### PR TITLE
Decouple image location/date extraction

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -127,8 +127,8 @@ async function extractLocation({
   attachmentFile,
   attachmentBuffer,
   attachmentArrayBuffer,
+  ext,
 }) {
-  const { ext } = await FileType.fromBuffer(attachmentBuffer);
   if (isVideo({ ext })) {
     return extractLocationDateFromVideo({ attachmentArrayBuffer })[0];
   }
@@ -160,8 +160,8 @@ async function extractDate({
   attachmentFile,
   attachmentBuffer,
   attachmentArrayBuffer,
+  ext,
 }) {
-  const { ext } = await FileType.fromBuffer(attachmentBuffer);
   if (isVideo({ ext })) {
     return extractLocationDateFromVideo({ attachmentArrayBuffer })[1];
   }
@@ -505,15 +505,19 @@ class Home extends React.Component {
         });
 
         // eslint-disable-next-line no-await-in-loop
+        const { ext } = await FileType.fromBuffer(attachmentBuffer);
+
+        // eslint-disable-next-line no-await-in-loop
         await Promise.all([
-          this.extractPlate({ attachmentFile, attachmentBuffer }),
-          extractDate({ attachmentBuffer, attachmentArrayBuffer }).then(
+          this.extractPlate({ attachmentFile, attachmentBuffer, ext }),
+          extractDate({ attachmentBuffer, attachmentArrayBuffer, ext }).then(
             this.setCreateDate,
           ),
           extractLocation({
             attachmentFile,
             attachmentBuffer,
             attachmentArrayBuffer,
+            ext,
           }).then(this.setCoords),
         ]);
       } catch (err) {
@@ -556,7 +560,7 @@ class Home extends React.Component {
   };
 
   // adapted from https://github.com/openalpr/cloudapi/tree/8141c1ba57f03df4f53430c6e5e389b39714d0e0/javascript#getting-started
-  extractPlate = async ({ attachmentFile, attachmentBuffer }) => {
+  extractPlate = async ({ attachmentFile, attachmentBuffer, ext }) => {
     console.time('extractPlate'); // eslint-disable-line no-console
 
     try {
@@ -565,7 +569,6 @@ class Home extends React.Component {
         return result;
       }
 
-      const { ext } = await FileType.fromBuffer(attachmentBuffer);
       if (isVideo({ ext })) {
         // eslint-disable-next-line no-param-reassign
         attachmentBuffer = await getVideoScreenshot({ attachmentFile });

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -506,9 +506,12 @@ class Home extends React.Component {
         // eslint-disable-next-line no-await-in-loop
         await Promise.all([
           this.extractPlate({ attachmentFile, attachmentBuffer, ext }),
-          extractDate({ attachmentArrayBuffer, ext, exifData }).then(
-            this.setCreateDate,
-          ),
+          extractDate({
+            attachmentFile,
+            attachmentArrayBuffer,
+            ext,
+            exifData,
+          }).then(this.setCreateDate),
           extractLocation({
             attachmentFile,
             attachmentArrayBuffer,

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -123,7 +123,11 @@ function extractLocationDateFromVideo({ attachmentArrayBuffer }) {
   return [{ latitude, longitude }, created.getTime()];
 }
 
-async function extractLocation({ attachmentFile, attachmentBuffer, attachmentArrayBuffer }) {
+async function extractLocation({
+  attachmentFile,
+  attachmentBuffer,
+  attachmentArrayBuffer,
+}) {
   const { ext } = await FileType.fromBuffer(attachmentBuffer);
   if (isVideo({ ext })) {
     return extractLocationDateFromVideo({ attachmentArrayBuffer })[0];
@@ -152,7 +156,11 @@ async function extractLocation({ attachmentFile, attachmentBuffer, attachmentArr
   });
 }
 
-async function extractDate({ attachmentFile, attachmentBuffer, attachmentArrayBuffer }) {
+async function extractDate({
+  attachmentFile,
+  attachmentBuffer,
+  attachmentArrayBuffer,
+}) {
   const { ext } = await FileType.fromBuffer(attachmentBuffer);
   if (isVideo({ ext })) {
     return extractLocationDateFromVideo({ attachmentArrayBuffer })[1];
@@ -499,8 +507,14 @@ class Home extends React.Component {
         // eslint-disable-next-line no-await-in-loop
         await Promise.all([
           this.extractPlate({ attachmentFile, attachmentBuffer }),
-          extractDate({ attachmentBuffer, attachmentArrayBuffer }).then(this.setCreateDate),
-          extractLocation({ attachmentFile, attachmentBuffer, attachmentArrayBuffer }).then(this.setCoords),
+          extractDate({ attachmentBuffer, attachmentArrayBuffer }).then(
+            this.setCreateDate,
+          ),
+          extractLocation({
+            attachmentFile,
+            attachmentBuffer,
+            attachmentArrayBuffer,
+          }).then(this.setCoords),
         ]);
       } catch (err) {
         const hasMultipleAttachments = attachmentData.length > 1;


### PR DESCRIPTION
Fixes https://github.com/josephfrazier/Reported-Web/issues/281:

> If the EXIF data is missing one of these values, the other one won't be extracted. For example, see this image: [share.icloud.com/photos/0ThSGFHhomUxLqKKH02O3nE7w](https://share.icloud.com/photos/0ThSGFHhomUxLqKKH02O3nE7w)
>
> See also conversation at [reportedcab.slack.com/archives/C9VNM3DL4/p1614782620005400?thread_ts=1614571624.001400&cid=C9VNM3DL4](https://reportedcab.slack.com/archives/C9VNM3DL4/p1614782620005400?thread_ts=1614571624.001400&cid=C9VNM3DL4):
>
> > ah yeah, it looks like it currently tries to extract both the location and the date, and only if both succeed will it set them on the page. I'll try to add some more info to the error message to confirm the error is happening where I think it is
>
> and [reportedcab.slack.com/archives/C9VNM3DL4/p1614783630008600?thread_ts=1614571624.001400&cid=C9VNM3DL4](https://reportedcab.slack.com/archives/C9VNM3DL4/p1614783630008600?thread_ts=1614571624.001400&cid=C9VNM3DL4):
>
> > yeah, I'm about to release a change that should make the error message more clear, and I think I know how to make it so that it will extract the date even if the location isn't present, and vice versa
>
> > I had originally coupled the two extractions since they both required the EXIF to be parsed from the image, but that can be refactored
>
> (related to #279)