### PR TITLE
Prepend `baseUrl` for all relative paths in `createFetch`

### DIFF
--- a/src/createFetch.js
+++ b/src/createFetch.js
@@ -36,7 +36,7 @@ function createFetch(fetch: Fetch, { baseUrl, cookie }: Options) {
   };
 
   return async (url: string, options: any) =>
-    url.startsWith('/api')
+    url.startsWith('/')
       ? fetch(`${baseUrl}${url}`, {
           ...defaults,
           ...options,


### PR DESCRIPTION
This was found while working on https://github.com/josephfrazier/reported-web/pull/875,
and we ended up not needing to change this there,
but it should be done anyway, so here's a separate change for it.

Below is a little bit of the PR #875 context:

`createFetch` only resolved paths starting with `/api` against
`baseUrl`; bare paths like `/submissions` were passed directly to
`fetch()`.  That works in the browser (which resolves against the
current origin), but on the server Node's `globalThis.fetch` cannot
resolve a bare path — it throws.  The error was silently caught by the
route action's `try/catch`, so `initialSubmissions` stayed null and
submissions were never pre-loaded during SSR.

Fix by prepending `baseUrl` for every path that starts with `/`.

Co-Authored-By: Claude Code with DeepSeek