### PR TITLE
package.json: Set `name` to "reported-web", not "web"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "reported-web",
   "version": "0.0.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
Occasionally I'll see `yarn` error messages that show `web@0.0.0` in the
output and was confused about what it could be referring to. This should
fix that.