### PR TITLE
Restore 311 captcha woes popup with more details and copyable Slack thread URL

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -461,6 +461,10 @@ class Home extends React.Component {
   }
 
   componentDidMount() {
+    alert(
+      'Reported cannot currently create 311 Service Requests, so your submissions are not going very far at the moment. See here for details:\n\nhttps://reportedcab.slack.com/archives/C802R14UX/p1781350550709439',
+    );
+
     // if there's no attachments or a time couldn't be extracted, just use now
     if (this.state.attachmentData.length === 0 || !this.state.CreateDate) {
       this.setCreateDate({ millisecondsSinceEpoch: Date.now() });

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -461,8 +461,14 @@ class Home extends React.Component {
   }
 
   componentDidMount() {
-    alert(
-      'Reported cannot currently create 311 Service Requests, so your submissions are not going very far at the moment. See here for details:\n\nhttps://reportedcab.slack.com/archives/C802R14UX/p1781350550709439',
+    prompt(
+      [
+        'Reported is currently experiencing bugs creating 311 Service Requests (aka SRs).',
+        'Your SRs may be delayed, and the Previous Submissions section may not show SR numbers even once created.',
+        'We are continuing to work on getting things back to normal, and hope to fix these issues for previously created submissions.',
+        'See this Slack thread for details:',
+      ].join('\n\n'),
+      'https://reportedcab.slack.com/archives/C802R14UX/p1781890945008119?thread_ts=1781350550.709439&cid=C802R14UX',
     );
 
     // if there's no attachments or a time couldn't be extracted, just use now


### PR DESCRIPTION
The Slack thread URL, for reference: https://reportedcab.slack.com/archives/C802R14UX/p1781890945008119?thread_ts=1781350550.709439&cid=C802R14UX

* Reapply "Alert user that Reported can't create 311 Service Requests right now …" (#794)

  This reverts commit 52d18003e846c13707eeaec9ee2135e2e52b703a.
* Add details to 311 captcha woes popup, use `prompt()` instead of `alert()` to make URL more copyable