### PR TITLE
Prevent iOS zoom on map address field by increasing font size

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1416,7 +1416,7 @@ const MyMapComponentPure = props => {
             padding: `0 12px`,
             borderRadius: `3px`,
             boxShadow: `0 2px 6px rgba(0, 0, 0, 0.3)`,
-            fontSize: `14px`,
+            fontSize: `16px`,
             outline: `none`,
             textOverflow: `ellipses`,
           }}


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C9VNM3DL4/p1663676505708239:

> From User1 at https://reportedcab.slack.com/archives/C7Z0BHMMY/p1663108832158739?thread_ts=1663092819.678649&cid=C7Z0BHMMY:
>
> Setting a location is awkward because of the size of the map pane on the screen/scrolling issues.
>
> EDIT:
>
> adding some feedback from User2 at https://reportedcab.slack.com/archives/C7Z0BHMMY/p1663547627566829?thread_ts=1663092819.678649&cid=C7Z0BHMMY since its discussing the same issue:
>
> Also agree with User1 that the map is currently one of the most frustrating parts. I put in an intersection, then need to scroll down in just the right part of the screen to get to the Done button; otherwise, I lose the intersection I just entered.

> User1: The issue seems to stem from iOS zooming in on the webpage when I click into the address field to type. It doesn't zoom out after I click out of the field or dismiss the keyboard.

> User1: Apparently iOS will only zoom in when you tap a text field if the text size is < 16px. You could try adjusting it and seeing if that helps? https://stackoverflow.com/a/6394497