### PR TITLE
Forbid timestamps from the future

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -361,16 +361,8 @@ app.use('/submit', (req, res) => {
           }
         });
 
-        const response = await fetch(
-          'https://worldtimeapi.org/api/timezone/America/New_York',
-        );
-        console.info(response);
-        const result = await response.json();
-        console.info(result);
-        const millisecondsSinceEpoch = timeofreport.valueOf();
-        const secondsSinceEpoch = millisecondsSinceEpoch / 1000;
-        if (secondsSinceEpoch > result.unixtime + 1) {
-          const message = `Timestamp cannot be in the future (submitted time: ${new Date(millisecondsSinceEpoch)}, actual time: ${new Date(result.unixtime * 1000)})`;
+        if (timeofreport.valueOf() > Date.now()) {
+          const message = `Timestamp cannot be in the future (submitted time: ${timeofreport}, actual time: ${new Date()})`;
           throw { message }; // eslint-disable-line no-throw-literal
         }
 


### PR DESCRIPTION
Fixes https://github.com/josephfrazier/reported-web/issues/624 - "Users are allowed to make submissions with timestamps in the future", with the caveat that it doesn't warn before form submission, and instead just returns an error response upon form submission:

> This doesn't make sense and might be a cause of the backend scripts submitting to 311 multiple times, see discussion at [reportedcab.slack.com/archives/C9VNM3DL4/p1760034914473779](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760034914473779):
> 
> > **(User)**
> > [2:35 PM](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760034914473779)
> > Help, this is still happening: all emails from one submission
> > [2:38](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760035109242579)
> > 9 emails now
> > [2:39](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760035150649069)
> > 10
> > **Joe Frazier**
> > [2:40 PM](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760035226941109)
> > [@(Developer)](https://reportedcab.slack.com/team/U05FY34UMHU) are you around to stop the script and possibly investigate?
> > **(Developer)**
> > [2:50 PM](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760035856985569)
> > I just stopped it. [@(User)](https://reportedcab.slack.com/team/U8H9PLBQB) I see your time in the future again. For example, Y201757C has time 3:09PM.
> > [2:51](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760035877567729)
> > This may be why the issue is coming up.
> > **(Developer)**
> > [3:14 PM](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760037277195819)
> > I put a quick fix which should handle such situations
> > **Joe Frazier**
> > [5:06 PM](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760043970638199)
> > Hmm, I seem to remember some discussion about what the webapp should do if the photo timestamp or user-chosen time is in the future, but can't find it now, and I don't think I actually made any changes to the webapp to prevent or at least warn the user about such timestamps. Glad to hear there's a fix on the backend though, that should be the final backstop.
> > New
> > **(Developer)**
> > [5:08 PM](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760044083320729)
> > I think we should take the current time. This is the best we can do.
> > **Joe Frazier**
> > [5:11 PM](https://reportedcab.slack.com/archives/C9VNM3DL4/p1760044264470179)
> > That seems reasonable, but I think it'd be even better if we can warn the user, as the actual time could have been in the past and maybe they made a mistake that they can correct. Then, if they fail to update the timestamp, prevent the submission from going through, rather than guessing that they meant the current time.

Example screenshot:

<img width="762" height="957" alt="image" src="https://github.com/user-attachments/assets/12e51b97-7c80-4221-b56f-2a93029c7ffa" />
