### PR TITLE
Inline `heroku-self-ping` functionality to remove vulnerable `form-data`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "geodist": "^0.2.1",
     "geolib": "^2.0.24",
     "global": "^4.3.2",
-    "heroku-self-ping": "^2.0.1",
     "history": "^4.7.2",
     "humanize-distance": "^1.0.9",
     "image-extensions": "^1.1.0",

--- a/src/server.js
+++ b/src/server.js
@@ -57,9 +57,25 @@ const {
   PLATERECOGNIZER_TOKEN_TWO,
 } = process.env;
 
-require('heroku-self-ping').default(config.api.serverUrl, {
-  verbose: true,
-});
+// Ping the app periodically to prevent Heroku eco tier dyno from sleeping
+const herokuSelfPingUrl = config.api.serverUrl;
+const herokuSelfPingInterval = 20 * 60 * 1000; // 20 minutes
+const herokuSelfPing = () => {
+  console.log(`Pinging ${herokuSelfPingUrl}...`);
+  nodeFetch(herokuSelfPingUrl)
+    .then(res => {
+      if (res.ok) {
+        console.log('herokuSelfPing successful');
+      } else {
+        console.error(`herokuSelfPing failed with status ${res.status}`);
+      }
+    })
+    .catch(err => {
+      console.error('herokuSelfPing failed:', err.message);
+    });
+};
+herokuSelfPing(); // ping immediately on startup
+setInterval(herokuSelfPing, herokuSelfPingInterval);
 
 // http://docs.parseplatform.org/js/guide/#getting-started
 Parse.initialize(PARSE_APP_ID, PARSE_JAVASCRIPT_KEY, PARSE_MASTER_KEY);

--- a/src/server.js
+++ b/src/server.js
@@ -58,24 +58,31 @@ const {
 } = process.env;
 
 // Ping the app periodically to prevent Heroku eco tier dyno from sleeping
-const herokuSelfPingUrl = config.api.serverUrl;
-const herokuSelfPingInterval = 20 * 60 * 1000; // 20 minutes
-const herokuSelfPing = () => {
-  console.info(`Pinging ${herokuSelfPingUrl}...`);
-  nodeFetch(herokuSelfPingUrl)
-    .then(res => {
-      if (res.ok) {
-        console.info('herokuSelfPing successful');
-      } else {
-        console.warn(`herokuSelfPing failed with status ${res.status}`);
-      }
-    })
-    .catch(err => {
-      console.error('herokuSelfPing failed:', err.message);
-    });
-};
-herokuSelfPing(); // ping immediately on startup
-setInterval(herokuSelfPing, herokuSelfPingInterval);
+// Only runs on Heroku (same detection logic as heroku-self-ping)
+const isHeroku =
+  'HEROKU' in process.env ||
+  ('DYNO' in process.env && process.env.HOME === '/app');
+
+if (isHeroku) {
+  const herokuSelfPingUrl = config.api.serverUrl;
+  const herokuSelfPingInterval = 20 * 60 * 1000; // 20 minutes
+  const herokuSelfPing = () => {
+    console.info(`Pinging ${herokuSelfPingUrl}...`);
+    nodeFetch(herokuSelfPingUrl)
+      .then(res => {
+        if (res.ok) {
+          console.info('herokuSelfPing successful');
+        } else {
+          console.warn(`herokuSelfPing failed with status ${res.status}`);
+        }
+      })
+      .catch(err => {
+        console.error('herokuSelfPing failed:', err.message);
+      });
+  };
+  herokuSelfPing(); // ping immediately on startup
+  setInterval(herokuSelfPing, herokuSelfPingInterval);
+}
 
 // http://docs.parseplatform.org/js/guide/#getting-started
 Parse.initialize(PARSE_APP_ID, PARSE_JAVASCRIPT_KEY, PARSE_MASTER_KEY);

