### PR TITLE
Upgrade Node from 18.12.1 to 20.8.0

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.8.1]
+        node-version: [20.8.0]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.12.1]
+        node-version: [20.8.1]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.8.1]
+        node-version: [20.8.0]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.12.1]
+        node-version: [20.8.1]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.8.1]
+        node-version: [20.8.0]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.12.1]
+        node-version: [20.8.1]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.8.1]
+        node-version: [20.8.0]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.12.1]
+        node-version: [20.8.1]
 
     steps:
     - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": "18.12.1",
+    "node": "20.8.1",
     "npm": ">=3.10.10"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": "20.8.1",
+    "node": "20.8.0",
     "npm": ">=3.10.10"
   },
   "browserslist": [


### PR DESCRIPTION
Heroku deploys are failing, so let's see if this helps: https://dashboard.heroku.com/apps/reported-web/activity/builds/736e17f0-6072-4cfc-abfb-a6989b16340e

    -----> Installing binaries
           engines.node (package.json):  18.12.1
           engines.npm (package.json):   >=3.10.10
           engines.yarn (package.json):  unspecified (use default)

           Resolving node version 18.12.1...
           Downloading and installing node 18.12.1...
           Bootstrapping npm >=3.10.10 (replacing 8.19.2)...
    npm ERR! code EBADENGINE
    npm ERR! engine Unsupported engine
    npm ERR! engine Not compatible with your version of node/npm: npm@10.2.0
    npm ERR! notsup Not compatible with your version of node/npm: npm@10.2.0
    npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
    npm ERR! notsup Actual:   {"npm":"8.19.2","node":"v18.12.1"}
    npm ERR! A complete log of this run can be found in:
    npm ERR!     /tmp/npmcache.YEcBM/_logs/2023-10-17T00_47_20_687Z-debug-0.log
           Unable to install npm >=3.10.10.  Does npm >=3.10.10 exist?  Is npm >=3.10.10 compatible with this Node.js version?
    -----> Build failed

           We're sorry this build is failing! You can troubleshoot common issues here:
           https://devcenter.heroku.com/articles/troubleshooting-node-deploys

           If you're stuck, please submit a ticket so we can help:
           https://help.heroku.com/