### PR TITLE
/submissions-map: Draw polygon instead of box, to make it easier to avoid getting too many results with a bounding box

### DIFF
--- a/public/submissions-map.html
+++ b/public/submissions-map.html
@@ -417,9 +417,9 @@
   </div>
 
   <div id="panel-draw">
-    <p>Draw a bounding box on the map to fetch public submissions in that area. Click the rectangle tool <strong style="color:var(--text)">▭</strong> in the top-left of the map, then drag to select an area.</p>
+    <p>Draw a polygon on the map to fetch public submissions in that area. Click the polygon tool <strong style="color:var(--text)">⬠</strong> in the top-left of the map, then click to add vertices. Double-click to finish.</p>
     <div id="draw-map"></div>
-    <div id="draw-status">Select the rectangle tool and drag to define an area.</div>
+    <div id="draw-status">Select the polygon tool and draw a shape on the map.</div>
   </div>
 </div>
 
@@ -642,8 +642,8 @@ document.getElementById('reset-btn').addEventListener('click', () => {
   pinned = false;
   popup.classList.remove('visible', 'pinned');
   if (drawnItems) drawnItems.clearLayers();
-  document.getElementById('draw-status').textContent = 'Select the rectangle tool and drag to define an area.';
-  clearUrlBbox();
+  document.getElementById('draw-status').textContent = 'Select the polygon tool and draw a shape on the map.';
+  clearUrlParams();
 });
 
 // ── TAB SWITCHING ──
