### PR TITLE
CI: Let `yarn start` take longer (20s vs 10)

### DIFF
--- a/.github/workflows/start.yml
+++ b/.github/workflows/start.yml
@@ -20,6 +20,6 @@ jobs:
     - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
     - run: export PATH=$HOME/.yarn/bin:$PATH
     - run: yarn
-    - run: timeout 10 yarn start > timeout.10.yarn.start.txt || true
-    - run: cat timeout.10.yarn.start.txt
-    - run: cat timeout.10.yarn.start.txt | grep "Finished 'start' after"
+    - run: timeout 20 yarn start > timeout.20.yarn.start.txt || true
+    - run: cat timeout.20.yarn.start.txt
+    - run: cat timeout.20.yarn.start.txt | grep "Finished 'start' after"


### PR DESCRIPTION
Not sure why, but it seems to be slower on this branch, here's a couple
failures:

* https://github.com/josephfrazier/reported-web/actions/runs/29717181201/job/88272636574?pr=834
* https://github.com/josephfrazier/reported-web/actions/runs/29880760643/job/88800904547?pr=834