### PR TITLE
CI: Don't reinstall `sharp` with `yarn --ignore-engines`

### DIFF
--- a/.github/workflows/test-alpr.yml
+++ b/.github/workflows/test-alpr.yml
@@ -23,7 +23,6 @@ jobs:
     - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
     - run: export PATH=$HOME/.yarn/bin:$PATH
     - run: yarn
-    - run: yarn add sharp --ignore-engines
     - shell: bash
       env:
         PLATERECOGNIZER_TOKEN: ${{ secrets.PLATERECOGNIZER_TOKEN }}

--- a/.github/workflows/test-no-alpr.yml
+++ b/.github/workflows/test-no-alpr.yml
@@ -23,7 +23,6 @@ jobs:
     - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
     - run: export PATH=$HOME/.yarn/bin:$PATH
     - run: yarn
-    - run: yarn add sharp --ignore-engines
     - shell: bash
       env:
         GEO_APP_ID: ${{ secrets.GEO_APP_ID }}


### PR DESCRIPTION
While working on adding an AGENTS.md file to the repo in https://github.com/josephfrazier/reported-web/pull/775,
I noticed that github copilot was using `YARN_IGNORE_ENGINES=1` and `--ignore-engines` when running yarn commands.

Its first draft mentioned that `--ignore-engines` was already present in
the CI workflow files, so I thought I'd see if we can remove it.