### PR TITLE
SubmissionDetails: Don't render `TLC Service Request Number` when `submission.reqnumber` is 'N/A until submitted to 311'

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -52,7 +52,9 @@ class SubmissionDetails extends React.Component {
     const tlcTask = (tasks || []).find(
       task => task.action === 'submit 311 complaint',
     );
-    const tlcCaseId = tlcTask ? tlcTask.case_id : reqnumber;
+    const tlcCaseId = tlcTask
+      ? tlcTask.case_id
+      : reqnumber !== 'N/A until submitted to 311' && reqnumber;
 
     const nypdTask = (tasks || []).find(
       task => task.action === 'submit 311 illegal parking complaint',

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -85,6 +85,7 @@ describe('SubmissionDetails', () => {
 
   test('renders delete button correctly', () => {
     const submission = {
+      reqnumber: 'N/A until submitted to 311',
       medallionNo: 'medallionNo',
       state: 'licenseState',
       typeofcomplaint: 'typeofcomplaint',

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -359,6 +359,16 @@ exports[`SubmissionDetails renders delete button correctly 1`] = `
     82 Reade St
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
+    <br />
+    TLC Service Request Number:
+     
+    <a
+      href="https://portal.311.nyc.gov/sr-details/?srnum=N/A until submitted to 311"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      N/A until submitted to 311
+    </a>
   </summary>
   <p>
     reportDescription

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -359,16 +359,6 @@ exports[`SubmissionDetails renders delete button correctly 1`] = `
     82 Reade St
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
-    <br />
-    TLC Service Request Number:
-     
-    <a
-      href="https://portal.311.nyc.gov/sr-details/?srnum=N/A until submitted to 311"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      N/A until submitted to 311
-    </a>
   </summary>
   <p>
     reportDescription


### PR DESCRIPTION
See here for context/details: https://reportedcab.slack.com/archives/C802R14UX/p1781896634770949?thread_ts=1781350550.709439&cid=C802R14UX

> > I'll probably try to get the webapp to use the `submission`'s SR number
> > as the TLC one if there's no `tasks` for the TLC submission
>
> Just released this fix as https://github.com/josephfrazier/reported-web/pull/796,
> which brought my TLC SR numbers back.
>
> It looks like I need another patch to not show the reqnumber when it's 
> `N/A until submitted to 311`, gonna work on that now