### PR TITLE
fix: api keys (geo_app_key, google_api_key) are impo... in geoclient.js

### DIFF
--- a/src/geoclient.js
+++ b/src/geoclient.js
@@ -1,6 +1,12 @@
 import axios from 'axios';
 import axiosRetry from 'axios-retry';
 
+if (process.env.BROWSER) {
+  throw new Error(
+    'Do not import `geoclient.js` from inside the client-side code.',
+  );
+}
+
 import cbData from './districts-info.json';
 
 const { GEO_APP_KEY, GOOGLE_API_KEY } = process.env;


### PR DESCRIPTION
## Summary
Fix a defence-in-depth security issue in `src/geoclient.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | MEDIUM |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/geoclient.js:1` |
| **Assessment** | Defence-in-depth |
| **Chain Complexity** | 2-step |

**Description**: API keys (GEO_APP_KEY, GOOGLE_API_KEY) are imported from process.env in a client-side JavaScript file. When this code is bundled and sent to the browser, these environment variables will be exposed to end users, allowing them to extract and misuse the API keys.

## Evidence

**Exploitation scenario**: An attacker who accesses the web application can open browser developer tools, view the source code, and extract the API keys embedded in the JavaScript bundle.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `src/geoclient.js`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
