### PR TITLE
CI: Run test independently of build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: Node.js CI - build
+name: Node.js CI - test
 
 on: [push]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
@@ -20,6 +20,9 @@ jobs:
     - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
     - run: export PATH=$HOME/.yarn/bin:$PATH
     - run: yarn
-    - run: yarn build --release
+    - shell: bash
       env:
-        CI: true
+        GEO_APP_ID: ${{ secrets.GEO_APP_ID }}
+        GEO_APP_KEY: ${{ secrets.GEO_APP_KEY }}
+        GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      run: yarn test


### PR DESCRIPTION
In https://github.com/josephfrazier/reported-web/pull/418, I found that
test failures were preventing me from seeing whether the build worked: https://github.com/josephfrazier/reported-web/actions/runs/5294435622/jobs/9583774656?pr=418
so let's split those up