### PR TITLE
Use NYC geoclient address for "Where" button instead of Google address

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "body-parser": "^1.20.2",
     "buffer": "^6.0.3",
     "buffer-to-arraybuffer": "^0.0.6",
+    "capitalize": "^2.0.4",
     "capture-frame": "^4.0.0",
     "classnames": "^2.2.6",
     "compression": "^1.7.2",

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -481,7 +481,7 @@ class Home extends React.Component {
 
     debouncedProcessValidation({ latitude, longitude }).then(data => {
       this.setState({
-        formatted_address: data.google_response.results[0].formatted_address,
+        formatted_address: `${data.geoclient_response.address.houseNumber} ${data.geoclient_response.address.streetName1In}, ${data.geoclient_response.address.firstBoroughName}`,
       });
     });
   };

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -44,6 +44,7 @@ import toastifyStyles from 'react-toastify/dist/ReactToastify.css';
 import { zip } from 'zip-array';
 import PolygonLookup from 'polygon-lookup';
 import { CSVLink } from 'react-csv';
+import capitalize from 'capitalize';
 
 import marx from 'marx-css/css/marx.css';
 import homeStyles from './Home.css';
@@ -481,7 +482,9 @@ class Home extends React.Component {
 
     debouncedProcessValidation({ latitude, longitude }).then(data => {
       this.setState({
-        formatted_address: `${data.geoclient_response.address.houseNumber} ${data.geoclient_response.address.streetName1In}, ${data.geoclient_response.address.firstBoroughName}`,
+        formatted_address: capitalize.words(
+          `${data.geoclient_response.address.houseNumber} ${data.geoclient_response.address.streetName1In}, ${data.geoclient_response.address.firstBoroughName}`,
+        ),
       });
     });
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,6 +3201,11 @@ caniuse-lite@^1.0.30001503:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz#e2a7e184a23affc9367b7c8d734e7ec4628c1309"
   integrity sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==
 
+capitalize@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/capitalize/-/capitalize-2.0.4.tgz#eed7f94c6699a318eeef6e68967fe139c764b866"
+  integrity sha512-wcSyiFqXRYyCoqu0o0ekXzJAKCLMkqWS5QWGlgTJFJKwRmI6pzcN2hBl5VPq9RzLW5Uf4FF/V/lcFfjCtVak2w==
+
 capture-exit@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-1.2.0.tgz#1c5fcc489fd0ab00d4f1ac7ae1072e3173fbab6f"


### PR DESCRIPTION
A user found a photo that caused "350 5th Ave, Naples" to appear on the
button, when the correct address is either/around 942 5th Ave, Manhattan
or 350 5th Ave, Manhattan. Another user found that the wrong address
appeared due to bad data coming from the Google Maps/Geocoding API, so
let's try using NYC Geoclient's data instead, presumably it won't ever
tell us we're in Florida...

See this thread for more context: https://reportedcab.slack.com/archives/C85007FUY/p1721092591901279

Use `capitalize` module to make "Where" button addresses prettier