### PR TITLE
Upgrade to heroku-24 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "stack": "heroku-22",
+  "stack": "heroku-24",
   "buildpacks": [
     {
       "url": "heroku/nodejs"


### PR DESCRIPTION
Prompted by the notice at https://dashboard.heroku.com/pipelines/cbc31c26-1c82-4965-91c0-8e311d3fa64b:

> This app is using the Heroku-22 stack, however a newer stack is available.
> To upgrade to Heroku-24, see:
> https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack

See https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack