### PR TITLE
Use toast notification instead of modal for warning/success messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-localstorage": "https://github.com/josephfrazier/react-localstorage#higher-ordered-component",
     "react-modal": "^3.4.5",
     "react-social-icons": "^2.8.1",
+    "react-toastify": "9.0.3",
     "recompose": "^0.26.0",
     "serialize-javascript": "^3.1.0",
     "sharp": "^0.27.1",

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -41,7 +41,7 @@ import wordlist from 'diceware-wordlist-en-eff';
 import Modal from 'react-modal';
 import Dropzone from '@josephfrazier/react-dropzone';
 import { ToastContainer, toast } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import toastifyStyles from 'react-toastify/dist/ReactToastify.css';
 
 import marx from 'marx-css/css/marx.css';
 import s from './Home.css';
@@ -1466,4 +1466,4 @@ const MyMapComponent = compose(
   withGoogleMap,
 )(MyMapComponentPure);
 
-export default withStyles(marx, s)(withLocalStorage(Home));
+export default withStyles(marx, s, toastifyStyles)(withLocalStorage(Home));

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -432,7 +432,7 @@ class Home extends React.Component {
               submission.state === licenseState,
           )
         ) {
-          this.alert(
+          this.notifyWarning(
             <p>
               You have already submitted a report for {plate} in {licenseState},
               are you sure you want to submit another?
@@ -573,7 +573,7 @@ class Home extends React.Component {
           ? 'one of the files, but they may have been found in other files.'
           : 'the file.';
 
-        this.alert(
+        this.notifyWarning(
           <React.Fragment>
             <p>
               Could not extract the {missingValuesString} from {fileCopy} Please
@@ -664,15 +664,15 @@ class Home extends React.Component {
   handleAxiosError = error =>
     Promise.reject(error)
       .catch(err => {
-        this.alert(`Error: ${err.response.data.error.message}`);
+        this.notifyWarning(`Error: ${err.response.data.error.message}`);
       })
       .catch(err => {
         console.error(err);
       });
 
-  success = modalText => toast.success(modalText);
+  notifySuccess = notificationContent => toast.success(notificationContent);
 
-  alert = modalText => toast.warn(modalText);
+  notifyWarning = notificationContent => toast.warn(notificationContent);
 
   loadPreviousSubmissions = () => {
     axios
@@ -816,7 +816,7 @@ class Home extends React.Component {
                             })
                             .then(() => {
                               const message = `Please check ${email} to reset your password.`;
-                              this.alert(message);
+                              this.notifyWarning(message);
                             })
                             .catch(this.handleAxiosError);
                         }}
@@ -941,7 +941,7 @@ class Home extends React.Component {
                   this.state.latitude === defaultLatitude &&
                   this.state.longitude === defaultLongitude
                 ) {
-                  this.alert('Please provide the location of the incident');
+                  this.notifyWarning('Please provide the location of the incident');
                   return;
                 }
 
@@ -999,7 +999,7 @@ class Home extends React.Component {
                       reportDescription: '',
                     }));
                     this.setLicensePlate({ plate: '', licenseState: 'NY' });
-                    this.success(
+                    this.notifySuccess(
                       <React.Fragment>
                         <p>Thanks for your submission!</p>
                         <p>
@@ -1252,7 +1252,7 @@ class Home extends React.Component {
                           });
                         })
                         .catch(err => {
-                          this.alert(err.message);
+                          this.notifyWarning(err.message);
                           console.error(err);
                         });
                     }}

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -670,6 +670,8 @@ class Home extends React.Component {
         console.error(err);
       });
 
+  success = modalText => toast.success(modalText);
+
   alert = modalText => toast.warn(modalText);
 
   loadPreviousSubmissions = () => {
@@ -997,7 +999,7 @@ class Home extends React.Component {
                       reportDescription: '',
                     }));
                     this.setLicensePlate({ plate: '', licenseState: 'NY' });
