### PR TITLE
SubmissionDetails: Fix "white screen of death" after completing submission by making `tasks` optional

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -54,7 +54,9 @@ class SubmissionDetails extends React.Component {
     );
     const tlcCaseId = tlcTask
       ? tlcTask.case_id
-      : reqnumber !== 'N/A until submitted to 311' && reqnumber;
+      : tasks.length === 0 &&
+        reqnumber !== 'N/A until submitted to 311' &&
+        reqnumber;
 
     const nypdTask = (tasks || []).find(
       task => task.action === 'submit 311 illegal parking complaint',

--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -54,7 +54,7 @@ class SubmissionDetails extends React.Component {
     );
     const tlcCaseId = tlcTask
       ? tlcTask.case_id
-      : tasks.length === 0 &&
+      : tasks?.length === 0 &&
         reqnumber !== 'N/A until submitted to 311' &&
         reqnumber;
 

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -30,6 +30,8 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
+
+      tasks: [],
     };
 
     const wrapper = renderer
@@ -66,6 +68,8 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
+
+      tasks: [],
     };
 
     const wrapper = renderer
@@ -102,6 +106,8 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
+
+      tasks: [],
     };
 
     const wrapper = renderer

--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -30,8 +30,6 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
-
-      tasks: [],
     };
 
     const wrapper = renderer
@@ -68,8 +66,6 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
-
-      tasks: [],
     };
 
     const wrapper = renderer
@@ -106,8 +102,6 @@ describe('SubmissionDetails', () => {
       videoData0: 'videoData0',
       videoData1: 'videoData1',
       videoData2: 'videoData2',
-
-      tasks: [],
     };
 
     const wrapper = renderer

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -141,16 +141,6 @@ exports[`SubmissionDetails renders children correctly 1`] = `
     82 Reade St
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
-    <br />
-    TLC Service Request Number:
-     
-    <a
-      href="https://portal.311.nyc.gov/sr-details/?srnum=reqnumber"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      reqnumber
-    </a>
   </summary>
   <p>
     reportDescription
@@ -225,12 +215,25 @@ exports[`SubmissionDetails renders children correctly 1`] = `
       src="videoData2"
     />
   </a>
-  <div>
-    <strong>
-      TLC Service Request:
-    </strong>
-    Loading Service Request Status...
-  </div>
+  <button
+    onClick={[Function]}
+    style={
+      {
+        "background": "white",
+        "color": "red",
+        "margin": "1px",
+      }
+    }
+    type="button"
+  >
+    <span
+      aria-label="Delete Submission"
+      role="img"
+    >
+      ❌
+    </span>
+    Delete Submission
+  </button>
 </details>
 `;
 
@@ -250,16 +253,6 @@ exports[`SubmissionDetails renders children correctly when medallionNo is missin
     82 Reade St
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
-    <br />
-    TLC Service Request Number:
-     
-    <a
-      href="https://portal.311.nyc.gov/sr-details/?srnum=reqnumber"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      reqnumber
-    </a>
   </summary>
   <p>
     reportDescription
@@ -334,12 +327,25 @@ exports[`SubmissionDetails renders children correctly when medallionNo is missin
       src="videoData2"
     />
   </a>
-  <div>
-    <strong>
-      TLC Service Request:
-    </strong>
-    Loading Service Request Status...
-  </div>
+  <button
+    onClick={[Function]}
+    style={
+      {
+        "background": "white",
+        "color": "red",
+        "margin": "1px",
+      }
+    }
+    type="button"
+  >
+    <span
+      aria-label="Delete Submission"
+      role="img"
+    >
+      ❌
+    </span>
+    Delete Submission
+  </button>
 </details>
 `;
 


### PR DESCRIPTION
The Home.js code concats the `submission` object onto the front of `this.state.submissions`,
and `submission` doesn't have a `tasks` property,
so allow it to be missing in order to avoid rendering bugs.