### PR TITLE
SubmissionDetails: Display `srlookup` keys/values verbatim

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "history": "^4.7.2",
     "http-delayed-response": "^0.0.4",
     "humanize-distance": "^1.0.9",
-    "humanize-string": "^1.0.2",
     "image-extensions": "^1.1.0",
     "intl": "^1.2.5",
     "isomorphic-style-loader": "^4.0.0",

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Loadable from 'react-loadable';
 import axios from 'axios';
-import humanizeString from 'humanize-string';
 
 class SubmissionDetails extends React.Component {
   constructor(props) {
@@ -77,10 +76,8 @@ class SubmissionDetails extends React.Component {
         axios.get(`/srlookup/${reqnumber}`).then(({ data }) => () => {
           const items = Object.entries(data).map(([key, value]) => (
             <React.Fragment key={key}>
-              <dt>{humanizeString(key)}:</dt>
-              <dd>
-                {key.endsWith('Date') ? new Date(value).toString() : value}
-              </dd>
+              <dt>{key}:</dt>
+              <dd>{value}</dd>
             </React.Fragment>
           ));
           return <dl>{items}</dl>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4252,7 +4252,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -7024,12 +7024,6 @@ humanize-distance@^1.0.9:
   resolved "https://registry.yarnpkg.com/humanize-distance/-/humanize-distance-1.0.9.tgz#bb62f78edd687f1cb19ddc7d34f9969db670ca3b"
   dependencies:
     intl "1.2.5"
-
-humanize-string@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/humanize-string/-/humanize-string-1.0.2.tgz#fef0a8bc9b1b857ca4013bbfaea75071736988f6"
-  dependencies:
-    decamelize "^1.0.0"
 
 iconv-lite@0.4.19:
   version "0.4.19"


### PR DESCRIPTION
The changes in https://github.com/josephfrazier/reported-web/pull/510
made it clear that the NYC 311 updates in
https://github.com/josephfrazier/reported-web/pull/509 included changes
to the HTML response field names.

Specifically, they're already "humanized", so we don't need to do that.
There's also no longer any that end in "Date", so we don't need that
branching either, especially since the changes in
https://github.com/josephfrazier/reported-web/pull/511 and
https://github.com/josephfrazier/reported-web/pull/512 make it so that
the values are humanized as well.

The only downside of this change is that "Description" now reads
"description", since that key is built by the webapp's `srlookup`
implementation, rather than being scraped from the 311 page. I haven't
changed the key name in the `srlookup` implementation, since Jeff's
backend code might be relying on it. Instead, I could have the
SubmissionDetails capitalize the field name in the UI, just haven't
bothered yet.