### PR TITLE
Load .env file when running `yarn start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "deploy": "babel-node tools/run deploy",
     "render": "babel-node tools/run render",
     "serve": "babel-node tools/run runServer",
-    "start": "babel-node tools/run start --inspect",
+    "start": "node -r dotenv/config node_modules/.bin/babel-node tools/run start --inspect",
     "localtunnel": "while true; do yarn lt --port 3000 --subdomain reported-web; done"
   }
 }

--- a/src/geoclient.js
+++ b/src/geoclient.js
@@ -22,7 +22,6 @@ export async function validateLocation({ lat, long }) {
     'https://maps.googleapis.com/maps/api/geocode/json?latlng=';
   const url = `${GOOGLE_MAP_URL +
     lat},${long}&result_type=street_address&key=${GOOGLE_API_KEY}`;
-  console.log({GOOGLE_API_KEY})
   const { data: googleResponse } = await axios.get(url);
 
   // check if zero results

--- a/src/geoclient.js
+++ b/src/geoclient.js
@@ -22,6 +22,7 @@ export async function validateLocation({ lat, long }) {
     'https://maps.googleapis.com/maps/api/geocode/json?latlng=';
   const url = `${GOOGLE_MAP_URL +
     lat},${long}&result_type=street_address&key=${GOOGLE_API_KEY}`;
+  console.log({GOOGLE_API_KEY})
   const { data: googleResponse } = await axios.get(url);
 
   // check if zero results


### PR DESCRIPTION
This makes it easier to manually test changes like in https://github.com/josephfrazier/reported-web/pull/591/:

> (migration guide is here: [mlipper.github.io/geoclient/docs/current/user-guide/changes.html#potential-breaking-changes](https://mlipper.github.io/geoclient/docs/current/user-guide/changes.html#potential-breaking-changes))
>
> (more context at [reportedcab.slack.com/archives/GMB2JT5UK/p1752035936843809](https://reportedcab.slack.com/archives/GMB2JT5UK/p1752035936843809))
>
> See email titled: _[Action Required] Upcoming Decommissioning of Geoclient v1 REST API_:
>
> > Dear Geoclient v1 User,
> > We are writing to inform you that the Geoclient v1 REST API will be officially decommissioned on October 1st, 2025 as part of our ongoing efforts to streamline our systems and improve security.
> > As an alternative, we encourage you to use Geoclient v2 which is backwards-compatible with v1. Geoclient v2 has additional features, better performance and is more secure. Like v1, Geoclient v2 usage is free and credentials are available after sign-up on the NYC API Developers Portal website.
> > Key Details:
> >
> > * Service: Geoclient v1
> > * Endpoint: [api.nyc.gov/geo/geoclient/v1](https://api.nyc.gov/geo/geoclient/v1)
> > * Deactivation Date: October 1st, 2025
> > * Impact: After this date, any requests to the Geoclient v1 API endpoint will fail.
> >
> > Alternative Solution:
> >
> > * Service: Geoclient v2
> > * Endpoint: [api.nyc.gov/geoclient/v2](https://api.nyc.gov/geoclient/v2)
> > * Backwards compatible with the v1 API
> > * Usage is free after sign-up
> > * Important: the URL path for the Geoclient v2 service is different from v1. Be sure to configure your application(s) with the correct Geoclient v2 endpoint URL.
> >
> > Next Steps:
> >
> > * Transition your application(s) to Geoclient v2 before October 1st, 2025.
> > * Log into the NYC Developer Portal and subscribe to the Geoclient v2 service.
> > * Contact our support team if you have questions or need assistance with the transition.
> >
> > Resources:
> >
> > * Step-by-step instructions on how to create an account on the NYC Developers Portal and sign up for access to Geoclient v2.
> > * Using Geoclient v2 in the Cloud explains how to authenticate your service calls.
> > * Questions about migrating from Geoclient v1 to v2 are answered on Geoclient's GitHub Issues page. Use the "v1 to v2" label on the issues you create.
> > * The geoclient-examples project which demonstrates calling Geoclient v2 in multiple languages.
> > * Visit the NYC API Developers Portal website for information on Geoclient and other official NYC APIs.
> >
> > Thanks for your interest in Geoclient!