### PR TITLE
SubmissionDetails: Use `submission.reqnumber` as TLC SR if the joined `tasks` do not include a TLC task

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -32,6 +32,7 @@ class SubmissionDetails extends React.Component {
       timeofreport,
       reportDescription,
       status,
+      reqnumber,
 
       photoData,
       photoData0,
@@ -51,7 +52,7 @@ class SubmissionDetails extends React.Component {
     const tlcTask = (tasks || []).find(
       task => task.action === 'submit 311 complaint',
     );
-    const tlcCaseId = tlcTask && tlcTask.case_id;
+    const tlcCaseId = tlcTask && tlcTask.case_id || reqnumber;
 
     const nypdTask = (tasks || []).find(
       task => task.action === 'submit 311 illegal parking complaint',

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -52,7 +52,7 @@ class SubmissionDetails extends React.Component {
     const tlcTask = (tasks || []).find(
       task => task.action === 'submit 311 complaint',
     );
-    const tlcCaseId = tlcTask && tlcTask.case_id || reqnumber;
+    const tlcCaseId = (tlcTask && tlcTask.case_id) || reqnumber;
 
     const nypdTask = (tasks || []).find(
       task => task.action === 'submit 311 illegal parking complaint',
@@ -214,6 +214,7 @@ SubmissionDetails.propTypes = {
     timeofreport: PropTypes.string,
     reportDescription: PropTypes.string,
     status: PropTypes.number,
+    reqnumber: PropTypes.string,
 
     photoData: PropTypes.object,
     photoData0: PropTypes.object,

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -52,7 +52,7 @@ class SubmissionDetails extends React.Component {
     const tlcTask = (tasks || []).find(
       task => task.action === 'submit 311 complaint',
     );
-    const tlcCaseId = (tlcTask && tlcTask.case_id) || reqnumber;
+    const tlcCaseId = tlcTask ? tlcTask.case_id : reqnumber;
 
     const nypdTask = (tasks || []).find(
       task => task.action === 'submit 311 illegal parking complaint',

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -85,7 +85,6 @@ describe('SubmissionDetails', () => {
 
   test('renders delete button correctly', () => {
     const submission = {
-      reqnumber: 'reqnumber',
       medallionNo: 'medallionNo',
       state: 'licenseState',
       typeofcomplaint: 'typeofcomplaint',

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -141,6 +141,16 @@ exports[`SubmissionDetails renders children correctly 1`] = `
     82 Reade St
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
+    <br />
+    TLC Service Request Number:
+     
+    <a
+      href="https://portal.311.nyc.gov/sr-details/?srnum=reqnumber"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      reqnumber
+    </a>
   </summary>
   <p>
     reportDescription
@@ -215,25 +225,12 @@ exports[`SubmissionDetails renders children correctly 1`] = `
       src="videoData2"
     />
   </a>
-  <button
-    onClick={[Function]}
-    style={
-      {
-        "background": "white",
-        "color": "red",
-        "margin": "1px",
-      }
-    }
-    type="button"
-  >
-    <span
-      aria-label="Delete Submission"
-      role="img"
-    >
-      ❌
-    </span>
-    Delete Submission
-  </button>
+  <div>
+    <strong>
+      TLC Service Request:
+    </strong>
+    Loading Service Request Status...
+  </div>
 </details>
 `;
 
@@ -253,6 +250,16 @@ exports[`SubmissionDetails renders children correctly when medallionNo is missin
     82 Reade St
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
+    <br />
+    TLC Service Request Number:
+     
+    <a
+      href="https://portal.311.nyc.gov/sr-details/?srnum=reqnumber"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      reqnumber
+    </a>
   </summary>
   <p>
     reportDescription
@@ -327,25 +334,12 @@ exports[`SubmissionDetails renders children correctly when medallionNo is missin
       src="videoData2"
     />
   </a>
-  <button
-    onClick={[Function]}
-    style={
-      {
-        "background": "white",
-        "color": "red",
-        "margin": "1px",
-      }
-    }
-    type="button"
-  >
-    <span
-      aria-label="Delete Submission"
-      role="img"
-    >
-      ❌
-    </span>
-    Delete Submission
-  </button>
+  <div>
+    <strong>
+      TLC Service Request:
+    </strong>
+    Loading Service Request Status...
+  </div>
 </details>
 `;
 


### PR DESCRIPTION
See here for context: https://reportedcab.slack.com/archives/C802R14UX/p1781890945008119?thread_ts=1781350550.709439&cid=C802R14UX

> hey [@Nochkin](https://reportedcab.slack.com/team/U05FY34UMHU), does
> the new unpushed code you're currently running create Parse `tasks` like
> the old way did?
>
> I got an email from 311 around 2am today about an SR being created for
> `184 STERLING PLACE` , which was [the most recent submission I had
> made](https://backend.back4app.com/apps/932de73d-5214-4a3e-aec5-5c9be0055dac/browser/submission?filters=%5B%7B%22field%22%3A%22objectId%22%2C%22constraint%22%3A%22eq%22%2C%22compareTo%22%3A%22x9xlYoZKvs%22%7D%5D)
> (1st attachment), but I noticed that the webapp isn't showing the SR
> number like it used to (2nd attachment). The data for this is derived by
> "joining" the Parse `submission` objects to their `tasks` ([relevant JS
>         here](https://github.com/josephfrazier/reported-web/blob/52d18003e846c13707eeaec9ee2135e2e52b703a/src/server.js#L258-L294)),
> but when I go look at
> [the](https://backend.back4app.com/apps/932de73d-5214-4a3e-aec5-5c9be0055dac/browser/tasks)`tasks`[in
> Back4App](https://backend.back4app.com/apps/932de73d-5214-4a3e-aec5-5c9be0055dac/browser/tasks)
> and sort by `updatedAt` or `createdAt` descending, I don't see anything
> after June 13 (3rd and 4th attachments). I also don't see
> [any](https://backend.back4app.com/apps/932de73d-5214-4a3e-aec5-5c9be0055dac/browser/tasks?filters=%5B%7B%22field%22%3A%22submission%22%2C%22constraint%22%3A%22eq%22%2C%22compareTo%22%3A%7B%22__type%22%3A%22Pointer%22%2C%22className%22%3A%22submission%22%2C%22objectId%22%3A%22x9xlYoZKvs%22%7D%7D%5D)`tasks`[associated
> with
> that](https://backend.back4app.com/apps/932de73d-5214-4a3e-aec5-5c9be0055dac/browser/tasks?filters=%5B%7B%22field%22%3A%22submission%22%2C%22constraint%22%3A%22eq%22%2C%22compareTo%22%3A%7B%22__type%22%3A%22Pointer%22%2C%22className%22%3A%22submission%22%2C%22objectId%22%3A%22x9xlYoZKvs%22%7D%7D%5D)`submission`,
> whereas `submission`s created before the captcha changes have their
> `tasks`
>
> Let me know if I can help get this working again! I'd be happy to,
> just need to see the code we're now running.

https://reportedcab.slack.com/archives/C802R14UX/p1781893910344299?thread_ts=1781350550.709439&cid=C802R14UX:

> I don't create any tasks data. It does it on the fly and updates the
> actual report entry with status and Sr number. Let me know if it's a big
> hassle to change it on your side and you would prefer for me to create a
> task the old way. I could just create a task with Sr number and other
> minimum info to be backward compatible.

https://reportedcab.slack.com/archives/C802R14UX/p1781894353098759?thread_ts=1781350550.709439&cid=C802R14UX:

> Ok, that explains it. My first thought is that since a `submission` can
> have multiple SRs (TLC and NYPD), the `tasks` table continues to be a
> good way to keep track of both SRs. This is assuming we get the NYPD SR
> creation back in place, which I would like to do.

https://reportedcab.slack.com/archives/C802R14UX/p1781894426719899?thread_ts=1781350550.709439&cid=C802R14UX:

> Sounds good. I'll reimplement it.

https://reportedcab.slack.com/archives/C802R14UX/p1781894453116909?thread_ts=1781350550.709439&cid=C802R14UX
and https://reportedcab.slack.com/archives/C802R14UX/p1781894652613429?thread_ts=1781350550.709439&cid=C802R14UX:

> Thank you, and let me know if you'd like any help! Don't want all this work to fall on you if it doesn't have to
>
> I'll probably try to get the webapp to use the `submission`'s SR number
> as the TLC one if there's no `tasks` for the TLC submission, so that the
> `submission`s that were processed this way can have their TLC SRs back
> in the webapp UI without us having to go back and retroactively create
> `tasks` for them, don't wanna pile more work on.

https://reportedcab.slack.com/archives/C802R14UX/p1781895079847639?thread_ts=1781350550.709439&cid=C802R14UX:

> Yes, that's a good idea to use it as a fallback for now.