### PR TITLE
Reduce platerecognizer resize threshold to 2590988 bytes

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -506,9 +506,9 @@ app.use('/submit', (req, res) => {
 // https://app.platerecognizer.com/upload-limit/
 const downscaleForPlateRecognizer = buffer => {
   const fileSize = buffer.length;
-  const maxFilesize = 3000000;
+  const maxFilesize = 2590988;
 
-  if (fileSize > maxFilesize) {
+  if (fileSize >= maxFilesize) {
     const targetWidth = 1024;
 
     // eslint-disable-next-line no-console


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C9VNM3DL4/p1659826514091039?thread_ts=1657582859.783929&cid=C9VNM3DL4:

> hmm, I added in some more logging (will shortly be released), and it looks like DSC_0107.JPG still trips the image size limit at 2590988 bytes, even after being re-oriented and implicitly shrank
>
> ```
> image buffer length BEFORE sharp: 7689501 bytes
> image buffer length AFTER sharp: 2590988 bytes
> orientImageBuffer: 611.094ms
> STARTING platerecognizer
> /platerecognizer plate-reader {
>   platerecognizerRes: Response {
>     size: 0,
>     timeout: 0,
>     [Symbol(Body internals)]: { body: [PassThrough], disturbed: false, error: null },
>     [Symbol(Response internals)]: {
>       url: 'https://api.platerecognizer.com/v1/plate-reader/',
>       status: 413,
>       statusText: 'Request Entity Too Large',
>       headers: [Headers],
>       counter: 0
>     }
>   }
> }
> /platerecognizer plate-reader: 152.952ms
> ```