### PR TITLE
Clear old localStorage keys on logout

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1226,6 +1226,10 @@ class Home extends React.Component {
       },
       () => {
         setHomeStateCookie('', 0);
+        // Remove old localStorage keys so they aren't re-migrated
+        // if the user logs back in later.
+        localStorage.removeItem('Function');
+        localStorage.removeItem('reportedWebHomeState');
       },
     );
   };


### PR DESCRIPTION
When logging out, remove the `Function` and `reportedWebHomeState`
localStorage keys so the migration block in `componentDidMount` won't
re-migrate stale data on the next login.

Co-Authored-By: Claude Code with DeepSeek