### PR TITLE
Also search `email` when looking for previous submissions, since iOS submissions don't always have the `Username` filled in

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -229,11 +229,22 @@ app.use('/api/process_validation', (req, res) => {
 async function getSubmissions(req) {
   return saveUser(req.body).then(user => {
     const Submission = Parse.Object.extend('submission');
-    const query = new Parse.Query(Submission);
+
+    const usernameQuery = new Parse.Query(Submission);
     // Search by "Username" (email address) to show submissions made by all
     // users with the same email, since the web and mobile clients create
     // separate users
-    query.equalTo('Username', user.get('username'));
+    usernameQuery.equalTo('Username', user.get('username'));
+    usernameQuery.descending('timeofreport');
+    usernameQuery.limit(Number.MAX_SAFE_INTEGER);
+
+    // Also search by "email" since submissions from iOS clients don't always have this set
+    const emailQuery = new Parse.Query(Submission);
+    emailQuery.equalTo('email', user.get('username'));
+    emailQuery.descending('timeofreport');
+    emailQuery.limit(Number.MAX_SAFE_INTEGER);
+
+    const query = Parse.Query.or(usernameQuery, emailQuery);
     query.descending('timeofreport');
     query.limit(Number.MAX_SAFE_INTEGER);
     return query.find();


### PR DESCRIPTION
From https://reportedcab.slack.com/archives/C9VNM3DL4/p1656783831210109:

> Report on the iOS app. Until the report is filed with 311, it doesn’t
> appear on your report history on the web app. After filed with 311, it
> appears on your report history on the web app

> Ok, so I found the code that looks up the submissions to display, it has
> a clue as to what might be happening: The mobile and web apps (EDIT:
> used to? this may not be the case now) create different users on
> the back4app/Parse server, so instead of showing only the submissions
> associated with your web app user, it looks up every submission that has
> your email address in the Username field, in order to get the mobile app
> submissions too.
>
> One possibility is that the mobile app submission
> process doesn't fill in the Username field until after the submission has
> been filed with 311, but I haven't confirmed this yet.
>
> ... (after another test submission was made from iOS)
>
> when I change the backend filter to look for the email field instead
> of the Username field, I see the TEST submission (which has an
> undefined Username). So, I think that's why it's not showing
> up on the webapp, because we're only looking for the Username field,
> and not also including the email field