### PR TITLE
Prevent submissions with coordinates outside NYC

### DIFF
--- a/src/getBoroName.js
+++ b/src/getBoroName.js
@@ -1,0 +1,16 @@
+import mem from 'mem';
+
+export function getBoroName({ lookup, end }) {
+  const boroughPolygon = (lookup &&
+    lookup.search(end.longitude, end.latitude)) || {
+    properties: {
+      BoroName: '(unknown borough)',
+    },
+  };
+
+  return boroughPolygon.properties.BoroName;
+}
+
+export const getBoroNameMemoized = mem(getBoroName, {
+  cacheKey: ({ lookup, end }) => !!lookup + JSON.stringify(end),
+});

--- a/src/routes/electricitibikes/ElectriCitibikes.js
+++ b/src/routes/electricitibikes/ElectriCitibikes.js
@@ -17,10 +17,10 @@ import strftime from 'strftime';
 import PolygonLookup from 'polygon-lookup';
 import geolib from 'geolib';
 import d2d from 'degrees-to-direction';
-import mem from 'mem';
 
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import marx from 'marx-css/css/marx.css';
+import { getBoroNameMemoized } from '../../getBoroName.js';
 import s from './ElectriCitibikes.css';
 
 class ElectriCitibikes extends React.Component {
@@ -106,21 +106,6 @@ function getMapUrl({ station, latitude, longitude }) {
 
   return `https://www.google.com/maps/search/?api=1&query=${station.latitude}%2C${station.longitude}`;
 }
-
-function getBoroName({ lookup, end }) {
-  const boroughPolygon = (lookup &&
-    lookup.search(end.longitude, end.latitude)) || {
-    properties: {
-      BoroName: '(unknown borough)',
-    },
-  };
-
-  return boroughPolygon.properties.BoroName;
-}
-
-const getBoroNameMemoized = mem(getBoroName, {
-  cacheKey: ({ lookup, end }) => !!lookup + JSON.stringify(end),
-});
 
 function getCompassBearing({ lookup, start, end }) {
   let rhumbLineBearing = geolib.getRhumbLineBearing(start, end);

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1236,6 +1236,7 @@ class Home extends React.Component {
                 </label>
 
                 <Modal
+                  parentSelector={() => document.querySelector(`.${s.root}`)}
                   isOpen={this.state.isMapOpen}
                   onRequestClose={() => this.setState({ isMapOpen: false })}
                   style={{

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1236,7 +1236,9 @@ class Home extends React.Component {
                 </label>
 
                 <Modal
-                  parentSelector={() => document.querySelector(`.${s.root}`) || document.body}
+                  parentSelector={() =>
+                    document.querySelector(`.${s.root}`) || document.body
+                  }
                   isOpen={this.state.isMapOpen}
                   onRequestClose={() => this.setState({ isMapOpen: false })}
                   style={{

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -477,6 +477,8 @@ class Home extends React.Component {
           coordsAreInNyc: false,
         });
         this.notifyError(errorMessage);
+
+        return;
       } else {
         this.setState({
           coordsAreInNyc: true,

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -286,6 +286,8 @@ const getBoroNameMemoized = mem(getBoroName, {
 });
 
 class Home extends React.Component {
+  static contextTypes = { fetch: PropTypes.func.isRequired };
+
   constructor(props) {
     super(props);
 
@@ -404,7 +406,7 @@ class Home extends React.Component {
     });
 
     // TODO this was copied from ElectriCitibikes.js, consider unifying them
-    fetch('/borough-boundaries-clipped-to-shoreline.geo.json')
+    this.context.fetch('/borough-boundaries-clipped-to-shoreline.geo.json')
       .then(response => response.json())
       .then(boroughBoundariesFeatureCollection => {
         this.setState({

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -471,14 +471,12 @@ class Home extends React.Component {
       const end = { latitude, longitude };
       const BoroName = getBoroNameMemoized({ lookup, end });
       if (BoroName === '(unknown borough)') {
-        const errorMessage = 'Please select a location within NYC';
+        const errorMessage = `latitude/longitude (${latitude}, ${longitude}) is outside NYC. Please select a location within NYC.`;
         this.setState({
           formatted_address: errorMessage,
           coordsAreInNyc: false,
         });
-        this.notifyError(
-          `latitude/longitude (${latitude}, ${longitude}) is outside NYC. ${errorMessage}`,
-        );
+        this.notifyError(errorMessage);
       } else {
         this.setState({
           coordsAreInNyc: true,

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -43,7 +43,6 @@ import Dropzone from '@josephfrazier/react-dropzone';
 import { ToastContainer, toast } from 'react-toastify';
 import toastifyStyles from 'react-toastify/dist/ReactToastify.css';
 import { zip } from 'zip-array';
-import mem from 'mem';
 import PolygonLookup from 'polygon-lookup';
 
 import marx from 'marx-css/css/marx.css';
@@ -52,6 +51,7 @@ import s from './Home.css';
 import SubmissionDetails from '../../components/SubmissionDetails.js';
 import { isImage, isVideo } from '../../isImage.js';
 import getNycTimezoneOffset from '../../timezone.js';
+import { getBoroNameMemoized } from '../../getBoroName.js';
 
 const GOOGLE_MAPS_API_KEY = 'AIzaSyDlwm2ykA0ohTXeVepQYvkcmdjz2M2CKEI';
 
@@ -269,21 +269,6 @@ async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
     throw 'creation date'; // eslint-disable-line no-throw-literal
   }
 }
-
-function getBoroName({ lookup, end }) {
-  const boroughPolygon = (lookup &&
-    lookup.search(end.longitude, end.latitude)) || {
-    properties: {
-      BoroName: '(unknown borough)',
-    },
-  };
-
-  return boroughPolygon.properties.BoroName;
-}
-// TODO the above/below functions were copied from ElectriCitibikes.js, consider unifying them
-const getBoroNameMemoized = mem(getBoroName, {
-  cacheKey: ({ lookup, end }) => !!lookup + JSON.stringify(end),
-});
 
 class Home extends React.Component {
   constructor(props) {

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -406,7 +406,8 @@ class Home extends React.Component {
     });
 
     // TODO this was copied from ElectriCitibikes.js, consider unifying them
-    this.context.fetch('/borough-boundaries-clipped-to-shoreline.geo.json')
+    this.context
+      .fetch('/borough-boundaries-clipped-to-shoreline.geo.json')
       .then(response => response.json())
       .then(boroughBoundariesFeatureCollection => {
         this.setState({

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1236,7 +1236,7 @@ class Home extends React.Component {
                 </label>
 
                 <Modal
-                  parentSelector={() => document.querySelector(`.${s.root}`)}
+                  parentSelector={() => document.querySelector(`.${s.root}`) || document.body}
                   isOpen={this.state.isMapOpen}
                   onRequestClose={() => this.setState({ isMapOpen: false })}
                   style={{

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -479,11 +479,11 @@ class Home extends React.Component {
         this.notifyError(errorMessage);
 
         return;
-      } else {
-        this.setState({
-          coordsAreInNyc: true,
-        });
       }
+
+      this.setState({
+        coordsAreInNyc: true,
+      });
     }
 
     debouncedProcessValidation({ latitude, longitude }).then(data => {

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -15,6 +15,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import App from '../../components/App';
 import Home from './Home';
+import boroughBoundariesFeatureCollection from '../../../public/borough-boundaries-clipped-to-shoreline.geo.json';
 
 require('timezone-mock').register('US/Eastern');
 require('jest-mock-now')();
@@ -36,7 +37,12 @@ describe('Home', () => {
     const wrapper = renderer
       .create(
         <App context={{ insertCss: () => {}, fetch: () => {}, pathname: '' }}>
-          <Home typeofcomplaintValues={typeofcomplaintValues} />
+          <Home
+            typeofcomplaintValues={typeofcomplaintValues}
+            boroughBoundariesFeatureCollection={
+              boroughBoundariesFeatureCollection
+            }
+          />
         </App>,
       )
       .toJSON();

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -11,6 +11,7 @@ import React from 'react';
 import sortBy from 'lodash.sortby';
 import Home from './Home';
 import Layout from '../../components/Layout';
+import boroughBoundariesFeatureCollection from '../../../public/borough-boundaries-clipped-to-shoreline.geo.json';
 
 async function action({ fetch }) {
   // get complaint categories from server
@@ -25,7 +26,12 @@ async function action({ fetch }) {
     chunks: ['home'],
     component: (
       <Layout>
-        <Home typeofcomplaintValues={typeofcomplaintValues} />
+        <Home
+          typeofcomplaintValues={typeofcomplaintValues}
+          boroughBoundariesFeatureCollection={
+            boroughBoundariesFeatureCollection
+          }
+        />
       </Layout>
     ),
   };


### PR DESCRIPTION
From https://reportedcab.slack.com/archives/C9VNM3DL4/p1677969946066369?thread_ts=1676288095.715499&cid=C9VNM3DL4:

> One thing I could do is outright prevent submissions with coordinates
> that definitely lie outside of NYC, like that one from Illinois above.
> That could be a simple bounding-box check, or something more
> sophisticated using a GeoJSON file that has polygons for each borough (I
> already have this for electric-citibike-finding purposes)

Note the TODO comments in the code