### PR TITLE
Fix cookie migration auto-login: check parsed data instead of `this.state`

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -505,6 +505,18 @@ class Home extends React.Component {
             });
             setHomeStateCookie(JSON.stringify(persistentData), COOKIE_MAX_AGE);
             this.setState(persistentData);
+
+            // The auto-login check below reads this.state, which may not
+            // reflect setState yet in React 16.  Check the parsed data
+            // directly so users with old localStorage entries that lack
+            // loginSuccessful don't need a second page load.
+            if (
+              persistentData.email &&
+              persistentData.password &&
+              !persistentData.loginSuccessful
+            ) {
+              this.handleLogIn();
+            }
             break;
           } catch {
             // Ignore parse errors from corrupted data.
@@ -513,9 +525,8 @@ class Home extends React.Component {
       }
     }
 
-    // Existing users who saved email & password before loginSuccessful
-    // was introduced won't have it set. Try to log them in so the
-    // server can validate the credentials and set the flag properly.
+    // If the cookie already existed at mount time (i.e. a subsequent
+    // page load), check whether loginSuccessful is missing and retry.
     if (
       this.state.email &&
       this.state.password &&


### PR DESCRIPTION
# (release announcement: https://reportedcab.slack.com/archives/C9VNM3DL4/p1786315862309479)

After `setState` in the migration block, `this.state` may not reflect
the new values yet in React 16's batching.  When the auto-login check
at line 519 read `this.state.email`, it could still see the constructor
default (`''`), skip `handleLogIn`, and leave the cookie without
`loginSuccessful: true`.  The next page load would then need another
auto-login cycle.

Fix by checking the parsed localStorage data directly inside the
migration block, so users with old data that lacks `loginSuccessful`
get logged in on the very first visit after deploy.

Co-Authored-By: Claude Code with DeepSeek