### PR TITLE
platerecognizer: Reduce image resize threshold file size to 2572792

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.2
+    - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
     - run: export PATH=$HOME/.yarn/bin:$PATH
     - run: yarn
     - run: yarn lint

--- a/src/server.js
+++ b/src/server.js
@@ -506,7 +506,7 @@ app.use('/submit', (req, res) => {
 // https://app.platerecognizer.com/upload-limit/
 const downscaleForPlateRecognizer = buffer => {
   const fileSize = buffer.length;
-  const maxFilesize = 2572792;
+  const maxFilesize = 2411654;
 
   if (fileSize >= maxFilesize) {
     const targetWidth = 1024;

--- a/src/server.js
+++ b/src/server.js
@@ -506,7 +506,7 @@ app.use('/submit', (req, res) => {
 // https://app.platerecognizer.com/upload-limit/
 const downscaleForPlateRecognizer = buffer => {
   const fileSize = buffer.length;
-  const maxFilesize = 2590988;
+  const maxFilesize = 2572792;
 
   if (fileSize >= maxFilesize) {
     const targetWidth = 1024;


### PR DESCRIPTION
A user found an image that was still too large for the platerecognizer
API, even after `sharp` had compressed it.