### PR TITLE
Bias maps addresses to NYC only when searching for address

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1499,6 +1499,12 @@ const MyMapComponentPure = props => {
         ref={onSearchBoxMounted}
         controlPosition={window.google.maps.ControlPosition.TOP_LEFT}
         onPlacesChanged={onPlacesChanged}
+        bounds={{
+          east: -73.700272,
+          north: 40.915256,
+          south: 40.496044,
+          west: -74.255735,
+        }}
       >
         <input
           type="text"


### PR DESCRIPTION
See comments at https://reportedcab.slack.com/archives/C9VNM3DL4/p1684710141854209

> Justin
> 2 feature requests -
> limit maps addresses to NYC only when searching for address
> 2 option to lockin an address or street so it doesn't keep changing when making many reports in the same area.
>
> Justin
> https://stackoverflow.com/questions/8282026/how-to-limit-google-autocomplete-results-to-city-and-country-only
> Stack OverflowStack Overflow
> How to limit google autocomplete results to City and Country only
> I am using google autocomplete places javascript to return suggested results for my searchbox , what I need is to only show the city and the country related to the characters entered but google api...
>
> Joseph Frazier
> Ooh, thanks for reminding me about the first idea! It did occur to me to limit address search to NYC, I just never got around to it. Maybe I'll take another look!

References:
* https://tomchentw.github.io/react-google-maps/#searchbox
* https://developers.google.com/maps/documentation/javascript/reference/places-widget#SearchBoxOptions
* https://developers.google.com/maps/documentation/javascript/reference/coordinates#LatLngBoundsLiteral
* the coordinates used came from asking ChatGPT "what are the lat/lng
  coordinates that define a bounding box around nyc", and were eyeballed
  by me before using them: https://chat.openai.com/