### PR TITLE
fix: upgrade object-to-formdata from v1 to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "multer": "^2.2.0",
     "node-fetch": "^2.6.7",
     "normalize.css": "^8.0.0",
-    "object-to-formdata": "^1.4.3",
+    "object-to-formdata": "^5.0.0",
     "object.omit": "^3.0.0",
     "p-event": "^1.3.0",
     "parse": "^2.10.0",

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -32,7 +32,7 @@ import captureFrame from 'capture-frame';
 import pEvent from 'p-event';
 import omit from 'object.omit';
 import bufferToArrayBuffer from 'buffer-to-arraybuffer';
-import objectToFormData from 'object-to-formdata';
+import { serialize } from 'object-to-formdata';
 import usStateNames from 'datasets-us-states-abbr-names';
 import fileExtension from 'file-extension';
 import diceware from 'diceware-generator';
@@ -225,7 +225,7 @@ async function fetchPlateResults({
   );
   console.timeEnd(`bufferToBlob(${attachmentFile.name})`); // eslint-disable-line no-console
 
-  const formData = objectToFormData({
+  const formData = serialize({
     attachmentFile: attachmentBlob,
     email,
     password,
@@ -1715,13 +1715,16 @@ class Home extends React.Component {
                   axios
                     .post(
                       '/submit',
-                      objectToFormData({
-                        ...this.getPerSubmissionState(),
-                        attachmentData: this.state.attachmentData,
-                        CreateDate: new Date(
-                          this.state.CreateDate,
-                        ).toISOString(),
-                      }),
+                      serialize(
+                        {
+                          ...this.getPerSubmissionState(),
+                          attachmentData: this.state.attachmentData,
+                          CreateDate: new Date(
+                            this.state.CreateDate,
+                          ).toISOString(),
+                        },
+                        { allowEmptyArrays: true },
+                      ),
                       {
                         onUploadProgress: progressEvent => {
                           const {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8028,10 +8028,10 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-to-formdata@^1.4.3:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/object-to-formdata/-/object-to-formdata-1.6.4.tgz#ee2c3693ae6829ce8847f77eff7a3d8289c843e1"
-  integrity sha512-1XZmRyR6yBhDxogp+9Vi00FFDtCah8x8FGc98lgvBzZlGeQGxj00pKmWHtzl7vrSpqPx5zXVb/XbiP5ZS2karg==
+object-to-formdata@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/object-to-formdata/-/object-to-formdata-5.0.0.tgz#d5a9ea70a64660d08f42c8432d256ac6038d62d0"
+  integrity sha512-reALyBo3+Nq71Py5uto2tjdxoAun83YqNBqElAWMNiOwfQxAnpMQiFPpZEvRL3kjShxsiBhNY/ikLUbc42TZ1Q==
 
 object.assign@^4.1.0, object.assign@^4.1.2, object.assign@^4.1.4, object.assign@^4.1.7:
   version "4.1.7"


### PR DESCRIPTION
v5 has two breaking changes for our usage:

1. Export renamed: default export 'objectToFormData' → named export
   'serialize'. Updated import and both call sites.

2. Empty arrays are now skipped by default (v1 always appended
   'key[]='). Pass { allowEmptyArrays: true } for the /submit
   call so empty attachmentData still sends the field.

v5 also adds better Blob/File detection, circular reference
protection, and React Native support — none affect our usage.

Co-Authored-By: Claude Code with DeepSeek