### PR TITLE
CI: Add job that does yarn build without --release, to catch cases when `yarn start` breaks locally

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,4 @@
-name: Node.js CI - build
+name: Node.js CI - build --release
 
 on: [push]
 
@@ -20,6 +20,6 @@ jobs:
     - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
     - run: export PATH=$HOME/.yarn/bin:$PATH
     - run: yarn
-    - run: yarn build
+    - run: yarn build --release
       env:
         CI: true


### PR DESCRIPTION
Discovered in #427, see https://github.com/josephfrazier/reported-web/pull/427/commits/6248e65edc23bc605bf6739cf48f873ffa86030c