### PR TITLE
Move magnifying glass (license plate picker) button on uploaded images to bottom-right corner

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1986,8 +1986,8 @@ class Home extends React.Component {
                               type="button"
                               style={{
                                 position: 'absolute',
-                                top: 0,
-                                left: 0,
+                                bottom: 0,
+                                right: 0,
                                 padding: 0,
                                 margin: '1px',
                                 background: 'white',


### PR DESCRIPTION
Change the 🔍 (license plate picker) button position from `top: 0; left: 0` to
`bottom: 0; right: 0` so it sits in the bottom-right corner of each uploaded
image instead of the top-left.

Co-Authored-By: Claude Code with DeepSeek