### PR TITLE
Use datalist for license state so users can type their own in while still having the autocomplete options

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -506,7 +506,6 @@ class Home extends React.Component {
   };
 
   setLicensePlate = ({ plate, licenseState }) => {
-    licenseState = licenseState || this.state.licenseState; // eslint-disable-line no-param-reassign
     this.setState({
       plate,
       licenseState,
@@ -1223,29 +1222,34 @@ class Home extends React.Component {
                       <option value={this.state.plateSuggestion} />
                     )}
                   </datalist>
-                  <select
+                  <input
+                    required
+                    type="search"
                     style={{
                       marginTop: '0.5rem',
                     }}
                     value={this.state.licenseState}
                     name="licenseState"
+                    list="stateSuggestion"
+                    autoComplete="off"
                     onChange={event => {
                       this.setLicensePlate({
                         plate: this.state.plate,
                         licenseState: event.target.value,
                       });
                     }}
-                  >
+                  />
+                  <datalist id="stateSuggestion">
                     {Object.entries(usStateNames)
                       .sort(([, name1], [, name2]) =>
                         name1.toUpperCase().localeCompare(name2.toUpperCase()),
                       )
                       .map(([abbr, name]) => (
                         <option key={abbr} value={abbr}>
-                          {name}
+                          {name} ({abbr})
                         </option>
                       ))}
-                  </select>
+                  </datalist>
                   {this.state.vehicleInfoComponent}
                 </label>
 

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -278,272 +278,432 @@ exports[`Home renders children correctly 1`] = `
             >
               
             </datalist>
-            <select
+            <input
+              autoComplete="off"
+              list="stateSuggestion"
               name="licenseState"
               onChange={[Function]}
+              required={true}
               style={
                 {
                   "marginTop": "0.5rem",
                 }
               }
+              type="search"
               value="NY"
+            />
+            <datalist
+              id="stateSuggestion"
             >
               <option
                 value="AL"
               >
                 Alabama
+                 (
+                AL
+                )
               </option>
               <option
                 value="AK"
               >
                 Alaska
+                 (
+                AK
+                )
               </option>
               <option
                 value="AZ"
               >
                 Arizona
+                 (
+                AZ
+                )
               </option>
               <option
                 value="AR"
               >
                 Arkansas
+                 (
+                AR
+                )
               </option>
               <option
                 value="CA"
               >
                 California
+                 (
+                CA
+                )
               </option>
               <option
                 value="CO"
               >
                 Colorado
+                 (
+                CO
+                )
               </option>
               <option
                 value="CT"
               >
                 Connecticut
+                 (
+                CT
+                )
               </option>
               <option
                 value="DE"
               >
                 Delaware
+                 (
+                DE
+                )
               </option>
               <option
                 value="DC"
               >
                 District of Columbia
+                 (
+                DC
+                )
               </option>
               <option
                 value="FL"
               >
                 Florida
+                 (
+                FL
+                )
               </option>
               <option
                 value="GA"
               >
                 Georgia
+                 (
+                GA
+                )
               </option>
               <option
                 value="HI"
               >
                 Hawaii
+                 (
+                HI
+                )
               </option>
               <option
                 value="ID"
               >
                 Idaho
+                 (
+                ID
+                )
               </option>
               <option
                 value="IL"
               >
                 Illinois
+                 (
+                IL
+                )
               </option>
               <option
                 value="IN"
               >
                 Indiana
+                 (
+                IN
+                )
               </option>
               <option
                 value="IA"
               >
                 Iowa
+                 (
+                IA
+                )
               </option>
               <option
                 value="KS"
               >
                 Kansas
+                 (
+                KS
+                )
               </option>
               <option
                 value="KY"
               >
                 Kentucky
+                 (
+                KY
+                )
               </option>
               <option
                 value="LA"
               >
                 Louisiana
+                 (
+                LA
+                )
               </option>
               <option
                 value="ME"
               >
                 Maine
+                 (
+                ME
+                )
               </option>
               <option
                 value="MD"
               >
                 Maryland
+                 (
+                MD
+                )
               </option>
               <option
                 value="MA"
               >
                 Massachusetts
+                 (
+                MA
+                )
               </option>
               <option
                 value="MI"
               >
                 Michigan
+                 (
+                MI
+                )
               </option>
               <option
                 value="MN"
               >
                 Minnesota
+                 (
+                MN
+                )
               </option>
               <option
                 value="MS"
               >
                 Mississippi
+                 (
+                MS
+                )
               </option>
               <option
                 value="MO"
               >
                 Missouri
+                 (
+                MO
+                )
               </option>
               <option
                 value="MT"
               >
                 Montana
+                 (
+                MT
+                )
               </option>
               <option
                 value="NE"
               >
                 Nebraska
+                 (
+                NE
+                )
               </option>
               <option
                 value="NV"
               >
                 Nevada
+                 (
+                NV
+                )
               </option>
               <option
                 value="NH"
               >
                 New Hampshire
+                 (
+                NH
+                )
               </option>
               <option
                 value="NJ"
               >
                 New Jersey
+                 (
+                NJ
+                )
               </option>
               <option
                 value="NM"
               >
                 New Mexico
+                 (
+                NM
+                )
               </option>
               <option
                 value="NY"
               >
                 New York
+                 (
+                NY
+                )
               </option>
               <option
                 value="NC"
               >
                 North Carolina
+                 (
+                NC
+                )
               </option>
               <option
                 value="ND"
               >
                 North Dakota
+                 (
+                ND
+                )
               </option>
               <option
                 value="OH"
               >
                 Ohio
+                 (
+                OH
+                )
               </option>
               <option
                 value="OK"
               >
                 Oklahoma
+                 (
+                OK
+                )
               </option>
               <option
                 value="OR"
               >
                 Oregon
+                 (
+                OR
+                )
               </option>
               <option
                 value="PA"
               >
                 Pennsylvania
+                 (
+                PA
+                )
               </option>
               <option
                 value="RI"
               >
                 Rhode Island
+                 (
+                RI
+                )
               </option>
               <option
                 value="SC"
               >
                 South Carolina
+                 (
+                SC
+                )
               </option>
               <option
                 value="SD"
               >
                 South Dakota
+                 (
+                SD
+                )
               </option>
               <option
                 value="TN"
               >
                 Tennessee
+                 (
+                TN
+                )
               </option>
               <option
                 value="TX"
               >
                 Texas
+                 (
+                TX
+                )
               </option>
               <option
                 value="UT"
               >
                 Utah
+                 (
+                UT
+                )
               </option>
               <option
                 value="VT"
               >
                 Vermont
+                 (
+                VT
+                )
               </option>
               <option
                 value="VA"
               >
                 Virginia
+                 (
+                VA
+                )
               </option>
               <option
                 value="WA"
               >
                 Washington
+                 (
+                WA
+                )
               </option>
               <option
                 value="WV"
               >
                 West Virginia
+                 (
+                WV
+                )
               </option>
               <option
                 value="WI"
               >
                 Wisconsin
+                 (
+                WI
+                )
               </option>
               <option
                 value="WY"
               >
                 Wyoming
+                 (
+                WY
+                )
               </option>
-            </select>
+            </datalist>
             <br />
           </label>
           <label


### PR DESCRIPTION
See email titled "Re: Glitches": https://mail.google.com/mail/u/0/#sent/FMfcgzQXJkQzKQxDrvjxTNhzNfHSVLCS

> > I very much appreciate that the app allows me to write in the
> > license-plate state; the web site offers a list of the 50 states and DC,
> > which is fine when it's not the odd Canadian or federal-government-fleet
> > plate
>
> Great point! I'll see if I can make it so that you can type your own
> state if you'd like, while still having the existing list to easily pick
> from, using a datalist. I'll try to keep you posted!

The `<input>` element syntax was adapted from the preceding `plate` field.

I don't know why I had the `licenseState = licenseState || this.state.licenseState`
line in the `setLicensePlate` function, but it made it so that you can't
delete all the characters from the field, so I removed it. It was added
in commit 0198474a9193a6b668a2f58fd224f98819d40f4e, but I didn't write
down why I added it.