### PR TITLE
fix: replace `form-data` with native `FormData` + `Blob` to restore platerecognizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "file-extension": "^4.0.5",
     "file-type": "^16.5.4",
     "force-ssl-heroku": "^1.0.2",
-    "form-data": "^4.0.6",
     "geodist": "^0.2.1",
     "geolib": "^2.0.24",
     "global": "^4.3.2",

--- a/src/__snapshots__/alpr.test.js.snap
+++ b/src/__snapshots__/alpr.test.js.snap
@@ -18,7 +18,7 @@ exports[`readLicenseViaALPR falling back to the second token 1`] = `
       "candidates": [
         {
           "plate": "k73jau",
-          "score": 1,
+          "score": 0.999,
         },
       ],
       "dscore": 0.853,
@@ -26,9 +26,9 @@ exports[`readLicenseViaALPR falling back to the second token 1`] = `
       "plateCropDataUrl": "THIS IS HASHED TO REDUCE LENGTH WHILE ASSURING INTEGRITY: 3ea1f17896751841dd8bd9e4320bc92884012cd1d1f16f24ef5867edd737ec05",
       "region": {
         "code": "us-nj",
-        "score": 0.518,
+        "score": 0.633,
       },
-      "score": 1,
+      "score": 0.999,
       "vehicle": {
         "box": {
           "xmax": 1869,
@@ -71,7 +71,7 @@ exports[`readLicenseViaALPR falling back to the second token 1`] = `
       "plateCropDataUrl": "THIS IS HASHED TO REDUCE LENGTH WHILE ASSURING INTEGRITY: 4701977d7c1729b997c1b77289c4f8c4b97b5d3aaa8e257a8debe629dcc06a44",
       "region": {
         "code": "us-ny",
-        "score": 0.784,
+        "score": 0.892,
       },
       "score": 1,
       "vehicle": {
@@ -104,7 +104,7 @@ exports[`readLicenseViaALPR falling back to the second token 1`] = `
       "plateCropDataUrl": "THIS IS HASHED TO REDUCE LENGTH WHILE ASSURING INTEGRITY: 9a7eed062844c015cabf1a523ebc6257e87ec7b6fedac4a33b0061ea44aecb12",
       "region": {
         "code": "us-ny",
-        "score": 0.923,
+        "score": 0.907,
       },
       "score": 1,
       "vehicle": {
@@ -143,7 +143,7 @@ exports[`readLicenseViaALPR using only the first token 1`] = `
       "candidates": [
         {
           "plate": "k73jau",
-          "score": 1,
+          "score": 0.999,
         },
       ],
       "dscore": 0.853,
@@ -151,9 +151,9 @@ exports[`readLicenseViaALPR using only the first token 1`] = `
       "plateCropDataUrl": "THIS IS HASHED TO REDUCE LENGTH WHILE ASSURING INTEGRITY: 3ea1f17896751841dd8bd9e4320bc92884012cd1d1f16f24ef5867edd737ec05",
       "region": {
         "code": "us-nj",
-        "score": 0.518,
+        "score": 0.633,
       },
-      "score": 1,
+      "score": 0.999,
       "vehicle": {
         "box": {
           "xmax": 1869,
@@ -196,7 +196,7 @@ exports[`readLicenseViaALPR using only the first token 1`] = `
       "plateCropDataUrl": "THIS IS HASHED TO REDUCE LENGTH WHILE ASSURING INTEGRITY: 4701977d7c1729b997c1b77289c4f8c4b97b5d3aaa8e257a8debe629dcc06a44",
       "region": {
         "code": "us-ny",
-        "score": 0.784,
+        "score": 0.892,
       },
       "score": 1,
       "vehicle": {
@@ -229,7 +229,7 @@ exports[`readLicenseViaALPR using only the first token 1`] = `
       "plateCropDataUrl": "THIS IS HASHED TO REDUCE LENGTH WHILE ASSURING INTEGRITY: 9a7eed062844c015cabf1a523ebc6257e87ec7b6fedac4a33b0061ea44aecb12",
       "region": {
         "code": "us-ny",
-        "score": 0.923,
+        "score": 0.907,
       },
       "score": 1,
       "vehicle": {

--- a/src/alpr.js
+++ b/src/alpr.js
@@ -1,5 +1,4 @@
 import sharp from 'sharp';
-import FormData from 'form-data';
 
 // Disable sharp's internal LRU cache so processed image data is released
 // immediately instead of being held in memory across requests.
@@ -54,10 +53,10 @@ const downscaleForPlateRecognizer = ({ buffer, targetWidth }) => {
     });
 };
 
-function platerecognizer({ attachmentBytesRotated, PLATERECOGNIZER_TOKEN }) {
+function platerecognizer({ imageBuffer, PLATERECOGNIZER_TOKEN }) {
+  const blob = new Blob([imageBuffer], { type: 'image/jpeg' });
   const body = new FormData();
-
-  body.append('upload', attachmentBytesRotated);
+  body.append('upload', blob, 'image.jpg');
 
   // body.append("regions", "us-ny"); // Change to your country
   body.append('regions', 'us'); // Change to your country
@@ -80,11 +79,13 @@ export default function readLicenseViaALPR({
     .then(buffer => downscaleForPlateRecognizer({ buffer, targetWidth: 4096 }))
     .then(buffer => downscaleForPlateRecognizer({ buffer, targetWidth: 2048 }))
     .then(processedBuffer => {
-      const attachmentBytesRotated = processedBuffer.toString('base64');
       console.log('STARTING platerecognizer'); // eslint-disable-line no-console
       console.time(`/platerecognizer plate-reader`); // eslint-disable-line no-console
 
-      return platerecognizer({ attachmentBytesRotated, PLATERECOGNIZER_TOKEN })
+      return platerecognizer({
+        imageBuffer: processedBuffer,
+        PLATERECOGNIZER_TOKEN,
+      })
         .then(platerecognizerRes => {
           if (platerecognizerRes.ok) {
             return platerecognizerRes;
@@ -95,7 +96,7 @@ export default function readLicenseViaALPR({
           );
 
           return platerecognizer({
-            attachmentBytesRotated,
+            imageBuffer: processedBuffer,
             PLATERECOGNIZER_TOKEN: PLATERECOGNIZER_TOKEN_TWO,
           });
         })
@@ -105,7 +106,18 @@ export default function readLicenseViaALPR({
           });
           return platerecognizerRes;
         })
-        .then(platerecognizerRes => platerecognizerRes.json())
+        .then(platerecognizerRes => {
+          if (!platerecognizerRes.ok) {
+            return platerecognizerRes.json().then(errData => {
+              const err = new Error(
+                `Plate Recognizer API error: ${platerecognizerRes.status} - ${JSON.stringify(errData)}`,
+              );
+              err.status = platerecognizerRes.status;
+              throw err;
+            });
+          }
+          return platerecognizerRes.json();
+        })
         .then(async data => {
           async function cropBox(box) {
             if (!box) return null;

--- a/src/alpr.js
+++ b/src/alpr.js
@@ -53,8 +53,8 @@ const downscaleForPlateRecognizer = ({ buffer, targetWidth }) => {
     });
 };
 
-function platerecognizer({ imageBuffer, PLATERECOGNIZER_TOKEN }) {
-  const blob = new Blob([imageBuffer], { type: 'image/jpeg' });
+function platerecognizer({ attachmentBufferRotated, PLATERECOGNIZER_TOKEN }) {
+  const blob = new Blob([attachmentBufferRotated], { type: 'image/jpeg' });
   const body = new FormData();
   body.append('upload', blob, 'image.jpg');
 
@@ -78,12 +78,12 @@ export default function readLicenseViaALPR({
   return orientImageBuffer({ attachmentBuffer })
     .then(buffer => downscaleForPlateRecognizer({ buffer, targetWidth: 4096 }))
     .then(buffer => downscaleForPlateRecognizer({ buffer, targetWidth: 2048 }))
-    .then(processedBuffer => {
+    .then(attachmentBufferRotated => {
       console.log('STARTING platerecognizer'); // eslint-disable-line no-console
       console.time(`/platerecognizer plate-reader`); // eslint-disable-line no-console
 
       return platerecognizer({
-        imageBuffer: processedBuffer,
+        attachmentBufferRotated,
         PLATERECOGNIZER_TOKEN,
       })
         .then(platerecognizerRes => {
@@ -96,7 +96,7 @@ export default function readLicenseViaALPR({
           );
 
           return platerecognizer({
-            imageBuffer: processedBuffer,
+            attachmentBufferRotated,
             PLATERECOGNIZER_TOKEN: PLATERECOGNIZER_TOKEN_TWO,
           });
         })
@@ -125,7 +125,7 @@ export default function readLicenseViaALPR({
             const width = xmax - xmin;
             const height = ymax - ymin;
             if (width <= 0 || height <= 0) return null;
-            const cropBuffer = await sharp(processedBuffer)
+            const cropBuffer = await sharp(attachmentBufferRotated)
               .extract({ left: xmin, top: ymin, width, height })
               .jpeg()
               .toBuffer();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5538,7 +5538,7 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     semver "^7.3.2"
     tapable "^1.0.0"
 
-form-data@^4.0.5, form-data@^4.0.6:
+form-data@^4.0.5:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
   integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==


### PR DESCRIPTION
(to confirm, even though CI doesn't require these tests to pass, due to historical flakiness, they did pass: https://github.com/josephfrazier/reported-web/actions/runs/31349320392/job/93337056360?pr=890#step:7:205)

The Plate Recognizer ALPR integration broke after commit `2d0dd00f`
(`fix: replace node-fetch with built-in Node.js fetch`, https://github.com/josephfrazier/reported-web/pull/683).
The `form-data` npm package is incompatible with Node 24's built-in `fetch()` in two ways:

1. **Missing `Content-Type` header**: The built-in `fetch()` does not
   auto-detect `form-data` bodies the way `node-fetch` did. Without
   `body.getHeaders()`, the request goes out with
   `Content-Type: text/plain;charset=UTF-8`, and the API returns
   `415 Unsupported Media Type`.

2. **Empty upload field**: Even when the `Content-Type` header is
   manually included via `body.getHeaders()`, the `form-data` readable
   stream is not transmitted correctly by built-in `fetch()` — the API
   receives an empty `upload` field and returns
   `400 {"non_field_errors":["Upload or upload_url field cannot be empty."]}`.

Additionally, when both API tokens fail, the code crashed on
`data.results.map()` because error response JSON has no `results` field.

**Fixes:**

- Replace `form-data` (npm) with the web standard `FormData` and `Blob`,
  which are available as globals in Node 24 and work correctly with the
  built-in `fetch()`.
- Send the processed image buffer directly (wrapped in a `Blob`) instead
  of base64-encoding it — more efficient and aligned with what the API
  expects for a file upload field.
- Add error handling: when the final response is not `ok`, parse the
  error body and throw a descriptive `Error` with the status and message
  instead of crashing on `data.results.map()`.
- Remove the `form-data` dependency from `package.json`.
- Update ALPR test snapshots (confidence scores vary slightly between
  API calls, which is normal).

**Verification:**

- `yarn test src/alpr.test.js` — 2/2 pass, 2/2 snapshots updated.
- `yarn fix` — no lint errors.
- Manual test with native `FormData` + `Blob` against the Plate
  Recognizer API returned `201 Created` with correct plate recognition
  results.

Co-Authored-By: Claude Code with DeepSeek

---

Other commits as of PR open:

* platerecognizer: Rename `imageBuffer` param to  `attachmentBufferRotated`

  This makes it easier to pass from the callers, and trace through calls.