### PR TITLE
Run migration auto-login in `setState` callback

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -504,19 +504,18 @@ class Home extends React.Component {
               if (k in parsed) persistentData[k] = parsed[k];
             });
             setHomeStateCookie(JSON.stringify(persistentData), COOKIE_MAX_AGE);
-            this.setState(persistentData);
 
-            // The auto-login check below reads this.state, which may not
-            // reflect setState yet in React 16.  Check the parsed data
-            // directly so users with old localStorage entries that lack
-            // loginSuccessful don't need a second page load.
-            if (
-              persistentData.email &&
-              persistentData.password &&
-              !persistentData.loginSuccessful
-            ) {
-              this.handleLogIn();
-            }
+            // Use the setState callback so handleLogIn sees the migrated
+            // email/password in this.state, not the constructor defaults.
+            this.setState(persistentData, () => {
+              if (
+                persistentData.email &&
+                persistentData.password &&
+                !persistentData.loginSuccessful
+              ) {
+                this.handleLogIn();
+              }
+            });
             break;
           } catch {
             // Ignore parse errors from corrupted data.


### PR DESCRIPTION
# (release announcement: https://reportedcab.slack.com/archives/C9VNM3DL4/p1786315862309479)

(This is a follow-up to https://github.com/josephfrazier/reported-web/pull/886)

`handleLogIn` reads `this.state.email`/`this.state.password` to
build the API request.  Calling it synchronously after `setState` meant
`this.state` could still hold the constructor defaults (`''`), causing
a "username/email is required" error.

Move the call into the `setState` callback, which runs after React has
flushed the state update.

Co-Authored-By: Claude Code with DeepSeek