### PR TITLE
Use default branch of react-localstorage fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-file-reader-input": "^2.0.0",
     "react-google-maps": "^9.4.5",
     "react-loadable": "^5.4.0",
-    "react-localstorage": "https://github.com/josephfrazier/react-localstorage#higher-ordered-component",
+    "react-localstorage": "https://github.com/josephfrazier/react-localstorage",
     "react-modal": "^3.4.5",
     "react-social-icons": "^2.8.1",
     "react-toastify": "9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11839,9 +11839,9 @@ react-loadable@^5.4.0:
   dependencies:
     prop-types "^15.5.0"
 
-"react-localstorage@https://github.com/josephfrazier/react-localstorage#higher-ordered-component":
+"react-localstorage@https://github.com/josephfrazier/react-localstorage":
   version "1.0.0"
-  resolved "https://github.com/josephfrazier/react-localstorage#f10d44bf02fafb5c07bb2f62b35d92ef1ba04462"
+  resolved "https://github.com/josephfrazier/react-localstorage#75f0303aa775e1625ef9cb0d936b6aa0bcdbaffc"
   dependencies:
     synchronous-promise "^2.0.5"
 


### PR DESCRIPTION
I merged in the higher-order component behavior in https://github.com/josephfrazier/react-localstorage/pull/1,
so we can move over to that.