### PR TITLE
fix: pressing Enter submits login/signup forms in auth modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,3 @@
   - `src/srlookup.test.js` calls `portal.311.nyc.gov`
   - `src/geoclient.test.js` depends on Google Geocoding and NYC Geoclient
 - In a restricted sandbox with no outbound access, those tests fail with DNS/network errors or timeouts. Work around this by running the narrowest relevant tests, or at least `yarn test:no-flaky` when you want parity with the main CI workflow.
-
-## Commit message style
-
-- Use markdown backtick code snippets for identifiers in commit message titles and bodies: `handleLogIn`, `type="submit"`, `<form>`, `src/routes/home/Home.js`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,7 @@
   - `src/srlookup.test.js` calls `portal.311.nyc.gov`
   - `src/geoclient.test.js` depends on Google Geocoding and NYC Geoclient
 - In a restricted sandbox with no outbound access, those tests fail with DNS/network errors or timeouts. Work around this by running the narrowest relevant tests, or at least `yarn test:no-flaky` when you want parity with the main CI workflow.
+
+## Commit message style
+
+- Use markdown backtick code snippets for identifiers in commit message titles and bodies: `handleLogIn`, `type="submit"`, `<form>`, `src/routes/home/Home.js`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,7 @@
   - `src/srlookup.test.js` calls `portal.311.nyc.gov`
   - `src/geoclient.test.js` depends on Google Geocoding and NYC Geoclient
 - In a restricted sandbox with no outbound access, those tests fail with DNS/network errors or timeouts. Work around this by running the narrowest relevant tests, or at least `yarn test:no-flaky` when you want parity with the main CI workflow.
+
+## Commit message style
+
+- Use markdown backtick code snippets for identifiers in commit message titles and bodies: `handleLogIn`, `type="submit"`, `<form>`, `src/routes/home/Home.js`.

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1084,7 +1084,8 @@ class Home extends React.Component {
     }
   };
 
