### PR TITLE
Show latitude and longitude when using device's coordinates

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -377,7 +377,7 @@ class Home extends React.Component {
         this.setCoords({
           latitude,
           longitude,
-          addressProvenance: '(from device)',
+          addressProvenance: `(from device: ${latitude}, ${longitude})`,
         });
       }
     });
@@ -1396,7 +1396,7 @@ class Home extends React.Component {
                           this.setCoords({
                             latitude,
                             longitude,
-                            addressProvenance: '(from device)',
+                            addressProvenance: `(from device: ${latitude}, ${longitude})`,
                           });
                         })
                         .catch(err => {


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C9VNM3DL4/p1756950650632059:

> “Use current location” isn’t geolocating me correctly

> right now I’m at 34/Park and it thinks I’m in the center of Tompkins square park

> I don’t care about this, but it’s very confusing

> Other geo apps on my phone are working normally

---

> Hmm, that's strange. The code for this button literally just gets your
> latitude/longitude from your phone, so it should be using whatever your
> phone reports
>
> However, it then does the "spiraling" with google maps and NYC
> geoclient, so my first thought is that maybe it's somehow spiraling out
> very far? Seems unlikely though.
>
> I'll see if I can push an update to add the phone's lat/lng to `Where
> (from device)` text, so we can debug this further.
>
> Will keep you posted!