### PR TITLE
Fix Jest open handle warning in srlookup test

### DIFF
--- a/src/srlookup.js
+++ b/src/srlookup.js
@@ -1,10 +1,13 @@
+import https from 'https';
 import axios from 'axios';
 import { JSDOM } from 'jsdom';
 
 export default async function srlookup({ reqnumber }) {
   const url = `https://portal.311.nyc.gov/sr-details/?srnum=${reqnumber}`;
 
-  const { data } = await axios.get(url);
+  const { data } = await axios.get(url, {
+    httpsAgent: new https.Agent({ keepAlive: false }),
+  });
   const { document } = new JSDOM(data).window;
 
   const result = {};


### PR DESCRIPTION
Pass httpsAgent with keepAlive: false to the axios request so the
TLS socket is closed after the response, preventing Jest from
detecting an open TLSWRAP handle.

The error that was happening on `yarn test --detectOpenHandles`:

    Jest has detected the following 1 open handle potentially keeping Jest from exiting:

      ●  TLSWRAP

           5 |   const url = `https://portal.311.nyc.gov/sr-details/?srnum=${reqnumber}`;
           6 |
        >  7 |   const { data } = await axios.get(url);
             |                                ^
           8 |   const { document } = new JSDOM(data).window;
           9 |
          10 |   const result = {};

          at RedirectableRequest.Object.<anonymous>.RedirectableRequest._performRequest (node_modules/follow-redirects/index.js:337:24)
          at new RedirectableRequest (node_modules/follow-redirects/index.js:111:8)
          at Object.request (node_modules/follow-redirects/index.js:543:14)
          at dispatchHttpRequest (node_modules/axios/lib/adapters/http.js:482:21)
          at node_modules/axios/lib/adapters/http.js:155:5
          at wrapAsync (node_modules/axios/lib/adapters/http.js:135:10)
          at http (node_modules/axios/lib/adapters/http.js:173:10)
          at Axios.dispatchRequest (node_modules/axios/lib/core/dispatchRequest.js:51:10)
          at Axios._request (node_modules/axios/lib/core/Axios.js:187:33)
          at Axios.request (node_modules/axios/lib/core/Axios.js:40:25)
          at Axios.<computed> [as get] (node_modules/axios/lib/core/Axios.js:213:17)
          at wrap [as get] (node_modules/axios/lib/helpers/bind.js:5:15)
          at get (src/srlookup.js:7:32)
          at Object.<anonymous> (src/srlookup.test.js:10:26)