### PR TITLE
srlookup: Show dates in America/New_York timezone (not sure if DST is handled)

### DIFF
--- a/src/__snapshots__/srlookup.test.js.snap
+++ b/src/__snapshots__/srlookup.test.js.snap
@@ -3,15 +3,15 @@
 exports[`srlookup returns the right object 1`] = `
 Object {
   "Additional Details": "Unsafe Driving",
-  "Date Closed": "2019-09-16T16:02:00Z",
-  "Date Reported": "2019-07-03T14:43:28Z",
+  "Date Closed": "9/16/2019, 12:02:00 PM",
+  "Date Reported": "7/3/2019, 10:43:28 AM",
   "Problem": "For Hire Vehicle Complaint",
   "Problem Details": "Driver Complaint - Non Passenger",
   "SR Address": "",
   "SR Number": "311-00039062",
   "SR Status": "Closed",
   "Time To Next Update": " N/A ",
-  "Updated On": "2019-09-16T16:02:22Z",
+  "Updated On": "9/16/2019, 12:02:22 PM",
   "description": "A hearing was scheduled at the OATH/Taxi and Limousine Tribunal.",
 }
 `;

--- a/src/srlookup.js
+++ b/src/srlookup.js
@@ -24,21 +24,27 @@ export default async function srlookup({ reqnumber }) {
     data,
   );
   if (srdatereported) {
-    result['Date Reported'] = srdatereported[1];
+    result['Date Reported'] = new Date(
+      srdatereported[1],
+    ).toLocaleString('en-US', { timeZone: 'America/New_York' });
   }
 
   const srupdatedon = /\$\("#srupdatedon"\).text\(getESTDate\("([^"]+)"\)\)/.exec(
     data,
   );
   if (srupdatedon) {
-    result['Updated On'] = srupdatedon[1];
+    result['Updated On'] = new Date(srupdatedon[1]).toLocaleString('en-US', {
+      timeZone: 'America/New_York',
+    });
   }
 
   const srdateclosed = /\$\("#srdateclosed"\).text\(getESTDate\("([^"]+)"\)\)/.exec(
     data,
   );
   if (srdateclosed) {
-    result['Date Closed'] = srdateclosed[1];
+    result['Date Closed'] = new Date(srdateclosed[1]).toLocaleString('en-US', {
+      timeZone: 'America/New_York',
+    });
   }
 
   return result;


### PR DESCRIPTION
This does not use the same `getNycTimezoneOffset` function that is used
when extracting the date from a photo's EXIF metadata, mainly because I
haven't bothered to make it work in this context yet.

Instead, this uses `Date#toLocaleString` to change UTC times to Eastern
times. It's not clear to me whether this approach takes Daylight Savings Time
into account properly, see https://stackoverflow.com/questions/16317807/does-javascript-date-tolocalestring-account-for-dst

However, in the places where this is used, showing Date
Reported/Updated/Closed on the webapp submission history page, as well
what Jeff's server-side code does with it, it doesn't really matter if
we're off by an hour, see his comment at https://reportedcab.slack.com/archives/C9VNM3DL4/p1717532887817279?thread_ts=1717450546.216129&cid=C9VNM3DL4:

> ah DST doesnt matter so much for this since it's really when the
> tickets are closed and it doesnt have to be precise (not like this is
> going in front of a judge or something)