### PR TITLE
Disable license state fallback to NY since lookup is broken

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -468,12 +468,15 @@ class Home extends React.Component {
               plate: `T${plate}`,
               licenseState,
             });
-          } else if (licenseState !== 'NY') {
-            this.setLicensePlate({
-              plate,
-              licenseState: 'NY',
-            });
           }
+          // Commented out due to https://github.com/josephfrazier/Reported-Web/issues/295
+          //
+          // } else if (licenseState !== 'NY') {
+          //   this.setLicensePlate({
+          //     plate,
+          //     licenseState: 'NY',
+          //   });
+          // }
         }
       });
   };


### PR DESCRIPTION
Got a report that setting the license plate state doesn't work, due to the fallback behavior: https://reportedcab.slack.com/archives/C9VNM3DL4/p1639432798001200

> I forget if I reported this but you can't change the license plate state field on the webapp.
>
> It just says "Could not find 12345 in New York, click here for details" no matter what state you choose.

See also https://github.com/josephfrazier/Reported-Web/issues/295