### PR TITLE
Downscale image further for platerecognizer ALPR if needed

### DIFF
--- a/src/alpr.js
+++ b/src/alpr.js
@@ -21,13 +21,11 @@ async function orientImageBuffer({ attachmentBuffer }) {
 }
 
 // https://app.platerecognizer.com/upload-limit/
-const downscaleForPlateRecognizer = buffer => {
+const downscaleForPlateRecognizer = ({ buffer, targetWidth }) => {
   const fileSize = buffer.length;
   const maxFilesize = 2411654;
 
   if (fileSize >= maxFilesize) {
-    const targetWidth = 4096;
-
     // eslint-disable-next-line no-console
     console.log(
       `file size is greater than maximum of ${maxFilesize} bytes, attempting to scale down to width of ${targetWidth}`,
@@ -76,7 +74,8 @@ export default function readLicenseViaALPR({
   PLATERECOGNIZER_TOKEN_TWO,
 }) {
   return orientImageBuffer({ attachmentBuffer })
-    .then(downscaleForPlateRecognizer)
+    .then(buffer => downscaleForPlateRecognizer({ buffer, targetWidth: 4096 }))
+    .then(buffer => downscaleForPlateRecognizer({ buffer, targetWidth: 2048 }))
     .then(buffer => buffer.toString('base64'))
     .then(attachmentBytesRotated => {
       console.log('STARTING platerecognizer'); // eslint-disable-line no-console


### PR DESCRIPTION
A user found an image that, despite already being less than 4096 pixels
wide, remained larger than the maximum filesize accepted by
platerecognizer, even after being downscaled.

This change makes it so that we scale it further down to 2048 pixels
wide if it's still too big after being scaled to 4096.

See here for more context:
https://reportedcab.slack.com/archives/C7Z0BHMMY/p1734719601962699?thread_ts=1733722096.369269&cid=C7Z0BHMMY:

> just tried that one locally, and it looks like the image is too big
> for the ALPR API, even after the webapp downscales it. Guess I need to
> tweak that to squeeze it down further, yet again...
>
>     image buffer length BEFORE sharp: 4855730 bytes
>     image buffer length AFTER sharp: 2589893 bytes
>     orientImageBuffer: 187.262ms
>     file size is greater than maximum of 2411654 bytes, attempting to scale down to width of 4096
>     file size after scaling down: 2426287 bytes
>     STARTING platerecognizer
>     /platerecognizer plate-reader got an error with first token, trying second
>     /platerecognizer plate-reader {
>       platerecognizerRes: Response {
>         size: 0,
>         timeout: 0,
>         [Symbol(Body internals)]: { body: [PassThrough], disturbed: false, error: null },
>         [Symbol(Response internals)]: {
>           url: 'https://api.platerecognizer.com/v1/plate-reader/',
>           status: 413,
>           statusText: 'Request Entity Too Large',
>           headers: [Headers],
>           counter: 0
>         }
>       }
>     }