### PR TITLE
Limit vehicle make logo to 250px wide

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -651,6 +651,7 @@ class Home extends React.Component {
                 alt={`${vehicleMake} logo`}
                 style={{
                   display: 'block',
+                  maxWidth: '250px',
                 }}
               />
             </React.Fragment>


### PR DESCRIPTION
This prevents it from taking up too much space, e.g. the Honda logo at
https://upload.wikimedia.org/wikipedia/commons/3/38/Honda.svg