### PR TITLE
Don't crash when "Automatically read license plates from pictures/videos" is unchecked

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -178,7 +178,7 @@ async function extractPlate({
 
     if (isAlprEnabled === false) {
       console.info('ALPR is disabled, skipping');
-      return { plate: '', licenseState: '' };
+      return { plate: '', licenseState: '', plateSuggestions: [] };
     }
 
     if (attachmentPlates.has(attachmentFile)) {


### PR DESCRIPTION
A user reported that unchecked the "Automatically read license plates from pictures/videos" box
and uploading this image: https://onedrive.live.com/?qt=allmyphotos&photosData=%2Fshare%2FB048B3CB6D88394F!s5551239383ea403da35733e676b2aed4%3Fithint%3Dphoto%26e%3Dpl4RQT%26migratedtospo%3Dtrue&sw=bypassConfig&cid=B048B3CB6D88394F&id=B048B3CB6D88394F!s5551239383ea403da35733e676b2aed4&redeem=aHR0cHM6Ly8xZHJ2Lm1zL2kvYy9iMDQ4YjNjYjZkODgzOTRmL0VaTWpVVlhxZ3oxQW8xY3o1bmF5cnRRQnotVk9jM1RCcFVKNmZTVUcyRU5UR3c_ZT1wbDRSUVQ&v=photos
makes "the entire site goes competely white": https://reportedcab.slack.com/archives/C802R14UX/p1750082048783709

After reproducing and investigating the issue, I found that the
`extractPlate` function returns a resolved Promise even when the box is
unchecked (because there wasn't an error, we just didn't want to do it),
but the code that handles the empty result assumes there's a
`plateSuggestions` on the `result` object:

```js
                this.setState({
                  plateSuggestions: result.plateSuggestions,
                });
```

One option would be to skip the `setState` when `plateSuggestions`
doesn't exist, or have it default to `[]`, but I thought it'd be better
to be a little more explicit in the `extractPlate` function about what
exactly should be happening, and making it so it always returns a
`result` object of the same shape.