### PR TITLE
Remove unnecessary `eslint-disable-line` comments from PlatePickerModal.js

### DIFF
--- a/src/routes/home/PlatePickerModal.js
+++ b/src/routes/home/PlatePickerModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'react-modal';
 
-import homeStyles from './Home.css'; // eslint-disable-line css-modules/no-unused-class
+import homeStyles from './Home.css';
 
 function PlatePickerModal({ isOpen, results, onSelectPlate, onClose }) {
   return (


### PR DESCRIPTION
Not sure how they got in there, but I noticed them while working on https://github.com/josephfrazier/reported-web/pull/868,
See https://github.com/josephfrazier/reported-web/actions/runs/30948028961/job/92122777891?pr=868