@@ -683,8 +683,11 @@ function initDrawMap() {
 
   const drawControl = new L.Control.Draw({
     draw: {
-      rectangle: { shapeOptions: { color: '#d4ff4e', weight: 2, fillOpacity: 0.08 } },
-      polygon: false,
+      rectangle: false,
+      polygon: {
+        shapeOptions: { color: '#d4ff4e', weight: 2, fillOpacity: 0.08 },
+        allowIntersection: false,
+      },
       circle: false,
       polyline: false,
       marker: false,
@@ -697,26 +700,33 @@ function initDrawMap() {
   drawMap.on(L.Draw.Event.CREATED, async (e) => {
     drawnItems.clearLayers();
     drawnItems.addLayer(e.layer);
-    const bounds = e.layer.getBounds();
-    updateUrlWithBbox(bounds.getSouth(), bounds.getNorth(), bounds.getWest(), bounds.getEast());
-    await fetchAndLoadBbox(bounds);
+    const polygonLatLngs = e.layer.getLatLngs()[0];
+    // Strip the closing duplicate vertex that Leaflet adds
+    const last = polygonLatLngs[polygonLatLngs.length - 1];
+    const vertices =
+      polygonLatLngs.length > 1 &&
+      polygonLatLngs[0].lat === last.lat &&
+      polygonLatLngs[0].lng === last.lng
+        ? polygonLatLngs.slice(0, -1)
+        : polygonLatLngs;
+    updateUrlWithPolygon(vertices);
+    await fetchAndLoadPolygon(vertices);
   });
 
   setTimeout(() => drawMap.invalidateSize(), 60);
 }
 
-async function fetchAndLoadBbox(bounds) {
+async function fetchAndLoadPolygon(vertices) {
   const statusEl = document.getElementById('draw-status');
   statusEl.textContent = 'Loading submissions\u2026';
 
-  const minLat = bounds.getSouth();
-  const maxLat = bounds.getNorth();
-  const minLng = bounds.getWest();
-  const maxLng = bounds.getEast();
+  const polygonStr = vertices
+    .map(ll => `${ll.lat.toFixed(6)},${ll.lng.toFixed(6)}`)
+    .join(';');
 
   try {
     const resp = await fetch(
-      `/api/submissions-bbox?minLat=${encodeURIComponent(minLat)}&maxLat=${encodeURIComponent(maxLat)}&minLng=${encodeURIComponent(minLng)}&maxLng=${encodeURIComponent(maxLng)}`
+      `/api/submissions-in-polygon?polygon=${encodeURIComponent(polygonStr)}`
     );
     if (!resp.ok) {
       const body = await resp.json().catch(() => ({}));
@@ -724,16 +734,16 @@ async function fetchAndLoadBbox(bounds) {
     }
     const data = await resp.json();
     if (!data.results || data.results.length === 0) {
-      statusEl.textContent = 'No public submissions found in this area. Try a larger area.';
+      statusEl.textContent = 'No public submissions found inside this polygon. Try a larger area.';
       return;
     }
-    statusEl.textContent = 'Select the rectangle tool and drag to define an area.';
+    statusEl.textContent = 'Select the polygon tool and draw a shape on the map.';
     if (data.capped) {
-      window.alert(`Results are capped at ${data.results.length.toLocaleString()} submissions. Draw a smaller box to see all reports in an area.`);
+      window.alert(`Results are capped at ${data.results.length.toLocaleString()} submissions. Draw a smaller polygon to see all reports in an area.`);
     }
     loadMap(data.results);
   } catch (e) {
-    statusEl.textContent = 'Select the rectangle tool and drag to define an area.';
+    statusEl.textContent = 'Select the polygon tool and draw a shape on the map.';
     const isNetworkError = e instanceof TypeError;
     window.alert(isNetworkError
       ? 'Network error: could not reach the server. Please check your connection and try again.'
@@ -742,12 +752,15 @@ async function fetchAndLoadBbox(bounds) {
 }
 
 // ── URL PARAMS ──
-function updateUrlWithBbox(minLat, maxLat, minLng, maxLng) {
-  const params = new URLSearchParams({ minLat, maxLat, minLng, maxLng });
+function updateUrlWithPolygon(vertices) {
+  const polygonStr = vertices
+    .map(ll => `${ll.lat.toFixed(6)},${ll.lng.toFixed(6)}`)
+    .join(';');
+  const params = new URLSearchParams({ polygon: polygonStr });
   history.pushState(null, '', `?${params}`);
 }
 
-function clearUrlBbox() {
+function clearUrlParams() {
   history.pushState(null, '', window.location.pathname);
 }
 
@@ -755,33 +768,28 @@ function clearUrlBbox() {
 // Called on initial load and whenever the user navigates back/forward.
 function applyUrlState() {
   const params = new URLSearchParams(window.location.search);
-  const minLat = params.get('minLat');
-  const maxLat = params.get('maxLat');
-  const minLng = params.get('minLng');
-  const maxLng = params.get('maxLng');
+  const polygonStr = params.get('polygon');
 
-  if (minLat && maxLat && minLng && maxLng) {
-    // Ensure paste screen is visible (we may be coming back from the map screen)
+  if (polygonStr) {
     document.getElementById('map-screen').style.display = 'none';
     document.getElementById('paste-screen').style.display = 'flex';
 
-    // Activate Draw Area tab (also calls initDrawMap, which sets drawnItems)
     document.getElementById('tab-draw').click();
 
-    const bounds = L.latLngBounds(
-      L.latLng(parseFloat(minLat), parseFloat(minLng)),
-      L.latLng(parseFloat(maxLat), parseFloat(maxLng)),
-    );
+    const vertices = polygonStr.split(';').map(pair => {
+      const [lat, lng] = pair.split(',');
+      return [parseFloat(lat), parseFloat(lng)];
+    });
 
-    // Show the rectangle on the draw map to indicate the queried area
     drawnItems.clearLayers();
-    const rect = L.rectangle(bounds, { color: '#d4ff4e', weight: 2, fillOpacity: 0.08 });
-    drawnItems.addLayer(rect);
-    drawMap.fitBounds(bounds, { padding: [20, 20] });
+    const polygon = L.polygon(vertices, { color: '#d4ff4e', weight: 2, fillOpacity: 0.08 });
+    drawnItems.addLayer(polygon);
+    drawMap.fitBounds(polygon.getBounds(), { padding: [20, 20] });
 
-    fetchAndLoadBbox(bounds);
+    const latLngs = vertices.map(v => L.latLng(v[0], v[1]));
+    fetchAndLoadPolygon(latLngs);
   } else {
-    // No bbox params — return to the paste/draw screen
+    // No params — return to the paste/draw screen
     document.getElementById('map-screen').style.display = 'none';
     document.getElementById('paste-screen').style.display = 'flex';
     pinned = false;
@@ -791,7 +799,7 @@ function applyUrlState() {
 
 window.addEventListener('popstate', applyUrlState);
 
-// On load: apply the URL state (handles direct links with bbox params)
+// On load: apply the URL state (handles direct links with polygon params)
 applyUrlState();
 </script>
 </body>

--- a/src/server.js
+++ b/src/server.js
@@ -586,7 +586,7 @@ app.get('/api/submissions-in-polygon', (req, res) => {
       if (lng < -180 || lng > 180) {
         throw new Error(`Vertex ${idx} longitude out of range (-180 to 180)`);
       }
-      return [lat, lng];
+      return [lng, lat];
     });
   } catch (e) {
     res.status(400).json({ error: e.message });

--- a/src/server.js
+++ b/src/server.js
@@ -545,7 +545,7 @@ app.get('/submissions-map', (req, res) => {
   res.sendFile(path.resolve(__dirname, 'public', 'submissions-map.html'));
 });
 
-const BBOX_FIELDS = [
+const POLYGON_FIELDS = [
   'location',
   'timeofreport',
   'license',
@@ -559,48 +559,61 @@ const BBOX_FIELDS = [
   'can_be_shared_publicly',
 ];
 
-const BBOX_RESULT_LIMIT = 10000;
+const POLYGON_RESULT_LIMIT = 10000;
 
-app.get('/api/submissions-bbox', (req, res) => {
-  const { minLat, maxLat, minLng, maxLng } = req.query;
+app.get('/api/submissions-in-polygon', (req, res) => {
+  let polygonCoords = null;
 
-  const parsedMinLat = parseFloat(minLat);
-  const parsedMaxLat = parseFloat(maxLat);
-  const parsedMinLng = parseFloat(minLng);
-  const parsedMaxLng = parseFloat(maxLng);
-
-  if (
-    [parsedMinLat, parsedMaxLat, parsedMinLng, parsedMaxLng].some(
-      Number.isNaN,
-    ) ||
-    parsedMinLat >= parsedMaxLat ||
-    parsedMinLng >= parsedMaxLng
-  ) {
-    res.status(400).json({
-      error:
-        'Invalid bounding box: provide minLat, maxLat, minLng, maxLng as numbers with minLat < maxLat and minLng < maxLng.',
+  const rawVertices = req.query.polygon.split(';');
+  if (rawVertices.length < 3) {
+    res.status(400).json({ error: 'Polygon must have at least 3 vertices.' });
+    return;
+  }
+  try {
+    polygonCoords = rawVertices.map((pair, idx) => {
+      const parts = pair.split(',');
+      if (parts.length !== 2) {
+        throw new Error(`Vertex ${idx} is invalid: expected "lat,lng"`);
+      }
+      const lat = parseFloat(parts[0]);
+      const lng = parseFloat(parts[1]);
+      if (Number.isNaN(lat) || Number.isNaN(lng)) {
+        throw new Error(`Vertex ${idx} has non-numeric coordinates`);
+      }
+      if (lat < -90 || lat > 90) {
+        throw new Error(`Vertex ${idx} latitude out of range (-90 to 90)`);
+      }
+      if (lng < -180 || lng > 180) {
+        throw new Error(`Vertex ${idx} longitude out of range (-180 to 180)`);
+      }
+      return [lat, lng];
     });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
     return;
   }
 
   const Submission = Parse.Object.extend('submission');
   const query = new Parse.Query(Submission);
-  query.greaterThanOrEqualTo('latitude1', parsedMinLat);
-  query.lessThanOrEqualTo('latitude1', parsedMaxLat);
-  query.greaterThanOrEqualTo('longitude1', parsedMinLng);
-  query.lessThanOrEqualTo('longitude1', parsedMaxLng);
+  query.withinPolygon('location', polygonCoords);
   query.equalTo('can_be_shared_publicly', true);
-  query.limit(BBOX_RESULT_LIMIT);
-  query.select(BBOX_FIELDS);
+  query.limit(POLYGON_RESULT_LIMIT);
+  query.select(POLYGON_FIELDS);
 
   query
     .find()
     .then(parseResults => {
       const results = parseResults.map(obj => {
         const json = obj.toJSON();
-        return Object.fromEntries(BBOX_FIELDS.map(k => [k, json[k] ?? null]));
+        return Object.fromEntries(
+          POLYGON_FIELDS.map(k => [k, json[k] ?? null]),
+        );
       });
-      res.json({ results, capped: results.length >= BBOX_RESULT_LIMIT });
+
+      res.json({
+        results,
+        capped: parseResults.length >= POLYGON_RESULT_LIMIT,
+      });
     })
     .catch(handlePromiseRejection(res));
 });

--- a/src/server.js
+++ b/src/server.js
@@ -564,7 +564,15 @@ const POLYGON_RESULT_LIMIT = 10000;
 app.get('/api/submissions-in-polygon', (req, res) => {
   let polygonCoords = null;
 
-  const rawVertices = req.query.polygon.split(';');
+  const polygonParam = req.query.polygon;
+  if (typeof polygonParam !== 'string' || !polygonParam.trim()) {
+    res.status(400).json({
+      error: 'Query parameter "polygon" is required and must be a non-empty string.',
+    });
+    return;
+  }
+
+  const rawVertices = polygonParam.trim().split(';');
   if (rawVertices.length < 3) {
     res.status(400).json({ error: 'Polygon must have at least 3 vertices.' });
     return;

--- a/src/server.js
+++ b/src/server.js
@@ -567,7 +567,8 @@ app.get('/api/submissions-in-polygon', (req, res) => {
   const polygonParam = req.query.polygon;
   if (typeof polygonParam !== 'string' || !polygonParam.trim()) {
     res.status(400).json({
-      error: 'Query parameter "polygon" is required and must be a non-empty string.',
+      error:
+        'Query parameter "polygon" is required and must be a non-empty string.',
     });
     return;
   }


### PR DESCRIPTION
See https://tabkactivistcommittee.slack.com/archives/C03QBLXSJ86/p1778094687670599?thread_ts=1774035171.813919&cid=C03QBLXSJ86:

> This is super cool.
>
> My immediate thoughts are that 1) I want to be able to freehand draw and 2) the
> first time I used the rectangle tool I did it fine, but the second time I
> clicked the map instead of dragging (idk why) and it throws a window error. It
> took me a second to realize what was happening

and my reply at https://tabkactivistcommittee.slack.com/archives/C03QBLXSJ86/p1778109254930409?thread_ts=1774035171.813919&cid=C03QBLXSJ86:

> Thanks for the quick feedback, some great stuff here! Lemme see if I can take a quick shot at some responses:
>
> > 1) I want to be able to freehand draw
> >
> > ...
> >
> > Also I think non-map people might be more comfortable with an interaction
> > like clicking a street and returning 311 reports "on" that street (backend
> > would just create a buffer around the street).
> > Or searching an address and seeing a radius.
>
> Yeah, those would be much better, especially since our grids aren't really
> compass-aligned. I started with the bounding box because that was the easiest
> thing to do, and I'm not sure if this database has built-in support for
> querying with e.g. a polygon, so the box was just a handful of
> greater-than/less-than queries on the latitude/longitude. That said, I might do
> a little research and see how hard it might be to do more arbitrary shapes.
>
> > 2) the first time I used the rectangle tool I did it fine, but the second
> > time I clicked the map instead of dragging (idk why) and it throws a window
> > error. It took me a second to realize what was happening
>
> Hmm, that's interesting. I haven't been able to reproduce it yet, is it
> happening consistently for you?
>
> > But also maybe general public is not the primary audience
> >
> > ...
> >
> > I also realize this might not be along the lines of the discussion happening
> > in this thread I just jumped on and saw this and these were my immediate
> > reactions.
>
> Heh, I'm still figuring out who the audience is! So far, I've wanted to make it
> easier to do the sort of thing in this thread (which has also come up in at
> least one other prior thread), that is, activists finding data about
> specific areas.
>
> I'd definitely be interested in making it more suitable for the general public,
> though, but I'd probably have to do more things like clarifying that this is
> not all 311 data, only the stuff that goes through Reported, etc.
>
> EDIT: Oh, and I just chose to post it from this thread since that's where the
> last relevant conversation was, not because it's specifically helpful to the
> Dekalb/Lafayette stuff. In fact, it's actually a bit of a derailment from
> that, would be happy to move the conversation elsewhere if anyone would
> prefer.

---

Commits:

* WIP NOT WORKING: submissions-map lets you draw polygon instead of box

  NOT WORKING: I always see "No public submissions found inside this polygon. Try a larger area." even though there are submissions in within the polygon.

  After the below LLM-powered change which added the polygon functionality, I manually removed the old bounding
  box functionality and ran `yarn fix` to correct the code style.

  Prompted deepseek-v4-pro[1m] via Claude Code with:

  > The Parse server version is 2.8.4, which supports geoWithin queries via the withJSON method, can we use that so that we avoid situations where the bounding box query gets capped to 10000 and we don't get all the submissions inside the
    polygon?

  And it summarized its changes as follows:

  > ● Done. The change is straightforward — here's what's different:
  >
  >   src/server.js — The polygon path now uses query.withinPolygon('location', polygonCoords) instead of the old approach:
  >
  >   - Before: Bbox range query on latitude1/longitude1 number fields → capped at 10k → server-side JS pointInPolygon() filtering. If the bbox was large, the 10k cap could truncate results before the polygon filter ran, silently dropping
  >   submissions that were inside the polygon.
  >   - After: MongoDB's $geoWithin on the location GeoPoint field handles filtering at the database level using the geospatial index. The 10k cap now applies to results actually inside the polygon, which is the correct behavior.
  >
  >   The pointInPolygon() function was removed since it's no longer needed. The old bbox query params (?minLat=...&maxLat=...) still work unchanged for backward compat. No client-side changes were needed — the polygon URL format and fetch logic
  >   stay the same.
  >
  > ✻ Baked for 7m 41s
  >
  > ※ recap: We switched the submissions-map from rectangle-only to arbitrary polygon drawing. Next step: verify it works end-to-end by starting the dev server and testing with a live polygon draw once the sharp module issue is resolved. (disable
    recaps in /config)

* /api/submissions-in-polygon: Pass [lng,lat] to Parse.Query.withinPolygon, not [lat,lng]

  Deepseek got this wrong, but I think I saw something about the
  coordinate sort order in its "thinking" messages, so I tried switching
  them and it worked!

* /api/submissions-in-polygon: Handle missing/empty `polygon` query parameter
  
  req.query.polygon is used without checking it exists (calling .split(';') directly). If the query param is missing or not a string, this route will throw and Express will return a 500/HTML error instead of a clean 400 JSON response. Add a guard for a missing/empty polygon param (and optionally trim) before splitting, and return a 400 with a helpful error message.