### PR TITLE
Increase attachment file size limit from 10mb to 20mb

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -72,12 +72,12 @@ Parse.serverURL = PARSE_SERVER_URL;
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: {
-    fileSize: 10 * 1000 * 1000, // 10MB
+    fileSize: 20 * 1000 * 1000, // just under 20MB
     files: 6,
   },
 });
 // Here's the logic for the above `limits`:
-// * Back4App has a per-file limit of 10mb: https://docs.back4app.com/docs/faq-parse-back4app/can-i-store-files-larger-than-10-mb-can-i-pay-to-remove-this-limit/
+// * Back4App has a per-file limit of 20mb: https://www.back4app.com/pricing
 // * Up to 6 files can be included with each submission to Back4App:
 //   * photoData0
 //   * photoData1


### PR DESCRIPTION
From https://reportedcab.slack.com/archives/C802R14UX/p1661215472653909?thread_ts=1660310434.082859&cid=C802R14UX:

> Ah, looking at the code, I see that I put a limit of 10MB per file
> (see first link below), because our backend server, Back4App, had
> per-file limit of 20MB. However, it looks like Back4App has increased
> their limit to 20MB, so I'll raise the webapp limit accordingly.
>
> I think people have previously uploaded videos to youtube and included the
> link in their submission text, or you could even use the Google Drive
> link you posted above, if you're willing to keep it public until
> 311/OATH handle the case.
>
> References:
> 1. 10mb limit in source code: https://github.com/josephfrazier/Reported-Web/blob/2e18e05c02472f252c32992964587fdb633f31c8/src/server.js#L72-L87
> 1. Back4App documentation of 20MB limit: https://www.back4app.com/pricing