### PR TITLE
Show link for manual plate lookup, to workaround rate-limiting

### DIFF
--- a/src/getVehicleType.js
+++ b/src/getVehicleType.js
@@ -1,8 +1,12 @@
 import axios from 'axios';
 
+export function vehicleTypeUrl({ licensePlate, licenseState }) {
+  return `https://www.carfax.com/api/mobile-homepage-quickvin-check?plate=${licensePlate}&state=${licenseState}`;
+}
+
 // ported from https://github.com/jeffrono/Reported/blob/19b588171315a3093d53986f9fb995059f5084b4/v2/enrich_functions.rb#L325-L346
 export default function getVehicleType({ licensePlate, licenseState }) {
-  const url = `https://www.carfax.com/api/mobile-homepage-quickvin-check?plate=${licensePlate}&state=${licenseState}`;
+  const url = vehicleTypeUrl({ licensePlate, licenseState });
 
   console.time(url); // eslint-disable-line no-console
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -52,6 +52,7 @@ import SubmissionDetails from '../../components/SubmissionDetails.js';
 import { isImage, isVideo } from '../../isImage.js';
 import getNycTimezoneOffset from '../../timezone.js';
 import { getBoroNameMemoized } from '../../getBoroName.js';
+import { vehicleTypeUrl } from '../../getVehicleType.js';
 
 usStateNames.DC = 'District of Columbia';
 
@@ -570,14 +571,24 @@ class Home extends React.Component {
         if (plate) {
           this.setState({
             vehicleInfoComponent: (
-              <a
-                href="https://github.com/josephfrazier/Reported-Web/issues/295"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Could not look up make/model of {plate} in{' '}
-                {usStateNames[licenseState]}, click here for details
-              </a>
+              <React.Fragment>
+                <a
+                  href="https://github.com/josephfrazier/Reported-Web/issues/295"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Could not look up make/model of {plate} in{' '}
+                  {usStateNames[licenseState]}, click here for details
+                </a>
+                <br />
+                <a
+                  href={vehicleTypeUrl({ licensePlate: plate, licenseState })}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Click here to manually look it up
+                </a>
+              </React.Fragment>
             ),
           });
 


### PR DESCRIPTION
Some users might like to be able to try the lookup themselves, when the
server doesn't work due to rate-limiting (see https://github.com/josephfrazier/Reported-Web/issues/295).

This adds a link to the URL with the JSON API response from carfax. It's
not the prettiest, but it works. One test case that wasn't working on https://reported-web.herokuapp.com/ was `HUK9845`.