### PR TITLE
Load Previous Submissions on mount

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -464,6 +464,8 @@ class Home extends React.Component {
     });
 
     this.forceUpdate(); // force "Create/Edit User" fields to render persisted value after load
+
+    this.loadPreviousSubmissions();
   }
 
   onDeleteSubmission = ({ objectId }) => {
@@ -1513,19 +1515,12 @@ class Home extends React.Component {
 
             <br />
 
-            <details
-              onToggle={evt => {
-                if (!evt.target.open) {
-                  return;
-                }
-                this.loadPreviousSubmissions();
-              }}
-            >
+            <details>
               <summary>
                 Previous Submissions (
                 {this.state.submissions.length > 0
                   ? this.state.submissions.length
-                  : 'click to load'}
+                  : 'loading...'}
                 )
               </summary>
 

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -36,21 +36,21 @@ describe('Home', () => {
     ];
 
     const insertCss = () => {};
-    const wrapper = renderer
-      .create(
-        <StyleContext.Provider value={{ insertCss }}>
-          <App context={{ fetch: () => {}, pathname: '' }}>
-            <Home
-              typeofcomplaintValues={typeofcomplaintValues}
-              boroughBoundariesFeatureCollection={
-                boroughBoundariesFeatureCollection
-              }
-            />
-          </App>
-        </StyleContext.Provider>,
-      )
-      .toJSON();
+    const tree = renderer.create(
+      <StyleContext.Provider value={{ insertCss }}>
+        <App context={{ fetch: () => {}, pathname: '' }}>
+          <Home
+            typeofcomplaintValues={typeofcomplaintValues}
+            boroughBoundariesFeatureCollection={
+              boroughBoundariesFeatureCollection
+            }
+          />
+        </App>
+      </StyleContext.Provider>,
+    );
 
-    expect(wrapper).toMatchSnapshot();
+    expect(tree.toJSON()).toMatchSnapshot();
+
+    tree.unmount();
   });
 });

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -670,12 +670,10 @@ exports[`Home renders children correctly 1`] = `
         </fieldset>
       </form>
       <br />
-      <details
-        onToggle={[Function]}
-      >
+      <details>
         <summary>
           Previous Submissions (
-          click to load
+          loading...
           )
         </summary>
         Loading submissions...


### PR DESCRIPTION
(made with the help of Claude Code)

## Summary
- Start fetching submissions in `componentDidMount` instead of waiting for the user to expand the `<details>` element
- With ~2500 submissions, this eliminates the noticeable wait when opening the section since data is likely already loaded
- Update summary text from "click to load" to "loading..." to reflect the new behavior

## Test plan
- [x] `yarn test` — all tests pass (snapshot updated)
- [x] `yarn lint` — no errors
- [x] Manual: open the page, expand "Previous Submissions" — data should appear immediately or near-immediately instead of requiring a loading wait