### PR TITLE
Guess timezone from CreateDate if OffsetTimeDigitized is not present

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -164,7 +164,9 @@ async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
       millisecondsSinceEpoch: CreateDate.getTime(),
       offset: OffsetTimeDigitized
         ? parseInt(OffsetTimeDigitized, 10) * -60
-        : getNycTimezoneOffset(CreateDate),
+				: CreateDate
+        	? getNycTimezoneOffset(CreateDate),
+        	: new Date().getTimezoneOffset(),
     };
   } catch (err) {
     console.error(err.stack);

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -164,9 +164,9 @@ async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
       millisecondsSinceEpoch: CreateDate.getTime(),
       offset: OffsetTimeDigitized
         ? parseInt(OffsetTimeDigitized, 10) * -60
-				: CreateDate
-        	? getNycTimezoneOffset(CreateDate),
-        	: new Date().getTimezoneOffset(),
+        : CreateDate
+        ? getNycTimezoneOffset(CreateDate)
+        : new Date().getTimezoneOffset(),
     };
   } catch (err) {
     console.error(err.stack);

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -142,7 +142,6 @@ async function extractLocation({ attachmentFile, attachmentArrayBuffer, ext }) {
 }
 
 async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
-  debugger;
   try {
     if (isVideo({ ext })) {
       return extractLocationDateFromVideo({ attachmentArrayBuffer })[1];

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -165,7 +165,6 @@ async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
       offset: OffsetTimeDigitized
         ? parseInt(OffsetTimeDigitized, 10) * -60
         : getNycTimezoneOffset(CreateDate),
-      // : new Date().getTimezoneOffset(),
     };
   } catch (err) {
     console.error(err.stack);

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -46,7 +46,7 @@ import s from './Home.css';
 
 import SubmissionDetails from '../../components/SubmissionDetails.js';
 import { isImage, isVideo } from '../../isImage.js';
-import { getNycTimezoneOffset } from '../../timezone.js';
+import getNycTimezoneOffset from '../../timezone.js';
 
 const GOOGLE_MAPS_API_KEY = 'AIzaSyDlwm2ykA0ohTXeVepQYvkcmdjz2M2CKEI';
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -165,8 +165,8 @@ async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
       millisecondsSinceEpoch: CreateDate.getTime(),
       offset: OffsetTimeDigitized
         ? parseInt(OffsetTimeDigitized, 10) * -60
-        : getNycTimezoneOffset(CreateDate)
-        // : new Date().getTimezoneOffset(),
+        : getNycTimezoneOffset(CreateDate),
+      // : new Date().getTimezoneOffset(),
     };
   } catch (err) {
     console.error(err.stack);

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -46,6 +46,7 @@ import s from './Home.css';
 
 import SubmissionDetails from '../../components/SubmissionDetails.js';
 import { isImage, isVideo } from '../../isImage.js';
+import { getNycTimezoneOffset } from '../../timezone.js';
 
 const GOOGLE_MAPS_API_KEY = 'AIzaSyDlwm2ykA0ohTXeVepQYvkcmdjz2M2CKEI';
 
@@ -141,6 +142,7 @@ async function extractLocation({ attachmentFile, attachmentArrayBuffer, ext }) {
 }
 
 async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
+  debugger;
   try {
     if (isVideo({ ext })) {
       return extractLocationDateFromVideo({ attachmentArrayBuffer })[1];
@@ -163,7 +165,8 @@ async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
       millisecondsSinceEpoch: CreateDate.getTime(),
       offset: OffsetTimeDigitized
         ? parseInt(OffsetTimeDigitized, 10) * -60
-        : new Date().getTimezoneOffset(),
+        : getNycTimezoneOffset(CreateDate)
+        // : new Date().getTimezoneOffset(),
     };
   } catch (err) {
     console.error(err.stack);

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -91,6 +91,6 @@ function isDst(date) {
   return from.getTime() < date.getTime() && date.getTime() < to.getTime();
 }
 
-export function getNycTimezoneOffset(date) {
+export default function getNycTimezoneOffset(date) {
   return isDst(date) ? -240 : -300;
 }

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -1,32 +1,3 @@
-function DisplayDstSwitchDates() {
-  let year = new Date().getYear();
-  if (year < 1000) year += 1900;
-
-  let firstSwitch = 0;
-  let secondSwitch = 0;
-  let lastOffset = 99;
-
-  // Loop through every month of the current year
-  for (let i = 0; i < 12; i += 1) {
-    // Fetch the timezone value for the month
-    const newDate = new Date(Date.UTC(year, i, 0, 0, 0, 0, 0));
-    const tz = (-1 * newDate.getTimezoneOffset()) / 60;
-
-    // Capture when a timzezone change occurs
-    if (tz > lastOffset) firstSwitch = i - 1;
-    else if (tz < lastOffset) secondSwitch = i - 1;
-
-    lastOffset = tz;
-  }
-
-  // Go figure out date/time occurrences a minute before
-  // a DST adjustment occurs
-  const secondDstDate = FindDstSwitchDate(year, secondSwitch);
-  const firstDstDate = FindDstSwitchDate(year, firstSwitch);
-
-  return { firstDstDate, secondDstDate };
-}
-
 function FindDstSwitchDate(year, month) {
   // Set the starting date
   const baseDate = new Date(Date.UTC(year, month, 0, 0, 0, 0, 0));
@@ -81,6 +52,35 @@ function FindDstSwitchDate(year, month) {
       return dstDate;
     }
   }
+}
+
+function DisplayDstSwitchDates() {
+  let year = new Date().getYear();
+  if (year < 1000) year += 1900;
+
+  let firstSwitch = 0;
+  let secondSwitch = 0;
+  let lastOffset = 99;
+
+  // Loop through every month of the current year
+  for (let i = 0; i < 12; i += 1) {
+    // Fetch the timezone value for the month
+    const newDate = new Date(Date.UTC(year, i, 0, 0, 0, 0, 0));
+    const tz = (-1 * newDate.getTimezoneOffset()) / 60;
+
+    // Capture when a timzezone change occurs
+    if (tz > lastOffset) firstSwitch = i - 1;
+    else if (tz < lastOffset) secondSwitch = i - 1;
+
+    lastOffset = tz;
+  }
+
+  // Go figure out date/time occurrences a minute before
+  // a DST adjustment occurs
+  const secondDstDate = FindDstSwitchDate(year, secondSwitch);
+  const firstDstDate = FindDstSwitchDate(year, firstSwitch);
+
+  return { firstDstDate, secondDstDate };
 }
 
 function isDst(date) {

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -85,13 +85,11 @@ function DisplayDstSwitchDates() {
 
 function isDst(date) {
   const result = DisplayDstSwitchDates();
-  // console.log(result)
 
   const { firstDstDate, secondDstDate } = result;
   const from = new Date(firstDstDate);
   const to = new Date(secondDstDate);
   const isDst = from.getTime() < date.getTime() && date.getTime() < to.getTime();
-  // console.log({isDst})
 
   return isDst;
 }

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -7,7 +7,7 @@ function DisplayDstSwitchDates() {
   let lastOffset = 99;
 
   // Loop through every month of the current year
-  for (let i = 0; i < 12; i++) {
+  for (let i = 0; i < 12; i += 1) {
     // Fetch the timezone value for the month
     const newDate = new Date(Date.UTC(year, i, 0, 0, 0, 0, 0));
     const tz = (-1 * newDate.getTimezoneOffset()) / 60;
@@ -35,7 +35,7 @@ function FindDstSwitchDate(year, month) {
   let dstDate;
 
   // Loop to find the exact day a timezone adjust occurs
-  for (let day = 0; day < 50; day++) {
+  for (let day = 0; day < 50; day += 1) {
     let tmpDate = new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
     let tmpOffset = (-1 * tmpDate.getTimezoneOffset()) / 60;
 
@@ -62,7 +62,7 @@ function FindDstSwitchDate(year, month) {
           );
           changeMinute = minutes;
           break;
-        } else minutes++;
+        } else minutes += 1;
       }
 
       // Add a month (for display) since JavaScript counts

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -1,81 +1,70 @@
-function DisplayDstSwitchDates()
-{
-  var year = new Date().getYear();
-  if (year < 1000)
-    year += 1900;
+function DisplayDstSwitchDates() {
+  let year = new Date().getYear();
+  if (year < 1000) year += 1900;
 
-  var firstSwitch = 0;
-  var secondSwitch = 0;
-  var lastOffset = 99;
+  let firstSwitch = 0;
+  let secondSwitch = 0;
+  let lastOffset = 99;
 
   // Loop through every month of the current year
-  for (let i = 0; i < 12; i++)
-  {
+  for (let i = 0; i < 12; i++) {
     // Fetch the timezone value for the month
-    var newDate = new Date(Date.UTC(year, i, 0, 0, 0, 0, 0));
-    var tz = -1 * newDate.getTimezoneOffset() / 60;
+    const newDate = new Date(Date.UTC(year, i, 0, 0, 0, 0, 0));
+    const tz = (-1 * newDate.getTimezoneOffset()) / 60;
 
     // Capture when a timzezone change occurs
-    if (tz > lastOffset)
-      firstSwitch = i-1;
-    else if (tz < lastOffset)
-      secondSwitch = i-1;
+    if (tz > lastOffset) firstSwitch = i - 1;
+    else if (tz < lastOffset) secondSwitch = i - 1;
 
     lastOffset = tz;
   }
 
   // Go figure out date/time occurrences a minute before
   // a DST adjustment occurs
-  var secondDstDate = FindDstSwitchDate(year, secondSwitch);
-  var firstDstDate = FindDstSwitchDate(year, firstSwitch);
+  const secondDstDate = FindDstSwitchDate(year, secondSwitch);
+  const firstDstDate = FindDstSwitchDate(year, firstSwitch);
 
-  return {firstDstDate, secondDstDate};
+  return { firstDstDate, secondDstDate };
 }
 
-function FindDstSwitchDate(year, month)
-{
+function FindDstSwitchDate(year, month) {
   // Set the starting date
-  var baseDate = new Date(Date.UTC(year, month, 0, 0, 0, 0, 0));
-  var changeDay = 0;
-  var changeMinute = -1;
-  var baseOffset = -1 * baseDate.getTimezoneOffset() / 60;
-  var dstDate;
+  const baseDate = new Date(Date.UTC(year, month, 0, 0, 0, 0, 0));
+  let changeDay = 0;
+  let changeMinute = -1;
+  const baseOffset = (-1 * baseDate.getTimezoneOffset()) / 60;
+  let dstDate;
 
   // Loop to find the exact day a timezone adjust occurs
-  for (let day = 0; day < 50; day++)
-  {
-    var tmpDate = new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
-    var tmpOffset = -1 * tmpDate.getTimezoneOffset() / 60;
+  for (let day = 0; day < 50; day++) {
+    let tmpDate = new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
+    let tmpOffset = (-1 * tmpDate.getTimezoneOffset()) / 60;
 
     // Check if the timezone changed from one day to the next
-    if (tmpOffset != baseOffset)
-    {
-      var minutes = 0;
+    if (tmpOffset != baseOffset) {
+      let minutes = 0;
       changeDay = day;
 
       // Back-up one day and grap the offset
-      tmpDate = new Date(Date.UTC(year, month, day-1, 0, 0, 0, 0));
-      tmpOffset = -1 * tmpDate.getTimezoneOffset() / 60;
+      tmpDate = new Date(Date.UTC(year, month, day - 1, 0, 0, 0, 0));
+      tmpOffset = (-1 * tmpDate.getTimezoneOffset()) / 60;
 
       // Count the minutes until a timezone change occurs
-      while (changeMinute == -1)
-      {
-        tmpDate = new Date(Date.UTC(year, month, day-1, 0, minutes, 0, 0));
-        tmpOffset = -1 * tmpDate.getTimezoneOffset() / 60;
+      while (changeMinute == -1) {
+        tmpDate = new Date(Date.UTC(year, month, day - 1, 0, minutes, 0, 0));
+        tmpOffset = (-1 * tmpDate.getTimezoneOffset()) / 60;
 
         // Determine the exact minute a timezone change
         // occurs
-        if (tmpOffset != baseOffset)
-        {
+        if (tmpOffset != baseOffset) {
           // Back-up a minute to get the date/time just
           // before a timezone change occurs
-          tmpOffset = new Date(Date.UTC(year, month,
-            day-1, 0, minutes-1, 0, 0));
+          tmpOffset = new Date(
+            Date.UTC(year, month, day - 1, 0, minutes - 1, 0, 0),
+          );
           changeMinute = minutes;
           break;
-        }
-        else
-          minutes++;
+        } else minutes++;
       }
 
       // Add a month (for display) since JavaScript counts
@@ -83,14 +72,13 @@ function FindDstSwitchDate(year, month)
       dstDate = tmpOffset.getMonth() + 1;
 
       // Pad the month as needed
-      if (dstDate < 10) dstDate = "0" + dstDate;
+      if (dstDate < 10) dstDate = `0${dstDate}`;
 
       // Add the day and year
-      dstDate += '/' + tmpOffset.getDate() + '/' + year + ' ';
+      dstDate += `/${tmpOffset.getDate()}/${year} `;
 
       // Capture the time stamp
-      tmpDate = new Date(Date.UTC(year, month,
-        day-1, 0, minutes-1, 0, 0));
+      tmpDate = new Date(Date.UTC(year, month, day - 1, 0, minutes - 1, 0, 0));
       dstDate += tmpDate.toTimeString().split(' ')[0];
       return dstDate;
     }
@@ -98,19 +86,19 @@ function FindDstSwitchDate(year, month)
 }
 
 function isDst(date) {
-  const result = DisplayDstSwitchDates()
+  const result = DisplayDstSwitchDates();
   // console.log(result)
 
-  const { firstDstDate, secondDstDate } = result
-  const from = new Date(firstDstDate)
-  const to = new Date(secondDstDate)
+  const { firstDstDate, secondDstDate } = result;
+  const from = new Date(firstDstDate);
+  const to = new Date(secondDstDate);
   const now = new Date();
-  const isDst = from.getTime() < now.getTime() && now.getTime() < to.getTime()
+  const isDst = from.getTime() < now.getTime() && now.getTime() < to.getTime();
   // console.log({isDst})
 
   return isDst;
 }
 
 export function getNycTimezoneOffset(date) {
-  return isDst(date) ? -240 : -300
+  return isDst(date) ? -240 : -300;
 }

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -84,7 +84,7 @@ function DisplayDstSwitchDates() {
 }
 
 function isDst(date) {
-  const { firstDstDate, secondDstDate } = DisplayDstSwitchDates();;
+  const { firstDstDate, secondDstDate } = DisplayDstSwitchDates();
   const from = new Date(firstDstDate);
   const to = new Date(secondDstDate);
 

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -87,9 +87,8 @@ function isDst(date) {
   const { firstDstDate, secondDstDate } = DisplayDstSwitchDates();;
   const from = new Date(firstDstDate);
   const to = new Date(secondDstDate);
-  const isDst = from.getTime() < date.getTime() && date.getTime() < to.getTime();
 
-  return isDst;
+  return from.getTime() < date.getTime() && date.getTime() < to.getTime();
 }
 
 export function getNycTimezoneOffset(date) {

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -84,9 +84,7 @@ function DisplayDstSwitchDates() {
 }
 
 function isDst(date) {
-  const result = DisplayDstSwitchDates();
-
-  const { firstDstDate, secondDstDate } = result;
+  const { firstDstDate, secondDstDate } = DisplayDstSwitchDates();;
   const from = new Date(firstDstDate);
   const to = new Date(secondDstDate);
   const isDst = from.getTime() < date.getTime() && date.getTime() < to.getTime();

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -90,8 +90,7 @@ function isDst(date) {
   const { firstDstDate, secondDstDate } = result;
   const from = new Date(firstDstDate);
   const to = new Date(secondDstDate);
-  const now = new Date();
-  const isDst = from.getTime() < now.getTime() && now.getTime() < to.getTime();
+  const isDst = from.getTime() < date.getTime() && date.getTime() < to.getTime();
   // console.log({isDst})
 
   return isDst;

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -30,7 +30,6 @@ function DisplayDstSwitchDates() {
 function FindDstSwitchDate(year, month) {
   // Set the starting date
   const baseDate = new Date(Date.UTC(year, month, 0, 0, 0, 0, 0));
-  let changeDay = 0;
   let changeMinute = -1;
   const baseOffset = (-1 * baseDate.getTimezoneOffset()) / 60;
   let dstDate;
@@ -43,7 +42,6 @@ function FindDstSwitchDate(year, month) {
     // Check if the timezone changed from one day to the next
     if (tmpOffset != baseOffset) {
       let minutes = 0;
-      changeDay = day;
 
       // Back-up one day and grap the offset
       tmpDate = new Date(Date.UTC(year, month, day - 1, 0, 0, 0, 0));

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -92,5 +92,5 @@ function isDst(date) {
 }
 
 export default function getNycTimezoneOffset(date) {
-  return isDst(date) ? -240 : -300;
+  return isDst(date) ? 240 : 300;
 }

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -40,7 +40,7 @@ function FindDstSwitchDate(year, month) {
     let tmpOffset = (-1 * tmpDate.getTimezoneOffset()) / 60;
 
     // Check if the timezone changed from one day to the next
-    if (tmpOffset != baseOffset) {
+    if (tmpOffset !== baseOffset) {
       let minutes = 0;
 
       // Back-up one day and grap the offset
@@ -48,13 +48,13 @@ function FindDstSwitchDate(year, month) {
       tmpOffset = (-1 * tmpDate.getTimezoneOffset()) / 60;
 
       // Count the minutes until a timezone change occurs
-      while (changeMinute == -1) {
+      while (changeMinute === -1) {
         tmpDate = new Date(Date.UTC(year, month, day - 1, 0, minutes, 0, 0));
         tmpOffset = (-1 * tmpDate.getTimezoneOffset()) / 60;
 
         // Determine the exact minute a timezone change
         // occurs
-        if (tmpOffset != baseOffset) {
+        if (tmpOffset !== baseOffset) {
           // Back-up a minute to get the date/time just
           // before a timezone change occurs
           tmpOffset = new Date(

--- a/src/timezone.js
+++ b/src/timezone.js
@@ -1,0 +1,116 @@
+function DisplayDstSwitchDates()
+{
+  var year = new Date().getYear();
+  if (year < 1000)
+    year += 1900;
+
+  var firstSwitch = 0;
+  var secondSwitch = 0;
+  var lastOffset = 99;
+
+  // Loop through every month of the current year
+  for (let i = 0; i < 12; i++)
+  {
+    // Fetch the timezone value for the month
+    var newDate = new Date(Date.UTC(year, i, 0, 0, 0, 0, 0));
+    var tz = -1 * newDate.getTimezoneOffset() / 60;
+
+    // Capture when a timzezone change occurs
+    if (tz > lastOffset)
+      firstSwitch = i-1;
+    else if (tz < lastOffset)
+      secondSwitch = i-1;
+
+    lastOffset = tz;
+  }
+
+  // Go figure out date/time occurrences a minute before
+  // a DST adjustment occurs
+  var secondDstDate = FindDstSwitchDate(year, secondSwitch);
+  var firstDstDate = FindDstSwitchDate(year, firstSwitch);
+
+  return {firstDstDate, secondDstDate};
+}
+
+function FindDstSwitchDate(year, month)
+{
+  // Set the starting date
+  var baseDate = new Date(Date.UTC(year, month, 0, 0, 0, 0, 0));
+  var changeDay = 0;
+  var changeMinute = -1;
+  var baseOffset = -1 * baseDate.getTimezoneOffset() / 60;
+  var dstDate;
+
+  // Loop to find the exact day a timezone adjust occurs
+  for (let day = 0; day < 50; day++)
+  {
+    var tmpDate = new Date(Date.UTC(year, month, day, 0, 0, 0, 0));
+    var tmpOffset = -1 * tmpDate.getTimezoneOffset() / 60;
+
+    // Check if the timezone changed from one day to the next
+    if (tmpOffset != baseOffset)
+    {
+      var minutes = 0;
+      changeDay = day;
+
+      // Back-up one day and grap the offset
+      tmpDate = new Date(Date.UTC(year, month, day-1, 0, 0, 0, 0));
+      tmpOffset = -1 * tmpDate.getTimezoneOffset() / 60;
+
+      // Count the minutes until a timezone change occurs
+      while (changeMinute == -1)
+      {
+        tmpDate = new Date(Date.UTC(year, month, day-1, 0, minutes, 0, 0));
+        tmpOffset = -1 * tmpDate.getTimezoneOffset() / 60;
+
+        // Determine the exact minute a timezone change
+        // occurs
+        if (tmpOffset != baseOffset)
+        {
+          // Back-up a minute to get the date/time just
+          // before a timezone change occurs
+          tmpOffset = new Date(Date.UTC(year, month,
+            day-1, 0, minutes-1, 0, 0));
+          changeMinute = minutes;
+          break;
+        }
+        else
+          minutes++;
+      }
+
+      // Add a month (for display) since JavaScript counts
+      // months from 0 to 11
+      dstDate = tmpOffset.getMonth() + 1;
+
+      // Pad the month as needed
+      if (dstDate < 10) dstDate = "0" + dstDate;
+
+      // Add the day and year
+      dstDate += '/' + tmpOffset.getDate() + '/' + year + ' ';
+
+      // Capture the time stamp
+      tmpDate = new Date(Date.UTC(year, month,
+        day-1, 0, minutes-1, 0, 0));
+      dstDate += tmpDate.toTimeString().split(' ')[0];
+      return dstDate;
+    }
+  }
+}
+
+function isDst(date) {
+  const result = DisplayDstSwitchDates()
+  // console.log(result)
+
+  const { firstDstDate, secondDstDate } = result
+  const from = new Date(firstDstDate)
+  const to = new Date(secondDstDate)
+  const now = new Date();
+  const isDst = from.getTime() < now.getTime() && now.getTime() < to.getTime()
+  // console.log({isDst})
+
+  return isDst;
+}
+
+export function getNycTimezoneOffset(date) {
+  return isDst(date) ? -240 : -300
+}


### PR DESCRIPTION
This should help alleviate the problem that
https://github.com/josephfrazier/Reported-Web/pull/319 is trying to
solve. Note that it's not foolproof, due to the inherent ambiguity of
expressing times without timezones. Specifically, photos taken during
the hour that occurs twice when we switch from EDT to EST, may not have
the correct timezone applied.

Most of the code in timezone.js came from https://www.codeproject.com/articles/58728/javascript-code-to-determine-when-daylight-savings