### PR TITLE
Update srlookup implementation to use "https://portal.311.nyc.gov/sr-details/?srnum=" instead of "https://portal.311.nyc.gov/sr-details/?id="

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -295,7 +295,7 @@ app.get('/srlookup/:reqnumber', (req, res) => {
       const result = {};
       result.description = document.querySelector(
         '#page-wrapper p',
-      ).textContent;
+      )?.textContent;
       const fields = [
         ...document.querySelectorAll('.info, .control'),
       ]

--- a/src/server.js
+++ b/src/server.js
@@ -280,13 +280,7 @@ app.use('/api/deleteSubmission', (req, res) => {
 });
 
 async function srlookup({ reqnumber }) {
-  const response = await axios.get(
-    `https://portal.311.nyc.gov/api-get-sr-or-correspondence-by-number/?number=${reqnumber}`,
-  );
-  const {
-    data: { srid },
-  } = response;
-  const url = `https://portal.311.nyc.gov/sr-details/?id=${srid}`;
+  const url = `https://portal.311.nyc.gov/sr-details/?srnum=${reqnumber}`
 
   return axios.get(url);
 }
@@ -302,15 +296,18 @@ app.get('/srlookup/:reqnumber', (req, res) => {
       result.description = document.querySelector(
         '#page-wrapper p',
       ).textContent;
-      [
-        ...document.querySelectorAll('#page-wrapper td.form-control-cell'),
-      ].forEach(e => {
-        const key = e.querySelector('label').textContent;
-        const input = e.querySelector('input');
-        const value = input && input.value;
+      const fields = [
+        ...document.querySelectorAll('.info, .control'),
+      ]
+      for(let i = 0; i < fields.length; i += 2) {
+        const keyField = fields[i]
+        const valueField = fields[i + 1]
+
+        const key = keyField.textContent;
+        const value = valueField.textContent;
 
         result[key] = value;
-      });
+      }
 
       res.json(result);
     })

--- a/src/server.js
+++ b/src/server.js
@@ -280,7 +280,7 @@ app.use('/api/deleteSubmission', (req, res) => {
 });
 
 async function srlookup({ reqnumber }) {
-  const url = `https://portal.311.nyc.gov/sr-details/?srnum=${reqnumber}`
+  const url = `https://portal.311.nyc.gov/sr-details/?srnum=${reqnumber}`;
 
   return axios.get(url);
 }
@@ -296,12 +296,10 @@ app.get('/srlookup/:reqnumber', (req, res) => {
       result.description = document.querySelector(
         '#page-wrapper p',
       )?.textContent;
-      const fields = [
-        ...document.querySelectorAll('.info, .control'),
-      ]
-      for(let i = 0; i < fields.length; i += 2) {
-        const keyField = fields[i]
-        const valueField = fields[i + 1]
+      const fields = [...document.querySelectorAll('.info, .control')];
+      for (let i = 0; i < fields.length; i += 2) {
+        const keyField = fields[i];
+        const valueField = fields[i + 1];
 
         const key = keyField.textContent;
         const value = valueField.textContent;


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C9VNM3DL4/p1717450546216129:

> your 311 status lookup tool seems to have been failing for a while
> here;s your tool (at least how i'm using it)
> https://reported-web.herokuapp.com/srlookup/311-08996900
> but it looks like 311 updated their URL structure a bit, from (https://portal.311.nyc.gov/api-get-sr-or-correspondence-by-number/?number=311-08996900) to :
> https://portal.311.nyc.gov/sr-details/?srnum=311-08996900

The following fields don't work yet, it looks like they are filled in on
the client side:

* Updated On
* Date Reported
* Date Closed

srlookup: Handle cases where description element does not exist, e.g. https://archive.is/https://portal.311.nyc.gov/sr-details/?srnum=311-18685922