### PR TITLE
Add dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "recompose": "^0.26.0",
     "serialize-javascript": "^3.1.0",
     "sharp": "^0.32.1",
+    "simpledotcss": "^2.2.1",
     "source-map-support": "^0.5.9",
     "strftime": "^0.10.0",
     "universal-router": "^6.0.0",

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -46,7 +46,7 @@ import { zip } from 'zip-array';
 import PolygonLookup from 'polygon-lookup';
 import { CSVLink } from 'react-csv';
 
-import marx from 'marx-css/css/marx.css';
+import marx from 'simpledotcss';
 import s from './Home.css';
 
 import SubmissionDetails from '../../components/SubmissionDetails.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13063,6 +13063,11 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+simpledotcss@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/simpledotcss/-/simpledotcss-2.2.1.tgz#7151371401821b33383a533b0a077fc8cf11959b"
+  integrity sha512-bEuU6rLmL8Lu6gBcn6HlslEEoHk4v8ldW3K4DOCT33e4L0Y3ExMT9DuITQ7KhRBKlKFDJ3DgAwxoGrN+0B9Jiw==
+
 sirv@^1.0.7:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C9VNM3DL4/p1692087071429079:

> Have we ever considered supporting dark mode? Sometimes I’m filing complaints late at night and I wish

> I'm curious, do you know if your browser automatically indicates a
> preference for dark mode at night? I'm asking because the webapp uses a
> pretty simple css framework, and I've found a similar one that will
> automatically use dark mode if preferred by the browser, so I'm hoping I
> could just drop that in and not have to add in other code to support
> switching between the two

> Yeah I’m pretty sure Safari on iOS just auto switches if it’s available!

---

Commits at PR open:

* yarn add simpledotcss

* XXX DOES NOT WORK: Home.js: Use simpledotcss instead of marx-css

  I get this error when I open localhost:3000

  > # SyntaxError
  >
  > ```
  > /Users/josephfrazier/workspace/reported-web/node_modules/simpledotcss/simple.css:2
  > :root,
  > ^
  >
  > SyntaxError: Unexpected token ':'
  >     at Object.compileFunction (node:vm:360:18)
  >     at wrapSafe (node:internal/modules/cjs/loader:1088:15)
  >     at Module._compile (node:internal/modules/cjs/loader:1123:27)
  >     at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
  >     at Object.newLoader [as .js] (/Users/josephfrazier/workspace/reported-web/node_modules/pirates/lib/index.js:104:7)
  >     at Module.load (node:internal/modules/cjs/loader:1037:32)
  >     at Function.Module._load (node:internal/modules/cjs/loader:878:12)
  >     at Module.require (node:internal/modules/cjs/loader:1061:19)
  >     at require (node:internal/modules/cjs/helpers:103:18)
  >     at Object.simpledotcss (/Users/josephfrazier/workspace/reported-web/external commonjs "simpledotcss":1:1)
  > ```