### PR TITLE
Revert "Disable zoom on mobile devices to avoid unescapeable map issue"

### DIFF
--- a/src/components/Html.js
+++ b/src/components/Html.js
@@ -43,10 +43,7 @@ class Html extends React.Component {
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />
           <title>{title}</title>
           <meta name="description" content={description} />
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-          />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="theme-color" content="#008000" />
           {scripts.map(script => (
             <link key={script} rel="preload" href={script} as="script" />


### PR DESCRIPTION
Reverts josephfrazier/Reported-Web#346, see https://github.com/josephfrazier/Reported-Web/issues/344#issuecomment-1179219200

> #346 didn't fix this on iOS Safari, see [reportedcab.slack.com/archives/C9VNM3DL4/p1657301370594619?thread_ts=1656783831.210109&cid=C9VNM3DL4](https://reportedcab.slack.com/archives/C9VNM3DL4/p1657301370594619?thread_ts=1656783831.210109&cid=C9VNM3DL4):
> 
> > hmm, it looks like Apple decided to allow zooming regardless in Safari back in iOS 10, guessing it hasn't changed since: [stackoverflow.com/questions/4389932/how-do-you-disable-viewport-zooming-on-mobile-safari/38852262#38852262](https://stackoverflow.com/questions/4389932/how-do-you-disable-viewport-zooming-on-mobile-safari/38852262#38852262)