### PR TITLE
fix: remove duplicate yarn version from engines.yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": "24.12.0",
-    "yarn": "1.22.22"
+    "node": "24.12.0"
   },
   "packageManager": "yarn@1.22.22",
   "browserslist": [


### PR DESCRIPTION
packageManager field already declares yarn@1.22.22, which takes precedence.
Heroku warns when both are present:

    !     Multiple Yarn versions declared
    !
    !     The package.json file indicates the target version of Yarn to install in two fields:
    !     - "packageManager": "yarn@1.22.22"
    !     - "engines.yarn": "1.22.22"
    !
    !     If both fields are present, then "packageManager" will take precedence and "yarn@1.22.22" will be installed.
    !
    !     To ensure we install the version of Yarn you want, remove one of these fields.

Co-Authored-By: Claude Code with DeepSeek