### PR TITLE
Fix user enumeration vulnerability in password reset

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -293,6 +293,13 @@ app.use('/requestPasswordReset', (req, res) => {
 
   // http://docs.parseplatform.org/js/guide/#resetting-passwords
   Parse.User.requestPasswordReset(email)
+    .catch(error => {
+      if (error?.message?.startsWith('No user found with email')) {
+        return;
+      }
+
+      throw error;
+    })
     .then(() => res.end())
     .catch(handlePromiseRejection(res));
 });


### PR DESCRIPTION
From https://reportedcab.slack.com/archives/C9VNM3DL4/p1764722333668989?thread_ts=1764699535.703549&cid=C9VNM3DL4:

> However... as I went to test the "user does not exist case", I found
> that we already have a user enumeration vulnerability: resetting the
> password for an email address without an account shows a message `Error:
> No user found with email user@domain.tld.` instead of the preferred
> message of e.g. `If you have an account under user@domain.tld, we sent an
> email there, go check it`

> I did find that [Parse updated their password reset code to fix this](https://github.com/parse-community/parse-server/commit/7fe40304532493c5cec7f3a446c80b5f72f47a4e), but our version of Parse is too old to have the fix (we're on 2.8.4, but the fix was released starting in 3.1.0), so I think I'll have to deal with this case in the webapp instead (and I also wonder if the mobile apps have the same vulnerability)

This shows the usual success message when the user doesn't exist, and
doesn't bother with the "if you have an account" wording, that can be
changed elsewhere later if we feel like it.

Example screenshot from running this branch locally against the production Parse DB:

---

<img width="769" height="430" alt="image" src="https://github.com/user-attachments/assets/a222204d-596a-4ef4-b0b2-551269eac946" />
