### PR TITLE
Fix `reduce of empty array with no initial value` error when no plate/date/location could be extracted from photos

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -723,6 +723,10 @@ class Home extends React.Component {
           }),
         );
 
+        if (listsOfExtractions.length === 0) {
+          return;
+        }
+
         const groupedByExtractionType = zip(...listsOfExtractions);
         const rejected = groupedByExtractionType
           .filter(results => results.every(r => r.status === 'rejected'))


### PR DESCRIPTION
I was seeing the below error locally when pasting `T131517C` into the
license plate field, without having any photos.

Incidentally, this might fix some of the "white screen of death"
reported by a user at https://reportedcab.slack.com/archives/C802R14UX/p1755045627188659?thread_ts=1753930757.964959&cid=C802R14UX:

> For those still keeping track, today I uploaded 13 reports in about 7
> minutes, using 5 tabs on a browser. Three of the reports misfired
> (giving the White Screen of Death), so I had to re-enter all the data,
> so I did 16 reports' worth of work, and actually got 13 reports in, in 7
> minutes.

(actually, I wasn't able to reproduce the white screen on production, so
I don't think this will fix that user's issue, but at least it won't
show up in the console any more)

    Unhandled Rejection (TypeError): reduce of empty array with no initial value
    zip
    node_modules/zip-array/index.js:15
    _callee5$
    src/routes/home/Home.js:726

      723 |   }),
      724 | );
      725 |
    > 726 | const groupedByExtractionType = zip(...listsOfExtractions);
      727 | const rejected = groupedByExtractionType
      728 |   .filter(results => results.every(r => r.status === 'rejected'))
      729 |   .map(extractions => extractions[0]);

    _callee6$
    src/routes/home/Home.js:651

      648 | };
      649 |
      650 | handleAttachmentData = async ({ attachmentData }) => {
    > 651 |   this.setState(
      652 |     state => ({
      653 |       attachmentData: state.attachmentData.concat(attachmentData),
      654 |     }),

    ./src/routes/home/Home.js/Home/<
    src/routes/home/Home.js:307

      304 | }
      305 |
      306 | class Home extends React.Component {
    > 307 |   constructor(props) {
      308 |     super(props);
      309 |
      310 |     const { typeofcomplaintValues } = props;

    ./src/routes/home/Home.js/componentDidMount/<
    src/routes/home/Home.js:409

      406 |   const attachmentData = [].map
      407 |     .call(items, item => item.getAsFile())
      408 |     .filter(file => !!file);
    > 409 |   this.handleAttachmentData({ attachmentData });
      410 | });
      411 |
      412 | window.addEventListener('beforeunload', beforeUnloadEvent => {

    EventListener.handleEvent*componentDidMount
    src/routes/home/Home.js:403

      400 |
      401 | // Allow users to paste image data
      402 | // adapted from https://github.com/charliewilco/react-gluejar/blob/b69d7cfa9d08bfb34d8eb6815e4b548528218883/src/index.js#L85
    > 403 | window.addEventListener('paste', clipboardEvent => {
      404 |   const { items } = clipboardEvent.clipboardData;
      405 |   // [].map.call because `items` isn't an array
      406 |   const attachmentData = [].map