-                    this.alert(
+                    this.success(
                       <React.Fragment>
                         <p>Thanks for your submission!</p>
                         <p>

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -40,6 +40,8 @@ import diceware from 'diceware-generator';
 import wordlist from 'diceware-wordlist-en-eff';
 import Modal from 'react-modal';
 import Dropzone from '@josephfrazier/react-dropzone';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 import marx from 'marx-css/css/marx.css';
 import s from './Home.css';
@@ -245,7 +247,6 @@ class Home extends React.Component {
     const initialStatePerSession = {
       attachmentData: [],
 
-      modalText: null,
       isPasswordRevealed: false,
       isUserInfoSaving: false,
       isSubmitting: false,
@@ -669,9 +670,17 @@ class Home extends React.Component {
         console.error(err);
       });
 
-  alert = modalText => this.setState({ modalText });
-
-  closeAlert = () => this.setState({ modalText: null });
+  alert = modalText =>
+    toast.warn(modalText, {
+      position: 'top-center',
+      autoClose: 5000,
+      hideProgressBar: false,
+      closeOnClick: true,
+      pauseOnHover: true,
+      draggable: true,
+      progress: undefined,
+      theme: 'dark',
+    });
 
   loadPreviousSubmissions = () => {
     axios
@@ -713,16 +722,18 @@ class Home extends React.Component {
               </a>
             </h1>
 
-            <Modal
-              isOpen={!!this.state.modalText}
-              onRequestClose={this.closeAlert}
-            >
-              {this.state.modalText}
-              <br />
-              <button type="button" onClick={this.closeAlert}>
-                Close
-              </button>
-            </Modal>
+            <ToastContainer
+              position="top-center"
+              autoClose={5000}
+              hideProgressBar={false}
+              newestOnTop={false}
+              closeOnClick
+              rtl={false}
+              pauseOnFocusLoss
+              draggable
+              pauseOnHover
+              theme="dark"
+            />
 
             {/* TODO use tabbed interface instead of toggling <details> ? */}
             <details

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -670,17 +670,7 @@ class Home extends React.Component {
         console.error(err);
       });
 
-  alert = modalText =>
-    toast.warn(modalText, {
-      position: 'top-center',
-      autoClose: 5000,
-      hideProgressBar: false,
-      closeOnClick: true,
-      pauseOnHover: true,
-      draggable: true,
-      progress: undefined,
-      theme: 'dark',
-    });
+  alert = modalText => toast.warn(modalText);
 
   loadPreviousSubmissions = () => {
     axios

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -664,7 +664,7 @@ class Home extends React.Component {
   handleAxiosError = error =>
     Promise.reject(error)
       .catch(err => {
-        this.notifyWarning(`Error: ${err.response.data.error.message}`);
+        this.notifyError(`Error: ${err.response.data.error.message}`);
       })
       .catch(err => {
         console.error(err);
@@ -672,7 +672,11 @@ class Home extends React.Component {
 
   notifySuccess = notificationContent => toast.success(notificationContent);
 
+  notifyInfo = notificationContent => toast.info(notificationContent);
+
   notifyWarning = notificationContent => toast.warn(notificationContent);
+
+  notifyError = notificationContent => toast.error(notificationContent);
 
   loadPreviousSubmissions = () => {
     axios
@@ -816,7 +820,7 @@ class Home extends React.Component {
                             })
                             .then(() => {
                               const message = `Please check ${email} to reset your password.`;
-                              this.notifyWarning(message);
+                              this.notifyInfo(message);
                             })
                             .catch(this.handleAxiosError);
                         }}
@@ -941,7 +945,9 @@ class Home extends React.Component {
                   this.state.latitude === defaultLatitude &&
                   this.state.longitude === defaultLongitude
                 ) {
-                  this.notifyWarning('Please provide the location of the incident');
+                  this.notifyError(
+                    'Please provide the location of the incident',
+                  );
                   return;
                 }
 
@@ -1252,7 +1258,7 @@ class Home extends React.Component {
                           });
                         })
                         .catch(err => {
-                          this.notifyWarning(err.message);
+                          this.notifyError(err.message);
                           console.error(err);
                         });
                     }}

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -37,6 +37,9 @@ exports[`Home renders children correctly 1`] = `
           Reported
         </a>
       </h1>
+      <div
+        className="Toastify"
+      />
       <details
         onToggle={[Function]}
         open={true}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3278,6 +3278,11 @@ clsx@^1.0.4:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
+clsx@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
 clui@^0.3.1:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/clui/-/clui-0.3.6.tgz#8e1e5cea7332a6e54083f59da0ccbe1d6f2fa787"
@@ -12360,6 +12365,13 @@ react-test-renderer@^16.5.2:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
+
+react-toastify@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.0.3.tgz#8e6d22651c85cb584c5ebd0b5e2c3bf0d7ec06ee"
+  integrity sha512-0QZJk0SqYBxouRBGCFU3ymvjlwimRRhVH7SzqGRiVrQ001KSoUNbGKx9Yq42aoPv18n45yJzEFG82zqv3HnASg==
+  dependencies:
+    clsx "^1.1.1"
 
 react-transition-group@^2.2.1:
   version "2.9.0"


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C9VNM3DL4/p1672888880155269:

> What do you think of replacing the react modals with alerts? instead
> of dismissing the popup it would be some text that disappears after a
> few seconds

I pinned to react-toastify version 9.0.3 due to this issue: https://github.com/fkhadra/react-toastify/issues/775

See here for a demo of react-toastify: https://fkhadra.github.io/react-toastify/introduction

Example images:


mobile alert/warning: 
![image](https://user-images.githubusercontent.com/6473925/214184085-a2120937-cab5-4475-897e-334109dac988.png)

desktop alert/warning: ![image](https://user-images.githubusercontent.com/6473925/214182462-7a625d22-e123-4c43-8557-d0f1270d79ff.png)

<img width="781" alt="image" src="https://user-images.githubusercontent.com/6473925/214182868-e357a837-f361-4ab5-a9db-4389ec305fa9.png">

desktop success: ![image](https://user-images.githubusercontent.com/6473925/214182509-c6f5e379-c713-4686-87d2-e1c67272e253.png)


