### PR TITLE
Warn user when a photo/video is too big

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -653,11 +653,13 @@ class Home extends React.Component {
       async () => {
         const listsOfExtractions = await Promise.all(
           this.state.attachmentData.map(async (attachmentFile, index) => {
-            if (attachmentFile.size > 20 * 1000 * 1000) { // just under 20MB, should match attachmentFile.size in Home.js
+            if (attachmentFile.size > 20 * 1000 * 1000) {
+              // just under 20MB, should match attachmentFile.size in Home.js
               this.notifyWarning(
                 <React.Fragment>
                   <p>
-                    File #{index + 1} is too big, over 20MB, please remove it and select a smaller one
+                    File #{index + 1} is too big, over 20MB, please remove it
+                    and select a smaller one
                   </p>
                 </React.Fragment>,
               );

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -652,7 +652,17 @@ class Home extends React.Component {
       }),
       async () => {
         const listsOfExtractions = await Promise.all(
-          this.state.attachmentData.map(async attachmentFile => {
+          this.state.attachmentData.map(async (attachmentFile, index) => {
+            if (attachmentFile.size > 20 * 1000 * 1000) { // just under 20MB, should match attachmentFile.size in Home.js
+              this.notifyWarning(
+                <React.Fragment>
+                  <p>
+                    File #{index + 1} is too big, over 20MB, please remove it and select a smaller one
+                  </p>
+                </React.Fragment>,
+              );
+            }
+
             // eslint-disable-next-line no-await-in-loop
             const {
               attachmentBuffer,

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -654,7 +654,7 @@ class Home extends React.Component {
         const listsOfExtractions = await Promise.all(
           this.state.attachmentData.map(async (attachmentFile, index) => {
             if (attachmentFile.size > 20 * 1000 * 1000) {
-              // just under 20MB, should match attachmentFile.size in Home.js
+              // just under 20MB, should match fileSize in server.js
               this.notifyWarning(
                 <React.Fragment>
                   <p>

--- a/src/server.js
+++ b/src/server.js
@@ -71,7 +71,7 @@ Parse.serverURL = PARSE_SERVER_URL;
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: {
-    fileSize: 20 * 1000 * 1000, // just under 20MB
+    fileSize: 20 * 1000 * 1000, // just under 20MB, should match attachmentFile.size in Home.js
     files: 6,
   },
 });


### PR DESCRIPTION
This is a follow-up to https://github.com/josephfrazier/reported-web/pull/594:

> A user reported this at [reportedcab.slack.com/archives/C802R14UX/p1752090637034029](https://reportedcab.slack.com/archives/C802R14UX/p1752090637034029):
>
> > i tried to upload a 75MB video and got a file too large error
> >
> > * what’s the max size?  please show that in the UI
> > * can the file size be checked before upload