### PR TITLE
feat: auto-focus email field when opening or switching auth modal tabs

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -85,6 +85,12 @@ const debouncedSaveStateToLocalStorage = debounce(self => {
   self.saveStateToLocalStorage();
 }, 500);
 
+function focusAuthEmail(tab) {
+  const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
+  const el = document.getElementById(emailId);
+  if (el) el.focus();
+}
+
 const defaultLatitude = 40.7128;
 const defaultLongitude = -74.006;
 
@@ -1055,12 +1061,6 @@ class Home extends React.Component {
       });
   };
 
-  focusAuthEmail = tab => {
-    const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
-    const el = document.getElementById(emailId);
-    if (el) el.focus();
-  };
-
   openAuthModal = (tab = 'login') => {
     this.setState(
       {
@@ -1069,7 +1069,7 @@ class Home extends React.Component {
         authError: null,
         isPasswordRevealed: tab === 'signup',
       },
-      () => requestAnimationFrame(() => this.focusAuthEmail(tab)),
+      () => requestAnimationFrame(() => focusAuthEmail(tab)),
     );
 
     if (tab === 'signup') {
@@ -1088,7 +1088,7 @@ class Home extends React.Component {
         authError: null,
         isPasswordRevealed: tab === 'signup',
       },
-      () => requestAnimationFrame(() => this.focusAuthEmail(tab)),
+      () => requestAnimationFrame(() => focusAuthEmail(tab)),
     );
 
     if (tab === 'signup') {

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1069,7 +1069,7 @@ class Home extends React.Component {
         authError: null,
         isPasswordRevealed: tab === 'signup',
       },
-      () => this.focusAuthEmail(tab),
+      () => requestAnimationFrame(() => this.focusAuthEmail(tab)),
     );
 
     if (tab === 'signup') {
@@ -1088,7 +1088,7 @@ class Home extends React.Component {
         authError: null,
         isPasswordRevealed: tab === 'signup',
       },
-      () => this.focusAuthEmail(tab),
+      () => requestAnimationFrame(() => this.focusAuthEmail(tab)),
     );
 
     if (tab === 'signup') {

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -579,7 +579,9 @@ class Home extends React.Component {
         this.state.authModalTab === 'signup'
           ? this.signupEmailRef
           : this.loginEmailRef;
-      if (ref.current) ref.current.focus();
+      requestAnimationFrame(() => {
+        if (ref.current) ref.current.focus();
+      });
     }
   }
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1056,12 +1056,19 @@ class Home extends React.Component {
   };
 
   openAuthModal = (tab = 'login') => {
-    this.setState({
-      isAuthModalOpen: true,
-      authModalTab: tab,
-      authError: null,
-      isPasswordRevealed: tab === 'signup',
-    });
+    this.setState(
+      {
+        isAuthModalOpen: true,
+        authModalTab: tab,
+        authError: null,
+        isPasswordRevealed: tab === 'signup',
+      },
+      () => {
+        const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
+        const el = document.getElementById(emailId);
+        if (el) el.focus();
+      },
+    );
 
     if (tab === 'signup') {
       this.maybeGeneratePassword();
@@ -1073,11 +1080,18 @@ class Home extends React.Component {
   };
 
   switchAuthTab = tab => {
-    this.setState({
-      authModalTab: tab,
-      authError: null,
-      isPasswordRevealed: tab === 'signup',
-    });
+    this.setState(
+      {
+        authModalTab: tab,
+        authError: null,
+        isPasswordRevealed: tab === 'signup',
+      },
+      () => {
+        const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
+        const el = document.getElementById(emailId);
+        if (el) el.focus();
+      },
+    );
 
     if (tab === 'signup') {
       this.maybeGeneratePassword();

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -85,12 +85,6 @@ const debouncedSaveStateToLocalStorage = debounce(self => {
   self.saveStateToLocalStorage();
 }, 500);
 
-function focusAuthEmail(tab) {
-  const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
-  const el = document.getElementById(emailId);
-  if (el) el.focus();
-}
-
 const defaultLatitude = 40.7128;
 const defaultLongitude = -74.006;
 
@@ -473,6 +467,8 @@ class Home extends React.Component {
     this.initialStatePerSubmission = initialStatePerSubmission;
     this.initialStatePersistent = initialStatePersistent;
     this.plateRef = React.createRef();
+    this.loginEmailRef = React.createRef();
+    this.signupEmailRef = React.createRef();
   }
 
   componentDidMount() {
@@ -570,6 +566,20 @@ class Home extends React.Component {
 
     if (this.state.isLoadPreviousSubmissionsEnabled) {
       this.loadPreviousSubmissions();
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      this.state.isAuthModalOpen &&
+      (this.state.authModalTab !== prevState.authModalTab ||
+        !prevState.isAuthModalOpen)
+    ) {
+      const ref =
+        this.state.authModalTab === 'signup'
+          ? this.signupEmailRef
+          : this.loginEmailRef;
+      if (ref.current) ref.current.focus();
     }
   }
 
@@ -1062,15 +1072,12 @@ class Home extends React.Component {
   };
 
   openAuthModal = (tab = 'login') => {
-    this.setState(
-      {
-        isAuthModalOpen: true,
-        authModalTab: tab,
-        authError: null,
-        isPasswordRevealed: tab === 'signup',
-      },
-      () => requestAnimationFrame(() => focusAuthEmail(tab)),
-    );
+    this.setState({
+      isAuthModalOpen: true,
+      authModalTab: tab,
+      authError: null,
+      isPasswordRevealed: tab === 'signup',
+    });
 
     if (tab === 'signup') {
       this.maybeGeneratePassword();
@@ -1082,14 +1089,11 @@ class Home extends React.Component {
   };
 
   switchAuthTab = tab => {
-    this.setState(
-      {
-        authModalTab: tab,
-        authError: null,
-        isPasswordRevealed: tab === 'signup',
-      },
-      () => requestAnimationFrame(() => focusAuthEmail(tab)),
-    );
+    this.setState({
+      authModalTab: tab,
+      authError: null,
+      isPasswordRevealed: tab === 'signup',
+    });
 
     if (tab === 'signup') {
       this.maybeGeneratePassword();
@@ -1490,6 +1494,7 @@ class Home extends React.Component {
                   <label htmlFor="auth-email">
                     Email:
                     <input
+                      ref={this.loginEmailRef}
                       required
                       id="auth-email"
                       type="email"
@@ -1579,6 +1584,7 @@ class Home extends React.Component {
                   <label htmlFor="auth-signup-email">
                     Email:
                     <input
+                      ref={this.signupEmailRef}
                       required
                       id="auth-signup-email"
                       type="email"

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1055,6 +1055,12 @@ class Home extends React.Component {
       });
   };
 
+  focusAuthEmail = tab => {
+    const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
+    const el = document.getElementById(emailId);
+    if (el) el.focus();
+  };
+
   openAuthModal = (tab = 'login') => {
     this.setState(
       {
@@ -1063,11 +1069,7 @@ class Home extends React.Component {
         authError: null,
         isPasswordRevealed: tab === 'signup',
       },
-      () => {
-        const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
-        const el = document.getElementById(emailId);
-        if (el) el.focus();
-      },
+      () => this.focusAuthEmail(tab),
     );
 
     if (tab === 'signup') {
@@ -1086,11 +1088,7 @@ class Home extends React.Component {
         authError: null,
         isPasswordRevealed: tab === 'signup',
       },
-      () => {
-        const emailId = tab === 'signup' ? 'auth-signup-email' : 'auth-email';
-        const el = document.getElementById(emailId);
-        if (el) el.focus();
-      },
+      () => this.focusAuthEmail(tab),
     );
 
     if (tab === 'signup') {


### PR DESCRIPTION
Focus `auth-email` (login) or `auth-signup-email` (signup) after the
modal renders, so the user can start typing immediately.

Co-Authored-By: Claude Code with DeepSeek