### PR TITLE
Fix Nissan logo thumbnail URL to comply with https://www.mediawiki.org/wiki/Common_thumbnail_sizes

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -326,7 +326,7 @@ async function extractDate({ attachmentFile, attachmentArrayBuffer, ext }) {
 class Home extends React.Component {
   static getVehicleMakeLogoUrl({ vehicleMake }) {
     if (vehicleMake.toLowerCase() === 'nissan') {
-      return 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/Nissan_2020_logo.svg/287px-Nissan_2020_logo.svg.png';
+      return 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/Nissan_2020_logo.svg/250px-Nissan_2020_logo.svg.png';
     }
     if (vehicleMake.toLowerCase() === 'honda') {
       return 'https://upload.wikimedia.org/wikipedia/commons/3/38/Honda.svg';


### PR DESCRIPTION
I noticed that the previous URL, https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/Nissan_2020_logo.svg/287px-Nissan_2020_logo.svg.png,
shows an error page saying:

> Use thumbnail steps listed on https://w.wiki/GHai. Please contact noc@wikimedia.org for further information (a765913)

and https://w.wiki/GHai goes to https://www.mediawiki.org/wiki/Common_thumbnail_sizes,
which says:

> Current standard sizes in Wikimedia production: 20px, 40px, 60px, 120px, 250px, 330px, 500px, 960px, 1280px, 1920px, 3840px

and 250px is closest to the previous 287px