### PR TITLE
fix: add 30s `AbortController` timeout to Plate Recognizer API calls

### DIFF
--- a/src/alpr.js
+++ b/src/alpr.js
@@ -53,6 +53,10 @@ const downscaleForPlateRecognizer = ({ buffer, targetWidth }) => {
     });
 };
 
+// 30-second timeout for Plate Recognizer API calls to prevent hung requests
+// from holding image buffers indefinitely
+const PLATERECOGNIZER_TIMEOUT_MS = 30_000;
+
 function platerecognizer({ attachmentBufferRotated, PLATERECOGNIZER_TOKEN }) {
   const blob = new Blob([attachmentBufferRotated], { type: 'image/jpeg' });
   const body = new FormData();
@@ -61,13 +65,20 @@ function platerecognizer({ attachmentBufferRotated, PLATERECOGNIZER_TOKEN }) {
   // body.append("regions", "us-ny"); // Change to your country
   body.append('regions', 'us'); // Change to your country
 
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    PLATERECOGNIZER_TIMEOUT_MS,
+  );
+
   return fetch('https://api.platerecognizer.com/v1/plate-reader/', {
     method: 'POST',
     headers: {
       Authorization: `Token ${PLATERECOGNIZER_TOKEN}`,
     },
     body,
-  });
+    signal: controller.signal,
+  }).finally(() => clearTimeout(timer));
 }
 
 export default function readLicenseViaALPR({


### PR DESCRIPTION
Without a timeout, a hung `fetch` to `api.platerecognizer.com` holds the
full image buffer indefinitely — a single stuck request pins ~20 MB in
the Node.js heap that GC can never collect. Over time, more requests get
stuck and memory grows until the dyno exceeds Heroku's limit.

## How AbortController + setTimeout fixes this

The old code called `fetch()` with no `signal`:

```js
return fetch(url, { method: 'POST', headers: {...}, body });
```

`body` contains a `Blob` built from the processed image buffer (~20 MB).
If the Plate Recognizer server is slow, unresponsive, or the network
drops, the Promise **never settles**. While it's pending:

- `attachmentBufferRotated` stays reachable through the closure chain
- `Blob` and `FormData` hold copies of the buffer
- The socket's send/receive buffers hold additional copies
- The GC can't collect any of it

The fix creates an [AbortController][] with a 30-second timer:

```js
const controller = new AbortController();
const timer = setTimeout(() => controller.abort(), 30_000);

return fetch(url, { ..., signal: controller.signal })
  .finally(() => clearTimeout(timer));
```

After 30 seconds, `controller.abort()` makes Node's undici HTTP client
tear down the TCP socket immediately. The `fetch` Promise rejects with
an `AbortError`, which propagates up through the `.catch()` handler in
`server.js`. Once that rejection handler runs, the Promise chain is
broken, the closure over `attachmentBufferRotated` is released, and GC
can collect everything.

The `clearTimeout(timer)` in `.finally()` prevents the timer itself
from leaking if the request succeeds before the timeout.

## References

- MDN: [AbortController][]
- MDN: [fetch `signal` option][]
- MDN: [Canceling a fetch][]
- Node.js: [AbortController global][]

[AbortController]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController
[fetch `signal` option]: https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch#signal
[Canceling a fetch]: https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch#canceling_a_fetch
[AbortController global]: https://nodejs.org/api/globals.html#class-abortcontroller

Co-Authored-By: Claude Code with DeepSeek