### PR TITLE
Down-scale images with larger file sizes before sending to plate recognizer API

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -338,8 +338,24 @@ function orientImageBuffer({ attachmentBuffer }) {
     .catch(() => attachmentBuffer)
     .then(buffer => Buffer.from(buffer))
     .then(buffer => {
-      console.log(`image buffer length AFTER sharp: ${buffer.length} bytes`); // eslint-disable-line no-console
       console.timeEnd(`orientImageBuffer`); // eslint-disable-line no-console
+      const fileSize = buffer.length;
+      console.log(`image buffer length AFTER sharp: ${fileSize} bytes`); // eslint-disable-line no-console
+
+      const maxFilesize = 3000000;
+      if (fileSize > maxFilesize) {
+        const targetWidth = 1024;
+        // eslint-disable-next-line no-console
+        console.log(
+          `file size is greater than maximum of ${maxFilesize} bytes, attempting to scale down to width of ${targetWidth}`,
+        );
+
+        return sharp(buffer)
+          .resize({ width: targetWidth })
+          .toBuffer()
+          .catch(() => attachmentBuffer)
+          .then(resizedBuffer => Buffer.from(resizedBuffer));
+      }
       return buffer;
     });
 }


### PR DESCRIPTION
Notes from https://reportedcab.slack.com/archives/C9VNM3DL4/p1658594595486789?thread_ts=1657582859.783929&cid=C9VNM3DL4:


> anyway, I quickly tried the first image locally, and while the re-orienting does indeed shrink the image. I don't think it shrinks it enough to be under the platerecognizer API limit (3MB IIRC):
> image buffer length BEFORE sharp: 6538314 bytes
> image buffer length AFTER sharp: 3762587 bytes
> For comparison, here's the before/after re-orient size for a different, smaller image, where the plate was read:
> image buffer length BEFORE sharp: 3723317 bytes
> image buffer length AFTER sharp: 1962551 bytes

> for reference, here's the image size/dimension limits: https://app.platerecognizer.com/upload-limit/
> File Upload Error - Payload Too Large
> File size must be lower than 3MB.
> Recommended image resolution: 1024×768.
> Recommended orientation: portrait.
> Vehicle should be at least 15% of the total image area.
> License plate should be readable by a human.
> the resolution recommendation appears not to limit anything, I'm guessing it's a suggested minimum rather than a maximum, but the file size limit is definitely being triggered

> If I do try to fix this, it'll probably be something along the lines of:
> after the image has been re-oriented
> see how much bigger the file is than the 3MB limit
> scale it down down proportionally until it fits
> A simpler approach might be to just scale it to 1024x768, but I'm guessing that would compromise readability in some cases, like you described
> (none of this would apply to the Reported submission, only the image sent to the plate reading API)

> I could have it only resize down to 1024x768 if the filesize would be bigger than 3MB, rather than always scaling it down. This would make it so that the plate-reading couldn't fail any more often than it already does