-  handleLogIn = async () => {
+  handleLogIn = async e => {
+    if (e) e.preventDefault();
     this.setState({ isUserInfoSaving: true, authError: null });
     try {
       const { data } = await axios.post('/api/logIn', {
@@ -1113,7 +1114,8 @@ class Home extends React.Component {
     }
   };
 
-  handleSignUp = async () => {
+  handleSignUp = async e => {
+    e.preventDefault();
     this.setState({ isUserInfoSaving: true, authError: null });
     try {
       const { data } = await axios.post('/api/logIn', {
@@ -1469,7 +1471,10 @@ class Home extends React.Component {
 
               {/* Log In form */}
               {this.state.authModalTab === 'login' && (
-                <div className={homeStyles['auth-modal-body']}>
+                <form
+                  className={homeStyles['auth-modal-body']}
+                  onSubmit={this.handleLogIn}
+                >
                   <label htmlFor="auth-email">
                     Email:
                     <input
@@ -1518,10 +1523,9 @@ class Home extends React.Component {
                     </div>
                   </label>
                   <button
-                    type="button"
+                    type="submit"
                     className={homeStyles['auth-submit-btn']}
                     disabled={this.state.isUserInfoSaving}
-                    onClick={this.handleLogIn}
                   >
                     {this.state.isUserInfoSaving ? 'Logging in...' : 'Log In'}
                   </button>
@@ -1551,12 +1555,15 @@ class Home extends React.Component {
                       Sign Up
                     </button>
                   </div>
-                </div>
+                </form>
               )}
 
               {/* Sign Up form */}
               {this.state.authModalTab === 'signup' && (
-                <div className={homeStyles['auth-modal-body']}>
+                <form
+                  className={homeStyles['auth-modal-body']}
+                  onSubmit={this.handleSignUp}
+                >
                   <label htmlFor="auth-signup-email">
                     Email:
                     <input
@@ -1653,10 +1660,9 @@ class Home extends React.Component {
                     by phone.
                   </label>
                   <button
-                    type="button"
+                    type="submit"
                     className={homeStyles['auth-submit-btn']}
                     disabled={this.state.isUserInfoSaving}
-                    onClick={this.handleSignUp}
                   >
                     {this.state.isUserInfoSaving
                       ? 'Creating account...'
@@ -1671,7 +1677,7 @@ class Home extends React.Component {
                       Log In
                     </button>
                   </div>
-                </div>
+                </form>
               )}
             </Modal>
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1056,12 +1056,19 @@ class Home extends React.Component {
   };
 
   openAuthModal = (tab = 'login') => {
-    this.setState({
-      isAuthModalOpen: true,
-      authModalTab: tab,
-      authError: null,
-      isPasswordRevealed: tab === 'signup',
-    });
+    this.setState(
+      {
+        isAuthModalOpen: true,
+        authModalTab: tab,
+        authError: null,
+        isPasswordRevealed: tab === 'signup',
+      },
+      () => {
+        const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
+        const el = document.getElementById(emailId);
+        if (el) el.focus();
+      },
+    );
 
     if (tab === 'signup') {
       this.maybeGeneratePassword();
@@ -1073,11 +1080,18 @@ class Home extends React.Component {
   };
 
   switchAuthTab = tab => {
-    this.setState({
-      authModalTab: tab,
-      authError: null,
-      isPasswordRevealed: tab === 'signup',
-    });
+    this.setState(
+      {
+        authModalTab: tab,
+        authError: null,
+        isPasswordRevealed: tab === 'signup',
+      },
+      () => {
+        const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
+        const el = document.getElementById(emailId);
+        if (el) el.focus();
+      },
+    );
 
     if (tab === 'signup') {
       this.maybeGeneratePassword();

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1056,19 +1056,12 @@ class Home extends React.Component {
   };
 
   openAuthModal = (tab = 'login') => {
-    this.setState(
-      {
-        isAuthModalOpen: true,
-        authModalTab: tab,
-        authError: null,
-        isPasswordRevealed: tab === 'signup',
-      },
-      () => {
-        const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
-        const el = document.getElementById(emailId);
-        if (el) el.focus();
-      },
-    );
+    this.setState({
+      isAuthModalOpen: true,
+      authModalTab: tab,
+      authError: null,
+      isPasswordRevealed: tab === 'signup',
+    });
 
     if (tab === 'signup') {
       this.maybeGeneratePassword();
@@ -1080,18 +1073,11 @@ class Home extends React.Component {
   };
 
   switchAuthTab = tab => {
-    this.setState(
-      {
-        authModalTab: tab,
-        authError: null,
-        isPasswordRevealed: tab === 'signup',
-      },
-      () => {
-        const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
-        const el = document.getElementById(emailId);
-        if (el) el.focus();
-      },
-    );
+    this.setState({
+      authModalTab: tab,
+      authError: null,
+      isPasswordRevealed: tab === 'signup',
+    });
 
     if (tab === 'signup') {
       this.maybeGeneratePassword();

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -291,8 +291,9 @@ exports[`Home renders Log In modal UI 1`] = `
           Sign Up
         </button>
       </div>
-      <div
+      <form
         className="auth-modal-body"
+        onSubmit={[Function]}
       >
         <label
           htmlFor="auth-email"
@@ -335,8 +336,7 @@ exports[`Home renders Log In modal UI 1`] = `
         <button
           className="auth-submit-btn"
           disabled={false}
-          onClick={[Function]}
-          type="button"
+          type="submit"
         >
           Log In
         </button>
@@ -375,7 +375,7 @@ exports[`Home renders Log In modal UI 1`] = `
             Sign Up
           </button>
         </div>
-      </div>
+      </form>
       <div
         className="auth-prompt"
       >
@@ -536,8 +536,9 @@ exports[`Home renders Sign Up modal UI 1`] = `
           Sign Up
         </button>
       </div>
-      <div
+      <form
         className="auth-modal-body"
+        onSubmit={[Function]}
       >
         <label
           htmlFor="auth-signup-email"
@@ -635,8 +636,7 @@ exports[`Home renders Sign Up modal UI 1`] = `
         <button
           className="auth-submit-btn"
           disabled={false}
-          onClick={[Function]}
-          type="button"
+          type="submit"
         >
           Sign Up
         </button>
@@ -652,7 +652,7 @@ exports[`Home renders Sign Up modal UI 1`] = `
             Log In
           </button>
         </div>
-      </div>
+      </form>
       <div
         className="auth-prompt"
       >


### PR DESCRIPTION
Changed the login and signup forms in the auth modal from `<div>` wrappers
to `<form>` elements with `onSubmit` handlers, and changed the submit
buttons from `type="button"` with `onClick` to `type="submit"`.
This allows pressing Enter in any form field to submit the form.

Also made `handleLogIn` safe to call without an event (auto-login on mount).

Co-Authored-By: Claude Code with DeepSeek