### PR TITLE
SubmissionDetails: Show separate `tasks` SR numbers again

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -32,7 +32,6 @@ class SubmissionDetails extends React.Component {
       timeofreport,
       reportDescription,
       status,
-      reqnumber,
 
       photoData,
       photoData0,
@@ -52,7 +51,7 @@ class SubmissionDetails extends React.Component {
     const tlcTask = (tasks || []).find(
       task => task.action === 'submit 311 complaint',
     );
-    const tlcCaseId = tlcTask ? tlcTask.case_id : reqnumber;
+    const tlcCaseId = tlcTask && tlcTask.case_id;
 
     const nypdTask = (tasks || []).find(
       task => task.action === 'submit 311 illegal parking complaint',
@@ -214,7 +213,6 @@ SubmissionDetails.propTypes = {
     timeofreport: PropTypes.string,
     reportDescription: PropTypes.string,
     status: PropTypes.number,
-    reqnumber: PropTypes.string,
 
     photoData: PropTypes.object,
     photoData0: PropTypes.object,

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -52,9 +52,7 @@ class SubmissionDetails extends React.Component {
     const tlcTask = (tasks || []).find(
       task => task.action === 'submit 311 complaint',
     );
-    const tlcCaseId = tlcTask
-      ? tlcTask.case_id
-      : reqnumber !== 'N/A until submitted to 311' && reqnumber;
+    const tlcCaseId = tlcTask ? tlcTask.case_id : reqnumber;
 
     const nypdTask = (tasks || []).find(
       task => task.action === 'submit 311 illegal parking complaint',

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -85,7 +85,6 @@ describe('SubmissionDetails', () => {
 
   test('renders delete button correctly', () => {
     const submission = {
-      reqnumber: 'N/A until submitted to 311',
       medallionNo: 'medallionNo',
       state: 'licenseState',
       typeofcomplaint: 'typeofcomplaint',

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -85,6 +85,7 @@ describe('SubmissionDetails', () => {
 
   test('renders delete button correctly', () => {
     const submission = {
+      reqnumber: 'reqnumber',
       medallionNo: 'medallionNo',
       state: 'licenseState',
       typeofcomplaint: 'typeofcomplaint',

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -141,16 +141,6 @@ exports[`SubmissionDetails renders children correctly 1`] = `
     82 Reade St
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
-    <br />
-    TLC Service Request Number:
-     
-    <a
-      href="https://portal.311.nyc.gov/sr-details/?srnum=reqnumber"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      reqnumber
-    </a>
   </summary>
   <p>
     reportDescription
@@ -225,12 +215,25 @@ exports[`SubmissionDetails renders children correctly 1`] = `
       src="videoData2"
     />
   </a>
-  <div>
-    <strong>
-      TLC Service Request:
-    </strong>
-    Loading Service Request Status...
-  </div>
+  <button
+    onClick={[Function]}
+    style={
+      {
+        "background": "white",
+        "color": "red",
+        "margin": "1px",
+      }
+    }
+    type="button"
+  >
+    <span
+      aria-label="Delete Submission"
+      role="img"
+    >
+      ❌
+    </span>
+    Delete Submission
+  </button>
 </details>
 `;
 
@@ -250,16 +253,6 @@ exports[`SubmissionDetails renders children correctly when medallionNo is missin
     82 Reade St
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
-    <br />
-    TLC Service Request Number:
-     
-    <a
-      href="https://portal.311.nyc.gov/sr-details/?srnum=reqnumber"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      reqnumber
-    </a>
   </summary>
   <p>
     reportDescription
@@ -334,12 +327,25 @@ exports[`SubmissionDetails renders children correctly when medallionNo is missin
       src="videoData2"
     />
   </a>
-  <div>
-    <strong>
-      TLC Service Request:
-    </strong>
-    Loading Service Request Status...
-  </div>
+  <button
+    onClick={[Function]}
+    style={
+      {
+        "background": "white",
+        "color": "red",
+        "margin": "1px",
+      }
+    }
+    type="button"
+  >
+    <span
+      aria-label="Delete Submission"
+      role="img"
+    >
+      ❌
+    </span>
+    Delete Submission
+  </button>
 </details>
 `;
 


### PR DESCRIPTION
The `tasks` are apparently being created again, see https://reportedcab.slack.com/archives/C802R14UX/p1782328067839199?thread_ts=1781350550.709439&cid=C802R14UX

> Oh. I got tasks populated actually since about a couple days ago. Forgot to
> mention it. Let me know how it looks or if I missed anything there.

---

Changes:

* Revert "SubmissionDetails: Don't render `TLC Service Request Number` when `submission.reqnumber` is 'N/A until submitted to 311' (#797)"

  This reverts commit c8df21e8f351382bfefad291af67a9d567e80de7, reversing
  changes made to 8564be867403200adfe02c0331225e2e981f8565.

* Revert "SubmissionDetails: Use `submission.reqnumber` as TLC SR if the joined `tasks` do not include a TLC task (#796)"

  This reverts commit 8564be867403200adfe02c0331225e2e981f8565.