### PR TITLE
fix: close JSDOM window in `srlookup.js` to release parsed DOM per request

### DIFF
--- a/src/srlookup.js
+++ b/src/srlookup.js
@@ -8,45 +8,55 @@ export default async function srlookup({ reqnumber }) {
   const { data } = await axios.get(url, {
     httpsAgent: new https.Agent({ keepAlive: false }),
   });
-  const { document } = new JSDOM(data).window;
+  // Use a separate variable for the window so we can close it when done,
+  // releasing the parsed DOM and any internal timers/handles jsdom holds.
+  const { window } = new JSDOM(data);
+  const { document } = window;
 
-  const result = {};
-  result.description = document.querySelector('#page-wrapper p')?.textContent;
-  const fields = [...document.querySelectorAll('.info, .control')];
-  for (let i = 0; i < fields.length; i += 2) {
-    const keyField = fields[i];
-    const valueField = fields[i + 1];
+  try {
+    const result = {};
+    result.description = document.querySelector('#page-wrapper p')?.textContent;
+    const fields = [...document.querySelectorAll('.info, .control')];
+    for (let i = 0; i < fields.length; i += 2) {
+      const keyField = fields[i];
+      const valueField = fields[i + 1];
 
-    const key = keyField.textContent;
-    const value = valueField.textContent;
+      const key = keyField.textContent;
+      const value = valueField.textContent;
 
-    result[key] = value;
+      result[key] = value;
+    }
+
+    const srdatereported =
+      /\$\("#srdatereported"\).text\(getESTDate\("([^"]+)"\)\)/.exec(data);
+    if (srdatereported) {
+      result['Date Reported'] = new Date(srdatereported[1]).toLocaleString(
+        'en-US',
+        { timeZone: 'America/New_York' },
+      );
+    }
+
+    const srupdatedon =
+      /\$\("#srupdatedon"\).text\(getESTDate\("([^"]+)"\)\)/.exec(data);
+    if (srupdatedon) {
+      result['Updated On'] = new Date(srupdatedon[1]).toLocaleString('en-US', {
+        timeZone: 'America/New_York',
+      });
+    }
+
+    const srdateclosed =
+      /\$\("#srdateclosed"\).text\(getESTDate\("([^"]+)"\)\)/.exec(data);
+    if (srdateclosed) {
+      result['Date Closed'] = new Date(srdateclosed[1]).toLocaleString(
+        'en-US',
+        {
+          timeZone: 'America/New_York',
+        },
+      );
+    }
+
+    return result;
+  } finally {
+    window.close();
   }
-
-  const srdatereported =
-    /\$\("#srdatereported"\).text\(getESTDate\("([^"]+)"\)\)/.exec(data);
-  if (srdatereported) {
-    result['Date Reported'] = new Date(srdatereported[1]).toLocaleString(
-      'en-US',
-      { timeZone: 'America/New_York' },
-    );
-  }
-
-  const srupdatedon =
-    /\$\("#srupdatedon"\).text\(getESTDate\("([^"]+)"\)\)/.exec(data);
-  if (srupdatedon) {
-    result['Updated On'] = new Date(srupdatedon[1]).toLocaleString('en-US', {
-      timeZone: 'America/New_York',
-    });
-  }
-
-  const srdateclosed =
-    /\$\("#srdateclosed"\).text\(getESTDate\("([^"]+)"\)\)/.exec(data);
-  if (srdateclosed) {
-    result['Date Closed'] = new Date(srdateclosed[1]).toLocaleString('en-US', {
-      timeZone: 'America/New_York',
-    });
-  }
-
-  return result;
 }


### PR DESCRIPTION
JSDOM's `window.close()` releases the parsed DOM tree and any internal
timers/handles. Without it, each call to `srlookup()` leaked the full
parsed 311 portal page until GC.

Wrapped in a `try`/`finally` so the window is always closed even if
parsing fails.

Co-Authored-By: Claude Code with DeepSeek