### PR TITLE
Improve feedback when ALPR/platerecognizer gives no results

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -629,6 +629,7 @@ class Home extends React.Component {
       const formData = new window.FormData();
       formData.append('attachmentFile', attachmentBlob);
       const { data } = await axios.post('/platerecognizer', formData);
+      // TODO: handle case where results array is empty
       const result = data.results[0];
       try {
         result.licenseState = result.region.code.split('-')[1].toUpperCase();


### PR DESCRIPTION
From the Slack thread at https://reportedcab.slack.com/archives/C9VNM3DL4/p1664032483942889?thread_ts=1657582859.783929&cid=C9VNM3DL4:

> yeah... it looks like this one did get resized to within the
> platerecognizer API file size limit (though, interestingly, the initial
> run of the sharp library actually increased the size), here's
> the server-side logs when I run the webapp locally.
>
> ```
> image buffer length BEFORE sharp: 2185751 bytes
> image buffer length AFTER sharp: 2649569 bytes
> orientImageBuffer: 741.517ms
> file size is greater than maximum of 2411654 bytes, attempting to scale down to width of 4096
> file size after scaling down: 2054754 bytes
> ```
>
> and the platerecognizer API responded with no results, indicating that
> it was able to process the image, it just couldn't find a plate
> :confused:here's the API response that went to the browser:
>
> ```json
> {
>   "processing_time": 128.126,
>   "results": [],
>   "filename": "1510_1xG41_e12aa9e8-4915-4219-bcbb-5f11417c81f2.jpg",
>   "version": 1,
>   "camera_id": null,
>   "timestamp": "2022-09-24T15:10:28.270005Z"
> }
> ```
>
> Maybe a good next step would be to make the error messaging
> differentiate between the following two cases:
>
> * there was an error processing the image, such as it being too large for the API
> * the API processed the image, but didn't find any plates
>
> This would make it easier to understand what's going on, without me
> having to try the image myself and look at the logs to figure it out