### PR TITLE
Use `express.urlencoded` and `express.json` instead of `body-parser` directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "axios": "^1.16.0",
     "axios-retry": "^3.4.0",
     "blob-util": "^2.0.2",
-    "body-parser": "^1.20.3",
     "buffer": "^6.0.3",
     "buffer-to-arraybuffer": "^0.0.6",
     "capitalize": "^2.0.4",

--- a/src/server.js
+++ b/src/server.js
@@ -12,7 +12,6 @@ import assert from 'assert';
 import express from 'express';
 import forceSsl from 'force-ssl-heroku';
 import compression from 'compression';
-import bodyParser from 'body-parser';
 import nodeFetch from 'node-fetch';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
@@ -135,9 +134,9 @@ app.set('trust proxy', config.trustProxy);
 // Register Node.js middleware
 // -----------------------------------------------------------------------------
 app.use(express.static(path.resolve(__dirname, 'public')));
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json({ limit: '80mb' }));
-// attachments are no longer sent as base64 JSON, but bodyParser still tries to parse non-JSON bodies, so this 80mb `limit` needs to be here to avoid errors
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json({ limit: '80mb' }));
+// attachments are no longer sent as base64 JSON, but express's internal usage of `body-parser` still tries to parse non-JSON bodies, so this 80mb `limit` needs to be here to avoid errors
 
 const handlePromiseRejection = res => error => {
   console.error({ error });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,7 +3337,7 @@ blob-util@^2.0.2:
   resolved "https://registry.yarnpkg.com/blob-util/-/blob-util-2.0.2.tgz#3b4e3c281111bb7f11128518006cdc60b403a1eb"
   integrity sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==
 
-body-parser@^1.20.3, body-parser@~1.20.3:
+body-parser@~1.20.3:
   version "1.20.4"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.4.tgz#f8e20f4d06ca8a50a71ed329c15dccad1cdc547f"
   integrity sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==


### PR DESCRIPTION
See https://stackoverflow.com/questions/55558402/what-is-the-meaning-of-bodyparser-urlencoded-extended-true-and-bodypar/67270036#67270036:

> In Express >= 4.16, body parser has been re-added under the methods
> express.json(). The replacement for the above question is
>
>     const express = require("express");
>     const app = express();
>     app.use(express.json());
>     app.use(express.urlencoded({ extended: true }));
>
> The extended option allows to choose between parsing the URL-encoded
> data with the querystring library (when false) or the qs library (when
> true). The “extended” syntax allows for rich objects and arrays
> to be encoded into the URL-encoded format, allowing for a JSON-like
> experience with URL-encoded. For more information, please see the qs
> library here.
>
> Defaults to true, but using the default has been deprecated. Please
> research into the difference between qs and querystring and choose the
> appropriate setting.

For context, I happened across this while debugging a few `Unexpected
end of form` errors that have come up recently, see https://reportedcab.slack.com/archives/C9VNM3DL4/p1784065376396739?thread_ts=1783902255.721759&cid=C9VNM3DL4

Github Copilot led me to believe the `body-parser` usage might be
related, see https://github.com/josephfrazier/reported-web/tasks/46fc1ea7-4b56-433e-ad1b-ecbbc8cc4c43?author=josephfrazier&q=is%3Aopen

(I don't think this commit fixes the issue as described below, but may
as well clean up along the way)

> Yes, body-parser is very likely contributing to the "unexpected end of form" error.
>
> Here's why:
>
> bodyParser.urlencoded and bodyParser.json are registered as global
> middleware (lines 144–145), meaning they run on every request —
> including multipart form uploads destined for multer.
>
> When a multipart request comes in:
>
> 1. bodyParser.urlencoded sees it and, because it's not
>    application/x-www-form-urlencoded, it passes through — but it may
>    read/buffer part of the request stream in the process.
> 2. bodyParser.json similarly peeks or buffers the stream looking for
>    JSON.
> 3. By the time multer/busboy tries to parse the multipart body, the
>    underlying request stream has already been partially or fully
>    consumed, causing busboy to see an incomplete form and throw
>    "unexpected end of form".
>
> This is a well-known Express pitfall: body-parser doesn't know to skip
> multipart/form-data content types entirely — depending on the version
> and implementation, it may still consume or disturb the stream.
>
> The fix would be to either:
>
> * Add a Content-Type check so the bodyParser middleware skips
>   multipart/form-data requests explicitly, e.g.:
>
>       app.use((req, res, next) => {
>         if (req.is('multipart/form-data')) return next();
>         bodyParser.urlencoded({ extended: true })(req, res, next);
>       });
>
> * Or move the bodyParser registration to only apply to specific
>   non-multipart routes rather than globally.
>
> The comment on line 146 ("bodyParser still tries to parse non-JSON
> bodies") already hints at the dev being aware of body-parser misbehaving
> with unexpected content types — this is likely the same root cause
> manifesting for multipart bodies too.