### PR TITLE
srlookup: Extract UTC `Date Closed`, `Date Reported`, and `Updated On` dates from 311 response

### DIFF
--- a/src/__snapshots__/srlookup.test.js.snap
+++ b/src/__snapshots__/srlookup.test.js.snap
@@ -3,15 +3,15 @@
 exports[`srlookup returns the right object 1`] = `
 Object {
   "Additional Details": "Unsafe Driving",
-  "Date Closed": "-",
-  "Date Reported": "-",
+  "Date Closed": "2019-09-16T16:02:00Z",
+  "Date Reported": "2019-07-03T14:43:28Z",
   "Problem": "For Hire Vehicle Complaint",
   "Problem Details": "Driver Complaint - Non Passenger",
   "SR Address": "",
-  "SR Number": "311-18685922",
-  "SR Status": "In Progress",
-  "Time To Next Update": " 1 Days ",
-  "Updated On": "-",
-  "description": undefined,
+  "SR Number": "311-00039062",
+  "SR Status": "Closed",
+  "Time To Next Update": " N/A ",
+  "Updated On": "2019-09-16T16:02:22Z",
+  "description": "A hearing was scheduled at the OATH/Taxi and Limousine Tribunal.",
 }
 `;

--- a/src/srlookup.js
+++ b/src/srlookup.js
@@ -20,5 +20,26 @@ export default async function srlookup({ reqnumber }) {
     result[key] = value;
   }
 
+  const srdatereported = /\$\("#srdatereported"\).text\(getESTDate\("([^"]+)"\)\)/.exec(
+    data,
+  );
+  if (srdatereported) {
+    result['Date Reported'] = srdatereported[1];
+  }
+
+  const srupdatedon = /\$\("#srupdatedon"\).text\(getESTDate\("([^"]+)"\)\)/.exec(
+    data,
+  );
+  if (srupdatedon) {
+    result['Updated On'] = srupdatedon[1];
+  }
+
+  const srdateclosed = /\$\("#srdateclosed"\).text\(getESTDate\("([^"]+)"\)\)/.exec(
+    data,
+  );
+  if (srdateclosed) {
+    result['Date Closed'] = srdateclosed[1];
+  }
+
   return result;
 }

--- a/src/srlookup.test.js
+++ b/src/srlookup.test.js
@@ -7,7 +7,7 @@ import srlookup from './srlookup.js';
 
 describe('srlookup', () => {
   test('returns the right object', async () => {
-    const result = await srlookup({ reqnumber: '311-18685922' });
+    const result = await srlookup({ reqnumber: '311-00039062' });
 
     expect(result).toMatchSnapshot();
   });


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C9VNM3DL4/p1717528491222359?thread_ts=1717450546.216129&cid=C9VNM3DL4

> aha, it looks like there's an inline script that changes the dates from UTC to EST:
>
>     <!-- Formatting the dates to local timezone -->
>     <script>
>     $(()=>{
>
>         $("#srdatereported").text(getESTDate("2024-05-22T18:35:11Z"));
>
>
>         $("#srupdatedon").text(getESTDate("2024-05-22T18:35:20Z"));
>
>
>     });
>     function getESTDate(utcdatestr) {
>       return new Date(utcdatestr).toLocaleString('en-US', {
>           year: 'numeric',
>           month: '2-digit',
>           day: '2-digit',
>           hour: '2-digit',
>           minute: '2-digit'
>       })
>     }
>     </script>
>
> so I could either run that script, or scrape it's source code and extract the dates from it

I'm going with UTC for now, but may consider changing it to EST later
since that would help Jeff, see https://reportedcab.slack.com/archives/C9VNM3DL4/p1717529202165399?thread_ts=1717450546.216129&cid=C9VNM3DL4

> Joe Frazier
>   18 minutes ago
> @jeff
>  I think I'm getting this close to working, would you prefer UTC dates or EST dates?
>
>
>
>
>
> jeff
>   < 1 minute ago
> oh EST would be great
>
>
> jeff
>   < 1 minute ago
> !
>
>
> jeff
>   < 1 minute ago
> thx