### PR TITLE
chore: upgrade eslint-plugin-css-modules to 2.12.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4876,11 +4876,11 @@ eslint-module-utils@^2.12.1:
     debug "^3.2.7"
 
 eslint-plugin-css-modules@^2.9.1:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.11.0.tgz#8de4d01d523a2d51c03043fa8004aab6b6cf3b1a"
-  integrity sha512-CLvQvJOMlCywZzaI4HVu7QH/ltgNXvCg7giJGiE+sA9wh5zQ+AqTgftAzrERV22wHe1p688wrU/Zwxt1Ry922w==
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-css-modules/-/eslint-plugin-css-modules-2.12.0.tgz#c4102c390c7efd68c4d53677c5e763971699322c"
+  integrity sha512-ruFBdad69ABrbCDCh5mXj7UzNmrvytfzPACjyvZWIAjFZAG8BXpYSbqmE8gU5wF+pIzV3jU2CWhLvfekXT/IgQ==
   dependencies:
-    gonzales-pe "^4.0.3"
+    gonzales-pe "^4.3.0"
     lodash "^4.17.2"
 
 eslint-plugin-flowtype@^8.0.3:
@@ -5784,7 +5784,7 @@ globjoin@^0.1.4:
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
 
-gonzales-pe@^4.0.3:
+gonzales-pe@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.3.0.tgz#fe9dec5f3c557eead09ff868c65826be54d067b3"
   integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==


### PR DESCRIPTION
While working on https://github.com/josephfrazier/reported-web/pull/831, I noticed that `yarn lint` wasn't finishing
(https://github.com/josephfrazier/reported-web/actions/runs/29665830448/job/88135966043?pr=831)
and tracked it down to eslint. Here's what claude/deepseek found after
some debugging:

> The eslint-plugin-css-modules no-unused-class and no-undef-class rules
> hang (infinite loop) when processing CSS files that contain composes
> directives with kebab-case class names (e.g. composes: status-bar-btn).
> The interaction between the two rules causes them to loop forever while
> resolving the composed class chain. This affects any JS file that
> imports Home.css.
>
> The debugging approach that cracked it:
>
> 1. Confirmed the hang — --debug showed it stopped after "Scope analysis successful", never reaching "Generating fixed text"
> 2. Ruled out autofix loops — --no-fix still hung
> 3. Isolated to a specific plugin — disabling css-modules/no-unused-class + css-modules/no-undef-class together fixed it, but neither alone did
> 4. Found all affected files — scripted eslint against every .js file individually with a timeout, revealing PlatePickerModal.js also hung
> 5. Identified the common factor — both files import Home.css, which has the new composes directives with kebab-case names

Thankfully, I noticed that the `eslint-plugin-css-modules` dependency
had an upgrade available, and that fixes it.