### PR TITLE
Prevent submission if address cannot be found

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1050,7 +1050,7 @@ class Home extends React.Component {
                   });
               }}
             >
-              <fieldset disabled={this.state.isSubmitting}>
+              <fieldset disabled={this.state.isSubmitting && this.state.formatted_address !== 'Finding Address...'}>
                 <FileReaderInput
                   multiple
                   as="buffer"


### PR DESCRIPTION
> I could make it so that you can't submit the form if the address field still says Finding Address. @jeff, do you think that would be a good idea? Submissions still have latitude and longitude regardless of whether an address can be found, but idk how address-less submissions are treated by the backend scripts or by 311
>
> I looked through the code, and the webapp address field that says "Finding Address..." gets submitted to the backend as the loc1_address property, but that property doesn't appear to be used by the backend for anything except putting it into the email receipt sent to users if it's present.
>
> There is a reference to the loc1_address in the cloudcode directory, but I don't think we're using that, at least, not the part that uses the submission_to_address Parse table.
>
> So, I think it doesn't really matter what, if any, value the webapp sends here. I wonder if I should change the "Finding Address..." text to something else if the address could not be found. If the webapp can't find the address, it's likely that the backend won't be able to either, so maybe the text should change to something like "Could not find address, please adjust location and try again"

> so yeah i think if it cannot resolve an address, then it should block the submission and give a clear explanation like “The location is not resolving to an address that the 311 form will allow. It requires a building number and street name and this sometimes doesn’t work in places like highways, airports or parks.”