### PR TITLE
Autocorrect 1######C to T######C only when it's the entire plate

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -627,7 +627,8 @@ class Home extends React.Component {
             ),
           });
 
-          if (plate.match(/1\d\d\d\d\d\dC/)) {
+          // autocorrect common license plate typos from ALPR/OCR
+          if (plate.match(/^1\d\d\d\d\d\dC$/)) {
             this.setLicensePlate({
               plate: plate.replace('1', 'T'),
               licenseState,


### PR DESCRIPTION
I accidentally entered an extra number, like this: T1######C
and it got corrected to TT######C, which was confusing.

Though it arguably helped me find the accidental extra digit, it still
doesn't feel right.