### PR TITLE
Add Safari/iOS note to `Unexpected end of form` error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ yarn dashboard # Runs a dashboard for the Parse server
 yarn mongo-stop # Stops MongoDB
 ```
 
+## `Unexpected end of form` errors
+
+These have been seen a few times from a couple users, seemingly limited to iOS, but on both Safari and Chrome.
+Chrome on iOS has worked at least once for an affected user, but not consistently.
+So far, my recommendation for this error is to use a non-iOS device.
+
 ## Context on `localStorage` use (w.r.t performance concerns about lag/delay/slowness/latency when typing)
 
 Over the years, reports of slow typing have come from multiple users, and it periodically gets (re)discussed in our Slack.

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -365,7 +365,16 @@ class Home extends React.Component {
   static handleAxiosError(error) {
     return Promise.reject(error)
       .catch(err => {
-        Home.notifyError(`Error: ${err.response.data.error.message}`);
+        const { message } = err.response.data.error;
+
+        const isEndOfForm = message === 'Unexpected end of form';
+        const addendum = isEndOfForm
+          ? '(Safari/iOS might be causing this, try a different browser/device)'
+          : '';
+
+        Home.notifyError(
+          `Error: ${err.response.data.error.message} ${addendum}`,
+        );
       })
       .catch(err => {
         console.error(err);


### PR DESCRIPTION
See here for more context: https://reportedcab.slack.com/archives/C9VNM3DL4/p1784061711619539?thread_ts=1783902255.721759&cid=C9VNM3DL4