### PR TITLE
fix: add id attributes to checkbox inputs so clicking label text works

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1268,6 +1268,7 @@ class Home extends React.Component {
                   </label>
                   <label htmlFor="testify">
                     <input
+                      id="testify"
                       type="checkbox"
                       checked={this.state.testify}
                       name="testify"
@@ -1502,6 +1503,7 @@ class Home extends React.Component {
 
                 <label htmlFor="isAlprEnabled">
                   <input
+                    id="isAlprEnabled"
                     type="checkbox"
                     checked={this.state.isAlprEnabled}
                     name="isAlprEnabled"
@@ -1512,6 +1514,7 @@ class Home extends React.Component {
 
                 <label htmlFor="isReverseGeocodingEnabled">
                   <input
+                    id="isReverseGeocodingEnabled"
                     type="checkbox"
                     checked={this.state.isReverseGeocodingEnabled}
                     name="isReverseGeocodingEnabled"
@@ -1760,6 +1763,7 @@ class Home extends React.Component {
 
                 <label htmlFor="can_be_shared_publicly">
                   <input
+                    id="can_be_shared_publicly"
                     type="checkbox"
                     checked={this.state.can_be_shared_publicly}
                     name="can_be_shared_publicly"
@@ -1832,6 +1836,7 @@ class Home extends React.Component {
                         style={{ display: 'block', marginBottom: '1rem' }}
                       >
                         <input
+                          id="isLoadPreviousSubmissionsEnabled"
                           type="checkbox"
                           checked={this.state.isLoadPreviousSubmissionsEnabled}
                           name="isLoadPreviousSubmissionsEnabled"

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -171,6 +171,7 @@ exports[`Home renders children correctly 1`] = `
             >
               <input
                 checked={false}
+                id="testify"
                 name="testify"
                 onChange={[Function]}
                 type="checkbox"
@@ -245,6 +246,7 @@ exports[`Home renders children correctly 1`] = `
           >
             <input
               checked={true}
+              id="isAlprEnabled"
               name="isAlprEnabled"
               onChange={[Function]}
               type="checkbox"
@@ -257,6 +259,7 @@ exports[`Home renders children correctly 1`] = `
           >
             <input
               checked={true}
+              id="isReverseGeocodingEnabled"
               name="isReverseGeocodingEnabled"
               onChange={[Function]}
               type="checkbox"
@@ -675,6 +678,7 @@ exports[`Home renders children correctly 1`] = `
           >
             <input
               checked={false}
+              id="can_be_shared_publicly"
               name="can_be_shared_publicly"
               onChange={[Function]}
               type="checkbox"


### PR DESCRIPTION
Done via Claude Code with `deepseek-v4-pro[1m]` with prompt:

> different bug now: clicking the text beside a checkbox doesn't toggle it, but I think I have the label set up properly. What's going on, and can you fix it?

Here's the commit message it came up with:

> The checkbox labels used `htmlFor="name"` but the inputs only had a
> `name` attribute, no `id`. The `htmlFor` attribute references an
> element's `id`, not `name`, so the explicit label-input association was
> a no-op. Implicit association (input nested inside label) can fail when
> intervening JSX whitespace nodes or parent event handlers interfere with
> browser label-content detection.
>
> Added matching `id` attributes to all five checkbox inputs: testify,
> isAlprEnabled, isReverseGeocodingEnabled, can_be_shared_publicly, and
> isLoadPreviousSubmissionsEnabled.