### PR TITLE
Add DC to state dropdown

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -35,6 +35,7 @@ import omit from 'object.omit';
 import bufferToArrayBuffer from 'buffer-to-arraybuffer';
 import objectToFormData from 'object-to-formdata';
 import usStateNames from 'datasets-us-states-abbr-names';
+// import usStateNamesWithoutDC from 'datasets-us-states-abbr-names';
 import fileExtension from 'file-extension';
 import diceware from 'diceware-generator';
 import wordlist from 'diceware-wordlist-en-eff';
@@ -53,6 +54,12 @@ import SubmissionDetails from '../../components/SubmissionDetails.js';
 import { isImage, isVideo } from '../../isImage.js';
 import getNycTimezoneOffset from '../../timezone.js';
 import { getBoroNameMemoized } from '../../getBoroName.js';
+
+// const usStateNames = {
+//   ...usStateNames,
+//   DC: 'District of Columbia'
+// }
+usStateNames.DC = 'District of Columbia';
 
 const GOOGLE_MAPS_API_KEY = 'AIzaSyDlwm2ykA0ohTXeVepQYvkcmdjz2M2CKEI';
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1204,11 +1204,15 @@ class Home extends React.Component {
                       });
                     }}
                   >
-                    {Object.entries(usStateNames).map(([abbr, name]) => (
-                      <option key={abbr} value={abbr}>
-                        {name}
-                      </option>
-                    ))}
+                    {Object.entries(usStateNames)
+                      .sort(([, name1], [, name2]) =>
+                        name1.toUpperCase().localeCompare(name2.toUpperCase()),
+                      )
+                      .map(([abbr, name]) => (
+                        <option key={abbr} value={abbr}>
+                          {name}
+                        </option>
+                      ))}
                   </select>
                   {this.state.vehicleInfoComponent}
                 </label>

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -316,6 +316,11 @@ exports[`Home renders children correctly 1`] = `
                 Delaware
               </option>
               <option
+                value="DC"
+              >
+                District of Columbia
+              </option>
+              <option
                 value="FL"
               >
                 Florida


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C802R14UX/p1684361116358619

> Justin
> We can't report drivers with D.C. plates!
> https://reported-web.herokuapp.com/
> 
> Joseph Frazier
> Great point! I think I could add a DC value pretty easily. What would you expect it to look like in the license state drop-down: Washington DC? District of Columbia? Something else?
> 
> Joseph Frazier
> Also @jeff do you know if DC is the correct value to submit to the backend here? Not sure how the backend code would handle it
> 
> RM
> Omg as a former District resident, all I have to say about this is “this again? Sigh“
> :laughing:
> 
> Justin
> I'd probably look for District of Columbia first!
