### PR TITLE
Wait 1 second before looking up license plate, not 500 milliseconds

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -70,7 +70,7 @@ const debouncedProcessValidation = debounce(async ({ latitude, longitude }) => {
 const debouncedGetVehicleType = debounce(
   ({ plate, licenseState }) =>
     axios.get(`/getVehicleType/${plate}/${licenseState}`),
-  500,
+  1000,
 );
 
 const debouncedSaveStateToLocalStorage = debounce(self => {


### PR DESCRIPTION
This should reduce the number of lookups we're doing, and may help
improve performance for users experiencing input lag.

See https://reportedcab.slack.com/archives/C9VNM3DL4/p1682517852476569 for context:

> RM
> When typing a license plate into the field, a new plate lookup is triggered after every character you type. It should only trigger one after you leave the field. (iOS chrome)
>
> Joseph Frazier
> good point, i'll try to take a look at this later today/week
>
>
> Joseph Frazier
> @RM I looked into this, and found that the current behavior is
> debounced to only do a lookup every half-second at most, but that is
> indeed effectively after every character, depending on how quickly
> you're typing. I'm curious, what's are the downsides you're seeing from
> the current behavior?
>
> RM
> Well I have a lot of typing latency and I wondered if these calls were increasing it
>
> RM
> But also I thought we paid for these lookups or had a quota
>
> Joseph Frazier
> ah, of course, we do have an [outstanding issues with it usually not
> working](https://github.com/josephfrazier/Reported-Web/issues/295),
> presumably due to rate-limiting or outright blocking. I hadn't made the
> connection, but maybe reducing the frequency of these lookups would help
> them work. I'll keep looking into it, hopefully will have a change
> sometime this week
>
> RM
> Side note regarding this: latency when typing is so great for me that it won’t accept more than about one character per two seconds
>
>
> Joseph Frazier
> gah, I thought we had sorted out the lag issues for you previously... taking another look at the lookup timing now