### PR TITLE
Remove herokuSelfPing keepalive, no longer needed on always-on basic dyno

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -68,33 +68,6 @@ if (commitHash === 'unknown') {
   }
 }
 
-// Ping the app periodically to prevent Heroku eco tier dyno from sleeping
-// Only runs on Heroku (same detection logic as heroku-self-ping)
-const isHeroku =
-  'HEROKU' in process.env ||
-  ('DYNO' in process.env && process.env.HOME === '/app');
-
-if (isHeroku) {
-  const herokuSelfPingUrl = config.api.serverUrl;
-  const herokuSelfPingInterval = 20 * 60 * 1000; // 20 minutes
-  const herokuSelfPing = () => {
-    console.info(`Pinging ${herokuSelfPingUrl}...`);
-    fetch(herokuSelfPingUrl)
-      .then(res => {
-        if (res.ok) {
-          console.info('herokuSelfPing successful');
-        } else {
-          console.warn(`herokuSelfPing failed with status ${res.status}`);
-        }
-      })
-      .catch(err => {
-        console.error('herokuSelfPing failed:', err.message);
-      });
-  };
-  herokuSelfPing(); // ping immediately on startup
-  setInterval(herokuSelfPing, herokuSelfPingInterval);
-}
-
 // http://docs.parseplatform.org/js/guide/#getting-started
 Parse.initialize(PARSE_APP_ID, PARSE_JAVASCRIPT_KEY, PARSE_MASTER_KEY);
 Parse.Cloud.useMasterKey();


### PR DESCRIPTION
Co-Authored-By: Claude Code with DeepSeek

Prompt:

> on a new branch from main: remove herokuselfping, now that prod is running on a heroku basic dyno and is therefore always-on. No need for PR review apps to always be on