### PR TITLE
Don't warn about duplicate plate if previous submission is older than 30 days

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -538,12 +538,23 @@ class Home extends React.Component {
       ),
     });
 
+    const now = Date.now();
     if (
-      this.state.submissions.some(
-        submission =>
+      this.state.submissions.some(submission => {
+        const timeDifference =
+          now - new Date(submission.timeofreport).valueOf();
+        const thirtyDaysInMilliseconds = 30 * 24 * 60 * 60 * 1000;
+        const olderThanThirtyDays =
+          timeDifference / thirtyDaysInMilliseconds > 1;
+        if (olderThanThirtyDays) {
+          return false;
+        }
+
+        return (
           (submission.license === plate || submission.medallionNo === plate) &&
-          submission.state === licenseState,
-      )
+          submission.state === licenseState
+        );
+      })
     ) {
       this.notifyWarning(
         <p>


### PR DESCRIPTION
See https://reportedcab.slack.com/archives/C802R14UX/p1760121238475159:

> I got a “you already submitted a report for car XYZ” … turns out i had reported the same guy in 2024.
>
> it would be good to only show the warning if the previous report is less than N days old (7? 30?)

> I actually had the same thing happen to me earlier, but it didn't
> occur to me to set a time window on the dupe checking. I'll try to give
> it a shot!