### PR TITLE
Revert "Restore 311 captcha woes popup with more details and copyable Slack thread URL"

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -457,16 +457,6 @@ class Home extends React.Component {
   }
 
   componentDidMount() {
-    prompt(
-      [
-        'Reported is currently experiencing bugs creating 311 Service Requests (aka SRs).',
-        'Your SRs may be delayed, and the Previous Submissions section may not show SR numbers even once created.',
-        'We are continuing to work on getting things back to normal, and hope to fix these issues for previously created submissions.',
-        'See this Slack thread for details:',
-      ].join('\n\n'),
-      'https://reportedcab.slack.com/archives/C802R14UX/p1781890945008119?thread_ts=1781350550.709439&cid=C802R14UX',
-    );
-
     // if there's no attachments or a time couldn't be extracted, just use now
     if (this.state.attachmentData.length === 0 || !this.state.CreateDate) {
       this.setCreateDate({ millisecondsSinceEpoch: Date.now() });


### PR DESCRIPTION
Reverts https://github.com/josephfrazier/reported-web/pull/795 (commit a6efba3c95c09080c035b9224c935ec32e146d04), now that things seem to be working as usual again, see https://reportedcab.slack.com/archives/C802R14UX/p1782408648584119?thread_ts=1781350550.709439&cid=C802R14UX:

> I [see](https://backend.back4app.com/apps/932de73d-5214-4a3e-aec5-5c9be0055dac/browser/tasks?filters=%5B%7B%22field%22%3A%22createdAt%22%2C%22constraint%22%3A%22after%22%2C%22compareTo%22%3A%7B%22__type%22%3A%22Date%22%2C%22iso%22%3A%222026-06-13T14%3A11%3A59.473Z%22%7D%7D%5D) the NYPD task creation is happening again, with both TLC and NYPD tasks being created for the same submission, thanks Nochkin!
> 
> <img width="2464" height="408" alt="image" src="https://github.com/user-attachments/assets/0df8b5d2-3879-421f-8732-eff262607659" />
