### PR TITLE
Reset submission state when all photos are removed

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1477,10 +1477,18 @@ class Home extends React.Component {
                                   plateThumbnailsByKey: {},
                                   vehicleInfoComponent: null,
                                   violationSummaryComponent: null,
+                                  CreateDate: jsDateToCreateDate(new Date()),
+                                  formatted_address: '',
                                 };
                               }
                               return { attachmentData };
                             });
+                            if (this.state.attachmentData.length === 1) {
+                              this.setCoords({
+                                latitude: defaultLatitude,
+                                longitude: defaultLongitude,
+                              });
+                            }
                           }}
                         >
                           <span role="img" aria-label="Delete photo/video">

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1463,32 +1463,37 @@ class Home extends React.Component {
                             background: 'white',
                           }}
                           onClick={() => {
-                            this.setState(state => {
-                              const attachmentData =
-                                state.attachmentData.filter(
-                                  file => file.name !== name,
-                                );
-                              if (attachmentData.length === 0) {
-                                return {
-                                  attachmentData,
-                                  plate: '',
-                                  licenseState: 'NY',
-                                  allPlateResults: [],
-                                  plateThumbnailsByKey: {},
-                                  vehicleInfoComponent: null,
-                                  violationSummaryComponent: null,
-                                  CreateDate: jsDateToCreateDate(new Date()),
-                                  formatted_address: '',
-                                };
-                              }
-                              return { attachmentData };
-                            });
-                            if (this.state.attachmentData.length === 1) {
-                              this.setCoords({
-                                latitude: defaultLatitude,
-                                longitude: defaultLongitude,
-                              });
-                            }
+                            const wasLastPhoto =
+                              this.state.attachmentData.length === 1;
+                            this.setState(
+                              state => {
+                                const attachmentData =
+                                  state.attachmentData.filter(
+                                    file => file.name !== name,
+                                  );
+                                if (attachmentData.length === 0) {
+                                  return {
+                                    attachmentData,
+                                    plate: '',
+                                    licenseState: 'NY',
+                                    allPlateResults: [],
+                                    plateThumbnailsByKey: {},
+                                    vehicleInfoComponent: null,
+                                    violationSummaryComponent: null,
+                                    CreateDate: jsDateToCreateDate(new Date()),
+                                  };
+                                }
+                                return { attachmentData };
+                              },
+                              () => {
+                                if (wasLastPhoto) {
+                                  this.setCoords({
+                                    latitude: defaultLatitude,
+                                    longitude: defaultLongitude,
+                                  });
+                                }
+                              },
+                            );
                           }}
                         >
                           <span role="img" aria-label="Delete photo/video">

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1463,31 +1463,29 @@ class Home extends React.Component {
                             background: 'white',
                           }}
                           onClick={() => {
-                            this.setState(
-                              state => {
-                                const attachmentData =
-                                  state.attachmentData.filter(
-                                    file => file.name !== name,
-                                  );
-                                if (attachmentData.length === 0) {
-                                  this.setCoords({
-                                    latitude: defaultLatitude,
-                                    longitude: defaultLongitude,
-                                  });
-                                  return {
-                                    attachmentData,
-                                    plate: '',
-                                    licenseState: 'NY',
-                                    allPlateResults: [],
-                                    plateThumbnailsByKey: {},
-                                    vehicleInfoComponent: null,
-                                    violationSummaryComponent: null,
-                                    CreateDate: jsDateToCreateDate(new Date()),
-                                  };
-                                }
-                                return { attachmentData };
-                              },
-                            );
+                            this.setState(state => {
+                              const attachmentData =
+                                state.attachmentData.filter(
+                                  file => file.name !== name,
+                                );
+                              if (attachmentData.length === 0) {
+                                this.setCoords({
+                                  latitude: defaultLatitude,
+                                  longitude: defaultLongitude,
+                                });
+                                return {
+                                  attachmentData,
+                                  plate: '',
+                                  licenseState: 'NY',
+                                  allPlateResults: [],
+                                  plateThumbnailsByKey: {},
+                                  vehicleInfoComponent: null,
+                                  violationSummaryComponent: null,
+                                  CreateDate: jsDateToCreateDate(new Date()),
+                                };
+                              }
+                              return { attachmentData };
+                            });
                           }}
                         >
                           <span role="img" aria-label="Delete photo/video">

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1463,8 +1463,6 @@ class Home extends React.Component {
                             background: 'white',
                           }}
                           onClick={() => {
-                            const wasLastPhoto =
-                              this.state.attachmentData.length === 1;
                             this.setState(
                               state => {
                                 const attachmentData =
@@ -1472,6 +1470,10 @@ class Home extends React.Component {
                                     file => file.name !== name,
                                   );
                                 if (attachmentData.length === 0) {
+                                  this.setCoords({
+                                    latitude: defaultLatitude,
+                                    longitude: defaultLongitude,
+                                  });
                                   return {
                                     attachmentData,
                                     plate: '',
@@ -1484,14 +1486,6 @@ class Home extends React.Component {
                                   };
                                 }
                                 return { attachmentData };
-                              },
-                              () => {
-                                if (wasLastPhoto) {
-                                  this.setCoords({
-                                    latitude: defaultLatitude,
-                                    longitude: defaultLongitude,
-                                  });
-                                }
                               },
                             );
                           }}

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1473,6 +1473,9 @@ class Home extends React.Component {
                                   latitude: defaultLatitude,
                                   longitude: defaultLongitude,
                                 });
+                                this.setCreateDate({
+                                  millisecondsSinceEpoch: Date.now(),
+                                });
                                 return {
                                   attachmentData,
                                   plate: '',
@@ -1481,7 +1484,6 @@ class Home extends React.Component {
                                   plateThumbnailsByKey: {},
                                   vehicleInfoComponent: null,
                                   violationSummaryComponent: null,
-                                  CreateDate: jsDateToCreateDate(new Date()),
                                 };
                               }
                               return { attachmentData };

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1463,11 +1463,24 @@ class Home extends React.Component {
                             background: 'white',
                           }}
                           onClick={() => {
-                            this.setState(state => ({
-                              attachmentData: state.attachmentData.filter(
-                                file => file.name !== name,
-                              ),
-                            }));
+                            this.setState(state => {
+                              const attachmentData =
+                                state.attachmentData.filter(
+                                  file => file.name !== name,
+                                );
+                              if (attachmentData.length === 0) {
+                                return {
+                                  attachmentData,
+                                  plate: '',
+                                  licenseState: 'NY',
+                                  allPlateResults: [],
+                                  plateThumbnailsByKey: {},
+                                  vehicleInfoComponent: null,
+                                  violationSummaryComponent: null,
+                                };
+                              }
+                              return { attachmentData };
+                            });
                           }}
                         >
                           <span role="img" aria-label="Delete photo/video">


### PR DESCRIPTION
When the last photo is removed via the ❌ button, revert everything that uploading the photo set, as if it was never uploaded:

- Clear the license plate and reset the license state to NY
- Clear ALPR results and plate thumbnails
- Clear vehicle info and violation summary lookups
- Reset CreateDate to the current time
- Reset coordinates and address to defaults (NYC center), including the full reverse geocode lookup

Co-Authored-By: Claude Code and DeepSeek