### PR TITLE
/platerecognizer endpoint: Send email/password from client, log into Parse before doing ALPR

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -169,6 +169,8 @@ async function extractPlate({
   attachmentBuffer,
   ext,
   isAlprEnabled,
+  email,
+  password,
 }) {
   try {
     console.time('extractPlate'); // eslint-disable-line no-console
@@ -197,7 +199,11 @@ async function extractPlate({
     );
     console.timeEnd(`bufferToBlob(${attachmentFile.name})`); // eslint-disable-line no-console
 
-    const formData = objectToFormData({ attachmentFile: attachmentBlob });
+    const formData = objectToFormData({
+      attachmentFile: attachmentBlob,
+      email,
+      password,
+    });
     const { data } = await axios.post('/platerecognizer', formData);
     const result = data.results[0];
     try {
@@ -647,6 +653,8 @@ class Home extends React.Component {
                 attachmentBuffer,
                 ext,
                 isAlprEnabled: this.state.isAlprEnabled,
+                email: this.state.email,
+                password: this.state.password,
               }).then(result => {
                 if (
                   this.state.plate === '' &&

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -197,8 +197,7 @@ async function extractPlate({
     );
     console.timeEnd(`bufferToBlob(${attachmentFile.name})`); // eslint-disable-line no-console
 
-    const formData = new window.FormData();
-    formData.append('attachmentFile', attachmentBlob);
+    const formData = objectToFormData({ attachmentFile: attachmentBlob });
     const { data } = await axios.post('/platerecognizer', formData);
     const result = data.results[0];
     try {

--- a/src/server.js
+++ b/src/server.js
@@ -543,7 +543,12 @@ app.use(
   async (req, res) => {
     const { email, password } = req.body;
 
-    await logIn({ email, password });
+    try {
+      await logIn({ email, password });
+    } catch (error) {
+      handlePromiseRejection(res)(error);
+      return;
+    }
 
     const attachmentBuffer = req.file.buffer;
 


### PR DESCRIPTION
See discussion at https://reportedcab.slack.com/archives/C9VNM3DL4/p1700539565194989?thread_ts=1697754508.856279&cid=C9VNM3DL4:
 
> Automatic license plate reading may temporarily stop working on the webapp until the 30th. I got an email about a usage limit, and my plan reset date is 2023-11-29 11:24 PM
> 
> > Plate Recognizer ALPR cloud has reached 95% of its allocated lookups for the period. Time to upgrade your account! > Otherwise, the ALPR cloud will not be able to process images once you reach 100% of the allocated lookups for the month.
> 
> Maybe it's time to finally add another key, and/or fall back to openalpr, and/or make sure that anyone using this endpoint is actually a Reported user (I don't think there's any auth on it currently)

---

Commits:

* Use objectToFormData for /platerecognizer request

* /platerecognizer endpoint: Send email/password from client, log into Parse before doing ALPR

* /platerecognizer: Don't crash server if login fails