### PR TITLE
fix: explicitly pass objectId from /submit to fix deleting just-created submission

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -539,6 +539,12 @@ class Home extends React.Component {
   }
 
   onDeleteSubmission = ({ objectId }) => {
+    if (!objectId) {
+      Home.notifyError(
+        'Unable to delete this submission — no objectId available. Try reloading the page and loading previous submissions to get the server-assigned ID.',
+      );
+      return;
+    }
     const confirmationMessage = `Are you sure you want to delete this submission? (objectId: ${objectId})`;
     // eslint-disable-next-line no-alert
     if (!window.confirm(confirmationMessage)) {
@@ -555,6 +561,9 @@ class Home extends React.Component {
             sub => sub.objectId !== objectId,
           ),
         }));
+      })
+      .catch(error => {
+        Home.handleAxiosError(error);
       });
   };
 

--- a/src/server.js
+++ b/src/server.js
@@ -520,6 +520,9 @@ app.use('/submit', (req, res) => {
         const submissionValue = submission.toJSON();
         submissionValue.timeofreport = submissionValue.timeofreport.iso;
         submissionValue.timeofreported = submissionValue.timeofreported.iso;
+        // Explicitly include objectId so the client can pass it
+        // back for delete/cancel operations (see #788)
+        submissionValue.objectId = submission.id;
 
         console.info({ submission: submissionValue });
 


### PR DESCRIPTION
fixes https://github.com/josephfrazier/reported-web/issues/788

I did this via Claude Code with model `deepseek-v4-pro[1m]` with the
following prompt:

> see if you can fix this issue, I htink it has to do with the /submit
> endpoint either not returning, or the client not parsing, the objectId
> from the new Parse submission, so the delete call has nothing to pass
> back to the server: https://github.com/josephfrazier/reported-web/issues/788

Here's the commit message it wrote when prompted: "write a commit message for this fix, but do not commit"

> The /submit endpoint relied on Parse's `toJSON()` to include `objectId`
> in the response, but this is an SDK implementation detail. If `this.id`
> wasn't populated after save (timing, response format, etc.), the client
> received a submission with no `objectId`, making it impossible to call
> `/api/deleteSubmission` to cancel the report.
>
> - Server: explicitly set `submissionValue.objectId = submission.id` in
>   the /submit response, matching how the /submissions endpoint already
>   includes it.
> - Client: guard against missing `objectId` in `onDeleteSubmission` with
>   a clear error notification instead of silently sending `undefined`.
> - Client: add missing `.catch()` on the delete API call so errors are
>   surfaced to the user.