### PR TITLE
CI: Differentiate "build --release" job from "build" with YAML key name `build-release`

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,7 +3,7 @@ name: Node.js CI - build --release
 on: [push]
 
 jobs:
-  build:
+  build-release:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This is so it appears as an option in the branch protection rules at https://github.com/josephfrazier/reported-web/settings/branch_protection_rules/2186061