### PR TITLE
Check for duplicate submissions before getting vehicle make/model/etc

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -528,6 +528,22 @@ class Home extends React.Component {
       ),
     });
 
+    if (
+      this.state.submissions.some(
+        submission =>
+          (submission.license === plate ||
+            submission.medallionNo === plate) &&
+          submission.state === licenseState,
+      )
+    ) {
+      this.notifyWarning(
+        <p>
+          You have already submitted a report for {plate} in {licenseState},
+          are you sure you want to submit another?
+        </p>,
+      );
+    }
+
     debouncedGetVehicleType({ plate, licenseState })
       .then(({ data }) => {
         const {
@@ -540,22 +556,6 @@ class Home extends React.Component {
         if (plate !== this.state.plate) {
           console.info('ignoring stale plate:', plate);
           return;
-        }
-
-        if (
-          this.state.submissions.some(
-            submission =>
-              (submission.license === plate ||
-                submission.medallionNo === plate) &&
-              submission.state === licenseState,
-          )
-        ) {
-          this.notifyWarning(
-            <p>
-              You have already submitted a report for {plate} in {licenseState},
-              are you sure you want to submit another?
-            </p>,
-          );
         }
 
         this.setState({


### PR DESCRIPTION
I realized that the dupe-checking was dependent on the make/model lookup
succeeding, which:

1. doesn't make sense
2. will rarely happen since the make/model lookup fails most of the time

so this fixes that.