### PR TITLE
Use America/New_York timezone for future timestamp error message

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -361,8 +361,11 @@ app.use('/submit', (req, res) => {
           }
         });
 
+        const timezone = process.env.TZ;
+        process.env.TZ = 'America/New_York';
         if (timeofreport.valueOf() > Date.now()) {
           const message = `Timestamp cannot be in the future (submitted time: ${timeofreport}, actual time: ${new Date()})`;
+          process.env.TZ = timezone;
           throw { message }; // eslint-disable-line no-throw-literal
         }
 


### PR DESCRIPTION
Fixes the issue from https://github.com/josephfrazier/reported-web/pull/627 mentioned in https://reportedcab.slack.com/archives/C9VNM3DL4/p1760125679309839:

> Currently, the error message shows the timezone as GMT (Coordinated
> Universal Time), as I haven't yet figured out how to make it be
> Eastern Time, which might be a little confusing to users, but it gets
> the idea across IMO.