--- a/src/server.js
+++ b/src/server.js
@@ -61,13 +61,13 @@ const {
 const herokuSelfPingUrl = config.api.serverUrl;
 const herokuSelfPingInterval = 20 * 60 * 1000; // 20 minutes
 const herokuSelfPing = () => {
-  console.log(`Pinging ${herokuSelfPingUrl}...`);
+  console.info(`Pinging ${herokuSelfPingUrl}...`);
   nodeFetch(herokuSelfPingUrl)
     .then(res => {
       if (res.ok) {
-        console.log('herokuSelfPing successful');
+        console.info('herokuSelfPing successful');
       } else {
-        console.error(`herokuSelfPing failed with status ${res.status}`);
+        console.warn(`herokuSelfPing failed with status ${res.status}`);
       }
     })
     .catch(err => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3792,11 +3792,6 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
-component-emitter@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
-
 compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
@@ -3897,11 +3892,6 @@ cookie@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
-
-cookiejar@^2.1.2:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
-  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 core-js-compat@^3.48.0:
   version "3.48.0"
@@ -5272,11 +5262,6 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-safe-stringify@^2.0.7:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
-  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
-
 fast-uri@^3.0.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
@@ -5571,15 +5556,6 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     semver "^7.3.2"
     tapable "^1.0.0"
 
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
 form-data@^4.0.5, form-data@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
@@ -5590,11 +5566,6 @@ form-data@^4.0.5, form-data@^4.0.6:
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.4"
     mime-types "^2.1.35"
-
-formidable@^1.2.2:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.6.tgz#d2a51d60162bbc9b4a055d8457a7c75315d1a168"
-  integrity sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -5976,14 +5947,6 @@ hasown@^2.0.3:
   integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
   dependencies:
     function-bind "^1.1.2"
-
-heroku-self-ping@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/heroku-self-ping/-/heroku-self-ping-2.0.1.tgz#6a4f6a79383f9cdde3488b899fe7507cb6b10746"
-  integrity sha512-L4G+nsJ2znW6aTXclwcNUvI/E7az/sLAlH5monP3MeFgpl2eGbcysKRp52HBFPQFsqW74LXaXtxTEdlZsKVTsA==
-  dependencies:
-    is-heroku "^2.0.0"
-    superagent "^5.2.2"
 
 history@^4.7.2:
   version "4.10.1"
@@ -6491,11 +6454,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-heroku@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-heroku/-/is-heroku-2.0.0.tgz#6482d1e861435103ae9f69e66f9bd28eb4ea0bca"
-  integrity sha512-c4vHXwxwfIZlKOEAyk25XICIfKlqWwYct+2zt1IQfpn2qt6SNqTp41QabAUN5B9JJMj6WQ7prN4HeM2KUF/gKw==
 
 is-map@^2.0.3:
   version "2.0.3"
@@ -7803,7 +7761,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@^1.1.2, methods@~1.1.2:
+methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -7839,7 +7797,7 @@ mime-db@^1.54.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34, mime-types@~2.1.35:
+mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34, mime-types@~2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7857,11 +7815,6 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-
-mime@^2.4.6:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
-  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
@@ -9286,7 +9239,7 @@ qs@^6.14.0, qs@^6.14.1:
   dependencies:
     side-channel "^1.1.0"
 
-qs@^6.9.4, qs@~6.14.0:
+qs@~6.14.0:
   version "6.14.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
   integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
@@ -10761,23 +10714,6 @@ stylis@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
-
-superagent@^5.2.2:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.3.1.tgz#d62f3234d76b8138c1320e90fa83dc1850ccabf1"
-  integrity sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==
-  dependencies:
-    component-emitter "^1.3.0"
-    cookiejar "^2.1.2"
-    debug "^4.1.1"
-    fast-safe-stringify "^2.0.7"
-    form-data "^3.0.0"
-    formidable "^1.2.2"
-    methods "^1.1.2"
-    mime "^2.4.6"
-    qs "^6.9.4"
-    readable-stream "^3.6.0"
-    semver "^7.3.2"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
"form-data uses unsafe random function in form-data for choosing boundary",
see https://github.com/josephfrazier/reported-web/security/dependabot/257

> Transitive dependency form-data 3.0.1 is introduced via
>
>     heroku-self-ping 2.0.1 > ... > form-data 3.0.1

and heroku-self-ping hasn't been updated in 6 years, so let's just
inline it since it's small.

Alternatively, we could upgrade from Heroku eco to basic for $2 more a
month, see https://devcenter.heroku.com/articles/dyno-tiers#eco-tier
But I didn't feel like doing that, on principle.

I was lazy and did this with the help of an LLM, see https://chat.deepseek.com/share/xh73u4mv68228jiiwa