### PR TITLE
Extract srlookup function into own file, move JSDOM scraping into it to make it easier to unit-test

### DIFF
--- a/src/__snapshots__/srlookup.test.js.snap
+++ b/src/__snapshots__/srlookup.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`srlookup returns the right object 1`] = `
+Object {
+  "Additional Details": "Unsafe Driving",
+  "Date Closed": "-",
+  "Date Reported": "-",
+  "Problem": "For Hire Vehicle Complaint",
+  "Problem Details": "Driver Complaint - Non Passenger",
+  "SR Address": "",
+  "SR Number": "311-18685922",
+  "SR Status": "In Progress",
+  "Time To Next Update": " 1 Days ",
+  "Updated On": "-",
+  "description": undefined,
+}
+`;

--- a/src/srlookup.js
+++ b/src/srlookup.js
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { JSDOM } from 'jsdom';
+
+export default async function srlookup({ reqnumber }) {
+  const url = `https://portal.311.nyc.gov/sr-details/?srnum=${reqnumber}`;
+
+  const { data } = await axios.get(url);
+  const { document } = new JSDOM(data).window;
+
+  const result = {};
+  result.description = document.querySelector('#page-wrapper p')?.textContent;
+  const fields = [...document.querySelectorAll('.info, .control')];
+  for (let i = 0; i < fields.length; i += 2) {
+    const keyField = fields[i];
+    const valueField = fields[i + 1];
+
+    const key = keyField.textContent;
+    const value = valueField.textContent;
+
+    result[key] = value;
+  }
+
+  return result;
+}

--- a/src/srlookup.test.js
+++ b/src/srlookup.test.js
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-env jest */
+
+import srlookup from './srlookup.js';
+
+describe('srlookup', () => {
+  test('returns the right object', async () => {
+    const result = await srlookup({ reqnumber: '311-18685922' });
+
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Add unit test for srlookup function

See also https://reportedcab.slack.com/archives/C9VNM3DL4/p1717527343704499?thread_ts=1717450546.216129&cid=C9VNM3DL4 for context:

> Joe Frazier
>   12 minutes ago
> so things are working for you again? I'm planning to try to get the
> Updated On
> Date Reported
> Date Closed
> fields working again, but am not yet sure how hard it will be (how long it will take)
>
>
>
>
>
> jeff
>   12 minutes ago
> ah shit, yeah so those date fields are sort of important :melting_face:
>
>
> jeff
>   11 minutes ago
> its ok, no major urgency
>
>
> jeff
>   11 minutes ago
> but yeah my bulk update tool relies on those dates to update the records
>
>
> jeff
>   11 minutes ago
> but i can make them optional on my end
>
>
> Joe Frazier
>   10 minutes ago
> it's annoying, it looks like 311 changed those so they aren't filled in, in the original HTML, but instead some client-side JS has to run to populate them, and I haven't yet figured out how exactly to replicate that
>
>
> jeff
>   9 minutes ago
> ok. yeah kinda sucks
>
>
> jeff
>   9 minutes ago
> but i get it
>
>
> Joe Frazier
>   7 minutes ago
> the webapp is using JSDOM to scrape the HTML, and it looks like it's possible to get it to run the <script> elements in the HTML, but it sounds like it could also be dangerous, since the JS sandbox isn't 100% secure: https://github.com/jsdom/jsdom#executing-scripts
> I'm hoping that if I look at the HTTP requests my browser makes a little more closely, I can figure out how exactly it's populating those fields, then recreate that in the webapp, for example by doing extra API calls if that's what the scripts are doing