### PR TITLE
Revert "Shorten TLC SR label to trigger snapshot update in workflow"

### DIFF
--- a/src/components/SubmissionDetails.js
+++ b/src/components/SubmissionDetails.js
@@ -168,7 +168,7 @@ class SubmissionDetails extends React.Component {
           {tlcCaseId && (
             <React.Fragment>
               <br />
-              TLC SR #:{' '}
+              TLC Service Request Number:{' '}
               <a
                 href={`https://portal.311.nyc.gov/sr-details/?srnum=${tlcCaseId}`}
                 target="_blank"

--- a/src/components/__snapshots__/SubmissionDetails.test.js.snap
+++ b/src/components/__snapshots__/SubmissionDetails.test.js.snap
@@ -17,7 +17,7 @@ exports[`SubmissionDetails renders TLC and NYPD SR numbers when submission has m
      on 
     2016-11-18T00:00:00.000Z UTC (MockDate: GMT-0500)
     <br />
-    TLC SR #:
+    TLC Service Request Number:
      
     <a
       href="https://portal.311.nyc.gov/sr-details/?srnum=TLC-12345"


### PR DESCRIPTION
I accidentally forgot to undo this in https://github.com/josephfrazier/reported-web/pull/883/,
so am following up here.

This reverts commit 9051022c7f88b1496cbb9efe11af37cc533fa2bd.