### PR TITLE
Make text for make/model lookup easier to understand

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -386,7 +386,7 @@ class Home extends React.Component {
       plate,
       licenseState,
       vehicleInfoComponent: plate ? (
-        `Searching for ${plate} in ${usStateNames[licenseState]}`
+        `Looking up make/model for ${plate} in ${usStateNames[licenseState]}`
       ) : (
         <br />
       ),
@@ -454,7 +454,7 @@ class Home extends React.Component {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Could not find {plate} in {usStateNames[licenseState]}, click
+                Could not look up make/model of {plate} in {usStateNames[licenseState]}, click
                 here for details
               </a>
             ),

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -454,8 +454,8 @@ class Home extends React.Component {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Could not look up make/model of {plate} in {usStateNames[licenseState]}, click
-                here for details
+                Could not look up make/model of {plate} in{' '}
+                {usStateNames[licenseState]}, click here for details
               </a>
             ),
           });


### PR DESCRIPTION
I realized that the previous text could imply that the plate/car doesn't exist, vs just that we couldn't automatically determine the make/model of it.