### PR TITLE
Show whether location came from device, photo, or manually setting via map

### DIFF
--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -585,7 +585,8 @@ exports[`Home renders children correctly 1`] = `
           <label
             htmlFor="where"
           >
-            Where:
+            Where: 
+            
             <br />
             <button
               name="where"


### PR DESCRIPTION
See feedback at https://reportedcab.slack.com/archives/C9VNM3DL4/p1663676341717829:

> User:
>
> It isn’t clear if it’s pulling location from my current location or the photo.

> Me:
>
> Good point, the user feedback here is pretty minimal/non-existent. For
> what it's worth, when you first open the site, it tries to get your
> current location, but once you upload photos, it tries to pull location
> from the photo, and lets you know if any photos did not have the
> necessary GPS metadata.
>
> Maybe one way to make this more obvious to users would be to add a note
> by the address field indicating if it was pulled from the device's
> current location, or if it was pulled from a photo, or if it was set
> manually.
>
> What do you think?