### PR TITLE
Don't render Previous Submissions list if collapsed

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -391,6 +391,7 @@ class Home extends React.Component {
       isReverseGeocodingEnabled: true,
       isUserInfoOpen: true,
       isMapOpen: false,
+      isPreviousSubmissionsOpen: false,
     };
 
     const initialStatePerSession = {
@@ -1671,7 +1672,11 @@ class Home extends React.Component {
 
             <br />
 
-            <details>
+            <details
+              onToggle={e =>
+                this.setState({ isPreviousSubmissionsOpen: e.target.open })
+              }
+            >
               <summary>
                 Previous Submissions (
                 {this.state.submissions.length > 0
@@ -1680,10 +1685,12 @@ class Home extends React.Component {
                 )
               </summary>
 
-              <PreviousSubmissionsList
-                submissions={this.state.submissions}
-                onDeleteSubmission={this.onDeleteSubmission}
-              />
+              {this.state.isPreviousSubmissionsOpen && (
+                <PreviousSubmissionsList
+                  submissions={this.state.submissions}
+                  onDeleteSubmission={this.onDeleteSubmission}
+                />
+              )}
             </details>
 
             <div style={{ float: 'right' }}>

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -676,13 +676,14 @@ exports[`Home renders children correctly 1`] = `
         </fieldset>
       </form>
       <br />
-      <details>
+      <details
+        onToggle={[Function]}
+      >
         <summary>
           Previous Submissions (
           loading...
           )
         </summary>
-        Loading submissions...
       </details>
       <div
         style={


### PR DESCRIPTION
_EDIT: Matt confirmed this fixed things for them, see https://reportedcab.slack.com/archives/C802R14UX/p1776392767049499?thread_ts=1776253265.889359&cid=C802R14UX_

> _Looks like that fixed it. I just submitted a bunch of reports from my phone successfully. Thanks a bunch!_

I'm hoping this fixes the bug described in https://reportedcab.slack.com/archives/C802R14UX/p1776253265889359:

> Is anyone else having trouble submitting via web on an iphone?  It
> started perhaps a month ago.
>
> After adding a photo and before hitting submit, the website has started
> crashing and giving an error, "A problem repeatedly occurred on
> [https://reported-web.herokuapp.com](https://reported-web.herokuapp.com)".
>
> If I fill out the details and hit submit quickly, I can get some
> submissions through, but the error is pretty frequent. Disabling license
> reading doesn't fix the problem. It's an iphone 16 so I don't think low
> memory etc. is a cause. I tried quickly with Safari on my Mac and
> couldn't reproduce it there.
>
> Only thing I can think of is that my account has a lot of submissions
> (~8500). If I click the disclosure triangle to view them, the site slows
> down glacially. But it has never caused problems as long as past
> submissions are hidden (as they are by default).

> hey Matt, thanks for the bug report! Also, congratulations on so many
> submissions! I think that might be the most I've heard of (I currently
> have 3111, for comparison).
>
> I'm glad you mentioned the quantity, as I know the Previous Submissions
> section has caused problems in the past. I thought I fixed it with
> [https://github.com/josephfrazier/reported-web/pull/676](https://github.com/josephfrazier/reported-web/pull/676)
> and I subsequently [made them automatically load (but not
> display)](https://github.com/josephfrazier/reported-web/pull/677).
> Perhaps the size of the previous submissions data is still causing a
> problem, even though they aren't displayed? Just to confirm, you're
> still seeing the `A problem repeatedly occurred
> on``[https://reported-web.herokuapp.com](https://reported-web.herokuapp.com)`
> error even when Previous Submissions is collapsed, right [@Matt
> ](https://reportedcab.slack.com/team/UJP7ZUUBB)?
>
> For my reference: I checked the approximate size of my 3111 submissions
> with `JSON.stringify(submissions).length` (after using React Dev Tools
> to pull the `this.state.submissions` variable out of the React
> tree) and got `8316931`, or about 8 megabytes. This means that
> your 8500 submissions might be around 22 MB.
>
> I checked the code and noticed that the list seems to be rendered even
> if the `<details>` dropdown isn't open, implementation and test snapshot
> below (note the `Loading submissions...` in the snapshot):
>
> ```
> <details>
> <summary>
> Previous Submissions (
> {this.state.submissions.length > 0
> ? this.state.submissions.length
> : 'loading...'}
> )
> </summary>
>
> <PreviousSubmissionsList
> submissions={this.state.submissions}
> onDeleteSubmission={this.onDeleteSubmission}
> />
> </details>
> ```
>
> ```
> <details>
> <summary>
> Previous Submissions (
> loading...
> )
> </summary>
> Loading submissions...
> </details>
> ```
>
> so maybe a workaround would be to skip the rendering if the dropdown is collapsed.