### PR TITLE
.gitignore Claude Code settings (credentials)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ yarn-error.log*
 logs
 
 # Editors and IDEs
+.claude/settings.local.json
 .idea
 .vscode/*
 !.vscode/settings.json


### PR DESCRIPTION
These are in the repo directory so tools like Docker Sandbox (`sbx`)
work more seamlessly, but I obviously don't want to share my API
token, so let's ignore that file.