### PR TITLE
fix: cancel unread response body when first Plate Recognizer token fails

### DIFF
--- a/src/alpr.js
+++ b/src/alpr.js
@@ -86,10 +86,14 @@ export default function readLicenseViaALPR({
         attachmentBufferRotated,
         PLATERECOGNIZER_TOKEN,
       })
-        .then(platerecognizerRes => {
+        .then(async platerecognizerRes => {
           if (platerecognizerRes.ok) {
             return platerecognizerRes;
           }
+
+          // Consume the failed response body so the underlying socket is
+          // released back to the pool rather than held until GC.
+          await platerecognizerRes.body?.cancel().catch(() => {});
 
           console.info(
             '/platerecognizer plate-reader got an error with first token, trying second',


### PR DESCRIPTION
When the first API token returns a non-ok response, the code retries with
the second token — but the old code never consumed or cancelled the first
response's body. This left the underlying HTTP socket and its associated
buffers alive until GC, even though the response data was never needed.

## How response.body.cancel() fixes this

The old code checked the response and fell through to the retry:

```js
.then(platerecognizerRes => {
  if (platerecognizerRes.ok) {
    return platerecognizerRes;
  }
  // first response body is never read or cancelled here
  console.info('...trying second token');
  return platerecognizer({ ..., PLATERECOGNIZER_TOKEN: TOKEN_TWO });
})
```

Node's built-in `fetch` (undici) streams response bodies. If the body
is never read, undici holds the underlying socket open with its read
buffers intact, waiting for the consumer to drain it. The socket is only
released when:

1. The body is fully consumed (e.g. `.json()`, `.text()`)
2. The body is explicitly cancelled (`.body.cancel()`)
3. The socket is closed by the server or GC

Since the failed response body is never consumed and GC is
non-deterministic, each token-fallback path accumulates an open socket +
buffers. Over many requests (especially during API flakiness), this
creates slow memory growth.

The fix calls `cancel()` on the response body's [ReadableStream][].

`response.body` is a [Response.body][] — which is a [ReadableStream][].
`ReadableStream.cancel()` is available directly on the stream, no
`getReader()` required:

```js
.then(async platerecognizerRes => {
  if (platerecognizerRes.ok) {
    return platerecognizerRes;
  }

  // Immediately release the socket and its buffers
  await platerecognizerRes.body?.cancel().catch(() => {});

  console.info('...trying second token');
  return platerecognizer({ ..., PLATERECOGNIZER_TOKEN: TOKEN_TWO });
})
```

`.body.cancel()` sends an RST to the server and tears down the socket
on the client side, freeing all associated memory immediately. The
`?.catch(() => {})` pattern handles the case where the body was already
consumed or the socket was already closed.

## References

- MDN: [Response.body][]
- MDN: [ReadableStream][]
- MDN: [ReadableStream.cancel()][]
- Node.js (undici): [fetch response body handling][]

[Response.body]: https://developer.mozilla.org/en-US/docs/Web/API/Response/body
[ReadableStream]: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream
[ReadableStream.cancel()]: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/cancel
[fetch response body handling]: https://nodejs.org/docs/latest/api/globals.html#fetch

Co-Authored-By: Claude Code with DeepSeek