### PR TITLE
Remove `/geo/` from NYC Geoclient API URL

### DIFF
--- a/src/geoclient.js
+++ b/src/geoclient.js
@@ -74,7 +74,7 @@ export async function validateLocation({ lat, long }) {
   }
 
   const { data: geoclientResponse } = await axios.get(
-    'https://api.nyc.gov/geo/geoclient/v2/address.json',
+    'https://api.nyc.gov/geoclient/v2/address.json',
     {
       params: {
         houseNumber: building,


### PR DESCRIPTION
See https://github.com/josephfrazier/reported-web/pull/623#issuecomment-3387588478:

> Also to get geocode working I needed to change the endpoint.
> `https://api.nyc.gov/geo/geoclient/v2/address.json` [api.nyc.gov/geoclient/v2/address.json](https://api.nyc.gov/geoclient/v2/address.json)
> Not sure how it works with the (old?) endpoint.