### PR TITLE
Test processValidation failure without real API calls

### DIFF
--- a/src/geoclient.js
+++ b/src/geoclient.js
@@ -110,7 +110,11 @@ export async function validateLocation({ lat, long }) {
 // spirals around that point, calling validateLocation until it succeeds
 // returns hash with google response, geoclient response, and status
 // ported from `process_validation` at https://github.com/jeffrono/Reported/blob/19b588171315a3093d53986f9fb995059f5084b4/v2/enrich_functions.rb#L48-L88
-export async function processValidation({ lat, long }) {
+export async function processValidation({
+  lat,
+  long,
+  validateLocationImplementation = validateLocation,
+}) {
   lat = Number(lat); // eslint-disable-line no-param-reassign
   long = Number(long); // eslint-disable-line no-param-reassign
 
@@ -123,7 +127,7 @@ export async function processValidation({ lat, long }) {
     let r;
     // test version 1
     // eslint-disable-next-line no-await-in-loop
-    r = await validateLocation({
+    r = await validateLocationImplementation({
       lat: lat + i * RADIUS,
       long,
     });
@@ -133,7 +137,7 @@ export async function processValidation({ lat, long }) {
     }
 
     // eslint-disable-next-line no-await-in-loop
-    r = await validateLocation({
+    r = await validateLocationImplementation({
       lat: lat - i * RADIUS,
       long,
     });
@@ -143,7 +147,7 @@ export async function processValidation({ lat, long }) {
     }
 
     // eslint-disable-next-line no-await-in-loop
-    r = await validateLocation({
+    r = await validateLocationImplementation({
       lat,
       long: long + i * RADIUS,
     });
@@ -153,7 +157,7 @@ export async function processValidation({ lat, long }) {
     }
 
     // eslint-disable-next-line no-await-in-loop
-    r = await validateLocation({
+    r = await validateLocationImplementation({
       lat,
       long: long - i * RADIUS,
     });

--- a/src/geoclient.test.js
+++ b/src/geoclient.test.js
@@ -49,9 +49,10 @@ describe('processValidation', () => {
       processValidation({
         lat: 40.6435893,
         long: -73.7820064,
+        validateLocationImplementation: async () => ({ valid: false }),
       }),
     ).rejects.toThrow(
       'could not reverse-geocode lat/long pair (40.6435893, -73.7820064)',
     );
-  }, 99999);
+  });
 });


### PR DESCRIPTION
After adding the test for a failure to find any location even after
spiraling, I quickly ran through the daily limit of Google API calls,
which is causing CI to fail, for example at https://github.com/josephfrazier/reported-web/actions/runs/5501794806/jobs/10025629227:

      ● processValidation › returns an error when no address is found after spiraling

        expect(function).toThrow(string)

        Expected the function to throw an error matching:
          "could not reverse-geocode lat/long pair (40.6435893, -73.7820064)"
        Instead, it threw:
          TypeError: Cannot read properties of undefined (reading 'address_components')
              37 |   console.log({ googleResponse }); // eslint-disable-line no-console
              38 |   const address = googleResponse.results[0];
            > 39 |   let building = address.address_components[0].short_name;
                 |                          ^
              40 |   // (ported from https://github.com/jeffrono/Reported/blob/6d9e1d8c087ee53954037b4e80a72481a8425045/v2/enrich_functions.rb#L426-L431)
              41 |   // strip out any whack extra characters here
              42 |   // a = '228 A'

          at validateLocation (src/geoclient.js:39:26)
          at processTicksAndRejections (node:internal/process/task_queues:95:5)
          at processValidation (src/geoclient.js:126:9)
          at Object.<anonymous> (src/geoclient.test.js:48:5)
          at Object.toThrow (node_modules/expect/build/index.js:217:22)
          at Object.<anonymous> (src/geoclient.test.js:53:15)
          at processTicksAndRejections (node:internal/process/task_queues:95:5)

      console.log src/geoclient.js:37
        {
          googleResponse: {
            error_message: 'You have exceeded your daily request quota for this API. If you did not set a custom daily request quota, verify your project has an active billing account: http://g.co/dev/maps-no-account',
            results: [],
            status: 'OVER_QUERY_LIMIT'
          }
        }

In lieu of stubbing the HTTP requests directly, or mocking
`validateLocation`, this approach uses dependency injection to allow the
test to substitute its own implementation.