### PR TITLE
SubmissionDetails: Don't use submission reqnumber when there's at least 1 task associated

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -54,7 +54,9 @@ class SubmissionDetails extends React.Component {
     );
     const tlcCaseId = tlcTask
       ? tlcTask.case_id
-      : reqnumber !== 'N/A until submitted to 311' && reqnumber;
+      : tasks.length === 0 &&
+        reqnumber !== 'N/A until submitted to 311' &&
+        reqnumber;
 
     const nypdTask = (tasks || []).find(
       task => task.action === 'submit 311 illegal parking complaint',

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -30,6 +30,8 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
+
+      tasks: [],
     };
 
     const wrapper = renderer
@@ -66,6 +68,8 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
+
+      tasks: [],
     };
 
     const wrapper = renderer
@@ -102,6 +106,8 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
+
+      tasks: [],
     };
 
     const wrapper = renderer


### PR DESCRIPTION
This builds on commit 8564be867403200adfe02c0331225e2e981f8565 (https://github.com/josephfrazier/reported-web/pull/796)
by handling the case where there's no TLC task, but there is an NYPD
task. Previously, because there was no TLC task, we would display the
reqnumber as the "TLC" Service Request number, when in fact it can now
be the NYPD SR number, based on the https://github.com/jeffrono/Reported/
changes that Nochkin is making. See here for details: https://reportedcab.slack.com/archives/C802R14UX/p1782328067839199?thread_ts=1781350550.709439&cid=C802R14UX

Nochkin:

> Oh. I got tasks populated actually since about a couple days ago. Forgot to mention it. Let me know how it looks or if I missed anything there.

Me:

> Oh, I hadn't noticed! My webapp is still showing "TLC Service Request Number" for non-TLC plates, but maybe that's a bug on my end. Let me take a closer look...