### PR TITLE
Use React StrictMode within App component

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -57,7 +57,11 @@ class App extends React.PureComponent {
   render() {
     // NOTE: If you need to add or modify header, footer etc. of the app,
     // please do that inside the Layout component.
-    return React.Children.only(this.props.children);
+    return (
+      <React.StrictMode>
+        {React.Children.only(this.props.children)}
+      </React.StrictMode>
+    )
   }
 }
 


### PR DESCRIPTION
The Firefox React Developer Tools addon/extension told me I should be
doing this, see https://16.reactjs.org/docs/strict-mode.html

I tried to wrap the App component itself in StrictMode in the Html
component so as to suppress that warning as well, but couldn't get it working.
I think this should be good enough though, since the App component
doesn't really have any application logic in it, and is therefore much
less likely to have problems.