### PR TITLE
Don't `handleAttachmentData` when pasting text into a field

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -406,6 +406,11 @@ class Home extends React.Component {
       const attachmentData = [].map
         .call(items, item => item.getAsFile())
         .filter(file => !!file);
+
+      if (attachmentData.length === 0) {
+        return;
+      }
+
       this.handleAttachmentData({ attachmentData });
     });
 


### PR DESCRIPTION
This is a follow-up to
https://github.com/josephfrazier/reported-web/pull/606 that should
prevent the plate/date/location extraction code from even being called.

Merge branch 'main' into fix.reduce.of.empty.array.2