### PR TITLE
Revert "Alert user that Reported can't create 311 Service Requests right now (due to new CAPTCHA requirements)"

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -461,10 +461,6 @@ class Home extends React.Component {
   }
 
   componentDidMount() {
-    alert(
-      'Reported cannot currently create 311 Service Requests, so your submissions are not going very far at the moment. See here for details:\n\nhttps://reportedcab.slack.com/archives/C802R14UX/p1781350550709439',
-    );
-
     // if there's no attachments or a time couldn't be extracted, just use now
     if (this.state.attachmentData.length === 0 || !this.state.CreateDate) {
       this.setCreateDate({ millisecondsSinceEpoch: Date.now() });


### PR DESCRIPTION
Reverts josephfrazier/reported-web#790, now that things are starting to work again, see details at https://reportedcab.slack.com/archives/C802R14UX/p1781807950111449?thread_ts=1781350550.709439&cid=C802R14UX

> Some updates. I'm currently running it in pilot mode (though submitting real reports). I do TLC-only reports for now. Not sure if it makes sense to do non-TLC parking stuff considering they are several days old anyway. At least, TLC would get their piece of punishment.
> There are some minor bugs and refactoring to do. I expect to put it to the original GitHub repo soon.