### PR TITLE
Only warn about "already submitted" plates on the same day, ignore license state

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -644,10 +644,7 @@ class Home extends React.Component {
         return false;
       }
 
-      return (
-        (submission.license === plate || submission.medallionNo === plate) &&
-        submission.state === licenseState
-      );
+      return submission.license === plate || submission.medallionNo === plate;
     });
 
     const priorCount = priorSubmissions.length;
@@ -657,8 +654,8 @@ class Home extends React.Component {
 
       Home.notifyWarning(
         <p>
-          You have already submitted {priorCount} {pluralReport} for {plate} in{' '}
-          {licenseState}, are you sure you want to submit another?
+          You have already submitted {priorCount} {pluralReport} for {plate} on{' '}
+          {selectedDateDay}, are you sure you want to submit another?
         </p>,
       );
     }

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -634,13 +634,13 @@ class Home extends React.Component {
         : null,
     });
 
-    const now = Date.now();
+    const selectedDate = new Date(this.state.CreateDate);
+    const selectedDateDay = selectedDate.toDateString();
 
     const priorSubmissions = this.state.submissions.filter(submission => {
-      const timeDifference = now - new Date(submission.timeofreport).valueOf();
-      const thirtyDaysInMilliseconds = 30 * 24 * 60 * 60 * 1000;
-      const olderThanThirtyDays = timeDifference / thirtyDaysInMilliseconds > 1;
-      if (olderThanThirtyDays) {
+      const submissionDate = new Date(submission.timeofreport);
+      const isSameDay = submissionDate.toDateString() === selectedDateDay;
+      if (!isSameDay) {
         return false;
       }
 


### PR DESCRIPTION
Changes:

* Only warn about "already submitted" plates on the same day

  This was done by prompting `deepseek-v4-pro[1m]` via Claude Code as follows:

  > in src/routes/home/Home.js when finding priorSubmissions, change the filter logic from "older than 30 days" to "on the same day as the date currently chosen by the user"

* Ignore license state when checking for "already submitted" warning

  This should make the warning pop up even if the state is wrong, which
  can save time if the ALPR fails.