### PR TITLE
Only show metadata extraction warning if it's missing from all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "universal-router": "^6.0.0",
     "util.promisify": "^1.0.0",
     "video-extensions": "^1.1.0",
-    "whatwg-fetch": "^3.0.0"
+    "whatwg-fetch": "^3.0.0",
+    "zip-array": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -575,7 +575,7 @@ class Home extends React.Component {
     const missingValuesString = rejected.map(v => v.reason).join(', ');
     const hasMultipleAttachments = attachmentData.length > 1;
     const fileCopy = hasMultipleAttachments
-      ? 'one of the files, but they may have been found in other files.'
+      ? 'the files.'
       : 'the file.';
 
     this.notifyWarning(

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -530,7 +530,7 @@ class Home extends React.Component {
       attachmentData: state.attachmentData.concat(attachmentData),
     }));
 
-    const arrs = await attachmentData.map(async attachmentFile => {
+    const arrs = await Promise.all(attachmentData.map(async attachmentFile => {
       // eslint-disable-next-line no-await-in-loop
       const { attachmentBuffer, attachmentArrayBuffer } = await blobToBuffer({
         attachmentFile,
@@ -558,7 +558,7 @@ class Home extends React.Component {
           });
         }),
       ]);
-    });
+    }));
 
     const zipped = zip(...arrs);
     const failedExtractions = zipped.filter(results =>

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -566,7 +566,7 @@ class Home extends React.Component {
 
     const rejected = zipped
       .filter(results => results.every(r => r.status === 'rejected'))
-      .map(extractions => extractions[0].reason);
+      .map(extractions => extractions[0]);
 
     if (rejected.length === 0) {
       return;

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -573,9 +573,7 @@ class Home extends React.Component {
 
     const missingValuesString = rejected.map(v => v.reason).join(', ');
     const hasMultipleAttachments = attachmentData.length > 1;
-    const fileCopy = hasMultipleAttachments
-      ? 'the files.'
-      : 'the file.';
+    const fileCopy = hasMultipleAttachments ? 'the files.' : 'the file.';
 
     this.notifyWarning(
       <React.Fragment>

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -530,7 +530,7 @@ class Home extends React.Component {
       attachmentData: state.attachmentData.concat(attachmentData),
     }));
 
-    const arrs = await Promise.all(
+    const listsOfExtractions = await Promise.all(
       attachmentData.map(async attachmentFile => {
         // eslint-disable-next-line no-await-in-loop
         const { attachmentBuffer, attachmentArrayBuffer } = await blobToBuffer({
@@ -562,7 +562,7 @@ class Home extends React.Component {
       }),
     );
 
-    const groupedByExtractionType = zip(...arrs);
+    const groupedByExtractionType = zip(...listsOfExtractions);
     const rejected = groupedByExtractionType
       .filter(results => results.every(r => r.status === 'rejected'))
       .map(extractions => extractions[0]);

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -562,9 +562,8 @@ class Home extends React.Component {
       }),
     );
 
-    const zipped = zip(...arrs);
-
-    const rejected = zipped
+    const groupedByExtractionType = zip(...arrs);
+    const rejected = groupedByExtractionType
       .filter(results => results.every(r => r.status === 'rejected'))
       .map(extractions => extractions[0]);
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -563,14 +563,16 @@ class Home extends React.Component {
     );
 
     const zipped = zip(...arrs);
-    const failedExtractions = zipped.filter(results =>
-      results.every(r => r.status === 'rejected'),
-    );
-    const failureReasons = failedExtractions.map(
-      extraction => extraction[0].reason,
-    );
-    const missingValuesString = failureReasons.join(', ');
 
+    const rejected = zipped
+      .filter(results => results.every(r => r.status === 'rejected'))
+      .map(extractions => extractions[0].reason);
+
+    if (rejected.length === 0) {
+      return;
+    }
+
+    const missingValuesString = rejected.map(v => v.reason).join(', ');
     const hasMultipleAttachments = attachmentData.length > 1;
     const fileCopy = hasMultipleAttachments
       ? 'one of the files, but they may have been found in other files.'

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -530,35 +530,37 @@ class Home extends React.Component {
       attachmentData: state.attachmentData.concat(attachmentData),
     }));
 
-    const arrs = await Promise.all(attachmentData.map(async attachmentFile => {
-      // eslint-disable-next-line no-await-in-loop
-      const { attachmentBuffer, attachmentArrayBuffer } = await blobToBuffer({
-        attachmentFile,
-      });
-
-      // eslint-disable-next-line no-await-in-loop
-      const { ext } = await FileType.fromBuffer(attachmentBuffer);
-
-      return Promise.allSettled([
-        this.extractPlate({ attachmentFile, attachmentBuffer, ext }),
-        extractDate({
+    const arrs = await Promise.all(
+      attachmentData.map(async attachmentFile => {
+        // eslint-disable-next-line no-await-in-loop
+        const { attachmentBuffer, attachmentArrayBuffer } = await blobToBuffer({
           attachmentFile,
-          attachmentArrayBuffer,
-          ext,
-        }).then(this.setCreateDate),
-        extractLocation({
-          attachmentFile,
-          attachmentArrayBuffer,
-          ext,
-        }).then(({ latitude, longitude }) => {
-          this.setCoords({
-            latitude,
-            longitude,
-            addressProvenance: '(extracted from picture/video)',
-          });
-        }),
-      ]);
-    }));
+        });
+
+        // eslint-disable-next-line no-await-in-loop
+        const { ext } = await FileType.fromBuffer(attachmentBuffer);
+
+        return Promise.allSettled([
+          this.extractPlate({ attachmentFile, attachmentBuffer, ext }),
+          extractDate({
+            attachmentFile,
+            attachmentArrayBuffer,
+            ext,
+          }).then(this.setCreateDate),
+          extractLocation({
+            attachmentFile,
+            attachmentArrayBuffer,
+            ext,
+          }).then(({ latitude, longitude }) => {
+            this.setCoords({
+              latitude,
+              longitude,
+              addressProvenance: '(extracted from picture/video)',
+            });
+          }),
+        ]);
+      }),
+    );
 
     const zipped = zip(...arrs);
     const failedExtractions = zipped.filter(results =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15995,3 +15995,8 @@ zen-observable@^0.8.0:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zip-array@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/zip-array/-/zip-array-1.0.1.tgz#99e7c23d7f449030e7f3a21a055785b46aeea58d"
+  integrity sha512-yVLk4tlBaAbd4+9BDLnN47GYUc/rHlf9hYyfDAIn76cqCn6+YTt9Hj2GDYiZKUNI+lNxTDcn58Uz2QbrLd/1ow==


### PR DESCRIPTION
This fixes https://github.com/josephfrazier/reported-web/issues/252:

> From my conversation with Rich at https://reportedcab.slack.com/archives/C9VNM3DL4/p1612717445004500?thread_ts=1610546281.002400&cid=C9VNM3DL4:
>
> > Ohhhh, you've stumbled across a quirk in how the error-handling is implemented, if I remember correctly: When I was first developing this, only one image was supported, so if it didn't find either the plate, date, or the location data, it would show the error message. Then, when I added support for multiple images, I didn't update the logic to take into account how many images there are.
> > So, I'm guessing what happened here is that it couldn't find the plate in the second image, and showed the error message instead of waiting for the plate to be found in the first image.
> > I'll update the error text to indicate that if multiple images are submitted, another one may have the required data, but there's a couple of bigger improvements that could be made:
> >
> > 1. Have the error message indicate which fields couldn't be found, instead of just saying "plate/location/date".
> > 2. If there are multiple images, check all of them before showing the error message.

> I've got an idea of how to handle this. Rather than:
>
>     * iterating over each file
>
>     * trying to extract plate/date/location from that file
>
>     * creating a notification listing the missing values in that file
>
>
> We can:
>
>     * map the list of files to a list of lists of 3 promise resolutions representing the plate/date/location extraction from that file
>
>     * zip the list of lists together to get a list containing:
>
>       * a list of plate extractions
>       * a list of date extractions
>       * a list of location extractions
>
>     * for each of the above 3 lists, notify about the extraction failure _only_ if all extractions failed