### PR TITLE
Fix scroll-to-top after submission

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -863,7 +863,11 @@ class Home extends React.Component {
                     .post('/saveUser', this.state)
                     .then(() => {
                       this.setState({ isUserInfoOpen: false });
-                      window.scrollTo(0, 0);
+                      document.querySelector(`.${homeStyles.root}`).scrollTo({
+                        top: 100,
+                        left: 100,
+                        behavior: 'smooth',
+                      });
                     })
                     .catch(this.handleAxiosError)
                     .then(() => {
@@ -1102,7 +1106,11 @@ class Home extends React.Component {
                   )
                   .then(({ data }) => {
                     const { submission } = data;
-                    window.scrollTo(0, 0);
+                    document.querySelector(`.${homeStyles.root}`).scrollTo({
+                      top: 100,
+                      left: 100,
+                      behavior: 'smooth',
+                    });
                     console.info(
                       `submitted successfully. Returned data: ${JSON.stringify(
                         data,


### PR DESCRIPTION
Turns out that because the `<Dropzone>` component has `overflow-y: scroll`,
we need to call `scrollTo` on it instead of `window`, see https://stackoverflow.com/questions/31119786/window-scrollto-in-react-components/62985207#62985207:

> window.scrollTo only works when the scroll behavior is set on html.
> If scroll is set on body then document.querySelector("body").scrollTo(0,0)
>
> If you have set overflow: scroll on some container inside of the DOM, then that need to be accessed. Assign an id to that. For example I have below div container for which I have set overflow: scroll.
>
>     <html lang="en" dir="ltr">
>       <head>
>         <meta charset="utf-8">
>         <title></title>
>       </head>
>       <body>
>         <div id="root">
>           <div id="scroller">
>             <!-- other content -->
>           </div>
>         </div>
>       </body>
>     </html>
>
> Then for scrolling behavior, you need to query the scroller.
>
>     const scrollToTop = () => {
>       document.getElementById("scroller").scroll(0,0)
>     }
>
>     <button onClick={scrollToTop}>Scroll to Top</button>
>
> This would work perfectly.