### PR TITLE
Remove deleted submission from Previous Submissions by ignoring false Parse error "Object not found for delete."

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -278,9 +278,21 @@ app.use('/api/deleteSubmission', (req, res) => {
     .then(submissions => {
       const submission = submissions.find(sub => sub.id === objectId);
       assert(submission); // TODO make it obvious that this is necessary
-      return submission.destroy().then(() => {
-        res.json({ objectId });
-      });
+      return submission
+        .destroy()
+        .catch(error => {
+          if (error.message === 'Object not found for delete.') {
+            console.info(
+              `/api/deleteSubmission: swallowing false Parse error "Object not found for delete."`,
+            );
+            return;
+          }
+
+          throw error;
+        })
+        .then(() => {
+          res.json({ objectId });
+        });
     })
     .catch(handlePromiseRejection(res));
 });


### PR DESCRIPTION
Parse gives this error even though we specifically ensured the
submission exists, and despite the deletion happening successfully, so
just ignore it, so that the UI can properly be updated by removing the
submission from the list.