### PR TITLE
SubmisionDetails: Show `license` field when `medallionNo` is missing

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -19,6 +19,7 @@ class SubmissionDetails extends React.Component {
     const {
       reqnumber,
       medallionNo,
+      license,
       typeofcomplaint,
       loc1_address, // eslint-disable-line camelcase
       timeofreport,
@@ -121,7 +122,7 @@ class SubmissionDetails extends React.Component {
         }}
       >
         <summary>
-          {medallionNo} {typeofcomplaint} near{' '}
+          {medallionNo || license} {typeofcomplaint} near{' '}
           {/* eslint-disable-next-line camelcase */}
           {(loc1_address || '').split(',')[0]} on {humanTimeString}
           <br />
@@ -147,6 +148,7 @@ SubmissionDetails.propTypes = {
   submission: PropTypes.shape({
     reqnumber: PropTypes.string,
     medallionNo: PropTypes.string,
+    license: PropTypes.string,
     typeofcomplaint: PropTypes.string,
     loc1_address: PropTypes.string,
     timeofreport: PropTypes.string,

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -46,6 +46,41 @@ describe('SubmissionDetails', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  test('renders children correctly when medallionNo is missing but license is present', () => {
+    const submission = {
+      reqnumber: 'reqnumber',
+      license: 'license',
+      typeofcomplaint: 'typeofcomplaint',
+      loc1_address: '82 Reade St, New York, NY 10007, USA',
+      timeofreport: new Date(Date.now()).toISOString(),
+      reportDescription: 'reportDescription',
+      status: 1,
+
+      photoData: { url: 'photoData.url' },
+      photoData0: { url: 'photoData0.url' },
+      photoData1: { url: 'photoData1.url' },
+      photoData2: { url: 'photoData2.url' },
+
+      videoData0: 'videoData0',
+      videoData1: 'videoData1',
+      videoData2: 'videoData2',
+    };
+
+    const wrapper = renderer
+      .create(
+        <App context={{ insertCss: () => {}, fetch: () => {}, pathname: '' }}>
+          <SubmissionDetails
+            isDetailsOpen
+            submission={submission}
+            onDeleteSubmission={() => {}}
+          />
+        </App>,
+      )
+      .toJSON();
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   test('renders delete button correctly', () => {
     const submission = {
       reqnumber: 'reqnumber',

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -97,6 +97,102 @@ exports[`SubmissionDetails renders children correctly 1`] = `
 </details>
 `;
 
+exports[`SubmissionDetails renders children correctly when medallionNo is missing but license is present 1`] = `
+<details
+  onToggle={[Function]}
+  open={true}
+>
+  <summary>
+     
+    typeofcomplaint
+     near
+     
+    82 Reade St
+     on 
+    2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
+    <br />
+    TLC Service Request Number: 
+    reqnumber
+  </summary>
+  <p>
+    reportDescription
+  </p>
+  <a
+    href="photoData.url"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <img
+      alt="#0"
+      src="photoData.url"
+    />
+  </a>
+  <a
+    href="photoData0.url"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <img
+      alt="#1"
+      src="photoData0.url"
+    />
+  </a>
+  <a
+    href="photoData1.url"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <img
+      alt="#2"
+      src="photoData1.url"
+    />
+  </a>
+  <a
+    href="photoData2.url"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <img
+      alt="#3"
+      src="photoData2.url"
+    />
+  </a>
+  <a
+    href="videoData0"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <video
+      alt="#0"
+      src="videoData0"
+    />
+  </a>
+  <a
+    href="videoData1"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <video
+      alt="#1"
+      src="videoData1"
+    />
+  </a>
+  <a
+    href="videoData2"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <video
+      alt="#2"
+      src="videoData2"
+    />
+  </a>
+  <div>
+    Loading Service Request Status...
+  </div>
+</details>
+`;
+
 exports[`SubmissionDetails renders delete button correctly 1`] = `
 <details
   onToggle={[Function]}

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -103,6 +103,7 @@ exports[`SubmissionDetails renders children correctly when medallionNo is missin
   open={true}
 >
   <summary>
+    license
      
     typeofcomplaint
      near

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -409,7 +409,9 @@ class Home extends React.Component {
         if (
           this.state.submissions.some(
             submission =>
-              submission.license === plate && submission.state === licenseState,
+              (submission.license === plate ||
+                submission.medallionNo === plate) &&
+              submission.state === licenseState,
           )
         ) {
           this.alert(


### PR DESCRIPTION
From https://reportedcab.slack.com/archives/C9VNM3DL4/p1656783831210109:

> Report on the iOS app. Until the report is filed with 311, it doesn’t
> appear on your report history on the web app. After filed with 311, it
> appears on your report history on the web app, but no plate number is
> shown. Both the 311 confirmation email and the tweet confirmation email
> show the plate number correctly.

> As for the plate number not showing, I think I know why: I was able to
> find the submission you're talking about, and while it has the license
> field filled in, it doesn't not have the medallionNo field filled in.

This doesn't address the report not appearing until filed with 311, but
it should fix the problem with the plate number not showing.