### PR TITLE
Add checkbox to toggle reverse geocoding (address extraction)

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -224,7 +224,18 @@ async function extractPlate({
   }
 }
 
-async function extractLocation({ attachmentFile, attachmentArrayBuffer, ext }) {
+async function extractLocation({
+  attachmentFile,
+  attachmentArrayBuffer,
+  ext,
+  isReverseGeocodingEnabled,
+}) {
+  if (isReverseGeocodingEnabled === false) {
+    console.info('Reverse geolocation is disabled, skipping');
+
+    throw 'location'; // eslint-disable-line no-throw-literal
+  }
+
   try {
     if (isVideo({ ext })) {
       return extractLocationDateFromVideo({ attachmentArrayBuffer })[0];
@@ -310,6 +321,7 @@ class Home extends React.Component {
     const initialStatePersistent = {
       ...initialStatePerSubmission,
       isAlprEnabled: true,
+      isReverseGeocodingEnabled: true,
       isUserInfoOpen: true,
       isMapOpen: false,
     };
@@ -662,6 +674,7 @@ class Home extends React.Component {
                 attachmentFile,
                 attachmentArrayBuffer,
                 ext,
+                isReverseGeocodingEnabled: this.state.isReverseGeocodingEnabled,
               }).then(({ latitude, longitude }) => {
                 this.setCoords({
                   latitude,
@@ -1168,6 +1181,16 @@ class Home extends React.Component {
                     onChange={this.handleInputChange}
                   />{' '}
                   Automatically read license plates from pictures/videos
+                </label>
+
+                <label htmlFor="isReverseGeocodingEnabled">
+                  <input
+                    type="checkbox"
+                    checked={this.state.isReverseGeocodingEnabled}
+                    name="isReverseGeocodingEnabled"
+                    onChange={this.handleInputChange}
+                  />{' '}
+                  Automatically read addresses from pictures/videos
                 </label>
 
                 <label htmlFor="plate">

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -248,6 +248,18 @@ exports[`Home renders children correctly 1`] = `
             Automatically read license plates from pictures/videos
           </label>
           <label
+            htmlFor="isReverseGeocodingEnabled"
+          >
+            <input
+              checked={true}
+              name="isReverseGeocodingEnabled"
+              onChange={[Function]}
+              type="checkbox"
+            />
+             
+            Automatically read addresses from pictures/videos
+          </label>
+          <label
             htmlFor="plate"
           >
             License/Medallion:


### PR DESCRIPTION
See comments at https://reportedcab.slack.com/archives/C9VNM3DL4/p1684710141854209

> Justin
> 2 feature requests -
> limit maps addresses to NYC only when searching for address
> 2 option to lockin an address or street so it doesn't keep changing when making many reports in the same area.
>
> Justin
> https://stackoverflow.com/questions/8282026/how-to-limit-google-autocomplete-results-to-city-and-country-only
> Stack OverflowStack Overflow
> How to limit google autocomplete results to City and Country only
> I am using google autocomplete places javascript to return suggested results for my searchbox , what I need is to only show the city and the country related to the characters entered but google api...
>
> Joseph Frazier
> Ooh, thanks for reminding me about the first idea! It did occur to me to limit address search to NYC, I just never got around to it. Maybe I'll take another look!
> I'm curious about the second idea. Is the problem that the geolocation isn't consistent across photos taken in the same area? (edited)
>
> Justin
> I subbmited 50+ reports on pacific between carlton ave and 6th. the cars closer to carlton geolocate to carlton so I have to fix it repeatedly. Not a huge deal but the UI is fairly sluggish so it adds up.
>
> jeff
> i believe the first one is implemented on ios btw - if the lat/lng of the photo is outside NYC it just throws an error like "this isn't in nyc"
>
> Justin
> this is for manually searching/changing the address
>
> jeff
> ah yeah that seems relatively straight forward
>
> Joseph Frazier
> Re. address locking: I'll add a checkbox similar to the Automatically read license plates from pictures/videos one. It would say something like Automatically read addresses from pictures/videos
> and be enabled by default, just like I did with the plate box