### PR TITLE
tests: try to sidestep `GEOSUPPORT ERROR. EMAIL GSS_FEEDBACK@PLANNING.NYC.GOV & REPORT 88-D ER ROR`

### DIFF
--- a/src/__snapshots__/geoclient.test.js.snap
+++ b/src/__snapshots__/geoclient.test.js.snap
@@ -570,7 +570,7 @@ New York, NY 10007",
 }
 `;
 
-exports[`processValidation returns the right object around 3521-3501 Riverdale Ave, The Bronx, NY 10463 1`] = `
+exports[`processValidation returns the right object around 3521 Riverdale Ave, The Bronx, NY 10463 1`] = `
 {
   "cb_data": {
     "address": "5676 Riverdale Avenue,

--- a/src/geoclient.test.js
+++ b/src/geoclient.test.js
@@ -34,7 +34,7 @@ describe('processValidation', () => {
     expect(result).toMatchSnapshot();
   });
 
-  test('returns the right object around 3521-3501 Riverdale Ave, The Bronx, NY 10463', async () => {
+  test('returns the right object around 3521 Riverdale Ave, The Bronx, NY 10463', async () => {
     const result = await processValidation({
       lat: 40.88067222222222,
       long: -73.91039722222223,


### PR DESCRIPTION
This seems to be acting flaky more often, for example see https://github.com/josephfrazier/reported-web/actions/runs/30161383997/job/89687153358?pr=851