### PR TITLE
fix: avoid unnecessary `Buffer.from()` copy in ALPR image pipeline

### DIFF
--- a/src/alpr.js
+++ b/src/alpr.js
@@ -10,16 +10,22 @@ async function orientImageBuffer({ attachmentBuffer }) {
   console.log(
     `image buffer length BEFORE sharp: ${attachmentBuffer.length} bytes`,
   );
-  return sharp(attachmentBuffer)
-    .rotate()
-    .toBuffer()
-    .catch(() => attachmentBuffer)
-    .then(buffer => Buffer.from(buffer))
-    .then(async buffer => {
-      console.log(`image buffer length AFTER sharp: ${buffer.length} bytes`); // eslint-disable-line no-console
-      console.timeEnd(`orientImageBuffer`); // eslint-disable-line no-console
-      return buffer;
-    });
+  return (
+    sharp(attachmentBuffer)
+      .rotate()
+      .toBuffer()
+      .catch(() => attachmentBuffer)
+      // sharp v0.35+ always returns a Buffer from toBuffer(), but older
+      // versions had a bug where it could return a Uint8Array instead
+      // (https://github.com/lovell/sharp/issues/1219). Guard against that
+      // without doing an unnecessary copy in the common case.
+      .then(buffer => (Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer)))
+      .then(async buffer => {
+        console.log(`image buffer length AFTER sharp: ${buffer.length} bytes`); // eslint-disable-line no-console
+        console.timeEnd(`orientImageBuffer`); // eslint-disable-line no-console
+        return buffer;
+      })
+  );
 }
 
 // https://app.platerecognizer.com/upload-limit/
@@ -36,21 +42,25 @@ const downscaleForPlateRecognizer = ({ buffer, targetWidth }) => {
     `file size is greater than maximum of ${maxFilesize} bytes, attempting to scale down to width of ${targetWidth}`,
   );
 
-  return sharp(buffer)
-    .resize({ width: targetWidth })
-    .toBuffer()
-    .catch(error => {
-      console.error('could not scale down, using unscaled image', { error });
-      return buffer;
-    })
-    .then(resizedBufferish => {
-      const resizedBuffer = Buffer.from(resizedBufferish);
-      // eslint-disable-next-line no-console
-      console.log(
-        `file size after scaling down: ${resizedBuffer.length} bytes`,
-      );
-      return resizedBuffer;
-    });
+  return (
+    sharp(buffer)
+      .resize({ width: targetWidth })
+      .toBuffer()
+      .catch(error => {
+        console.error('could not scale down, using unscaled image', { error });
+        return buffer;
+      })
+      // sharp v0.35+ always returns a Buffer from toBuffer(), but guard
+      // against the old Uint8Array bug without an unnecessary copy.
+      .then(resizedBuffer => {
+        const safe = Buffer.isBuffer(resizedBuffer)
+          ? resizedBuffer
+          : Buffer.from(resizedBuffer);
+        // eslint-disable-next-line no-console
+        console.log(`file size after scaling down: ${safe.length} bytes`);
+        return safe;
+      })
+  );
 };
 
 function platerecognizer({ attachmentBufferRotated, PLATERECOGNIZER_TOKEN }) {


### PR DESCRIPTION
`orientImageBuffer` and `downscaleForPlateRecognizer` both called
`Buffer.from()` on sharp's output. `sharp().toBuffer()` always returns
a [Buffer][] in v0.35+, so this created a redundant copy — doubling heap
usage for each processed image (up to 20 MB per copy).

Commit `23ae46c6` (May 2018) added it as a workaround for a sharp bug
where `.toBuffer()` could return a `Uint8Array` instead of a proper
`Buffer`: https://github.com/lovell/sharp/issues/1219#issuecomment-392299058

This was a real issue in sharp's ~0.20 era. But since then:

- sharp v0.35.0 introduced a dedicated [`toUint8Array()`][] method for
  getting `Uint8Array` output — it wouldn't need a separate method if
  `toBuffer()` still returned `Uint8Array` sometimes
- The docs consistently type `toBuffer()` as `Promise<Buffer>`
- The current dependency is `^0.35.3`

The bug has been fixed for years. The variable name `resizedBufferish`
(with the ...ish suffix) is the only remaining trace of the old
uncertainty around the return type.

Instead of unconditionally copying, use [`Buffer.isBuffer()`][] to
check first:

```js
// Before (orientImageBuffer)
.then(buffer => Buffer.from(buffer))

// After — only copies if sharp returns a non-Buffer
.then(buffer =>
  Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer),
)

// Before (downscaleForPlateRecognizer)
.then(resizedBufferish => {
  const resizedBuffer = Buffer.from(resizedBufferish);

// After — guards the old bug without a copy in the common case
.then(resizedBuffer => {
  const safe =
    Buffer.isBuffer(resizedBuffer)
      ? resizedBuffer
      : Buffer.from(resizedBuffer);
```

In the normal case (sharp v0.35+), `Buffer.isBuffer()` returns `true`
and the original buffer is passed through. If the old bug ever recurs,
`Buffer.from()` still runs as a fallback.

- [sharp issue #1219][] — the original `Uint8Array` bug
- sharp: [`toBuffer()`][sharp toBuffer]
- sharp: [`toUint8Array()`][`toUint8Array()`]
- Node.js: [`Buffer.isBuffer()`][`Buffer.isBuffer()`]

[Buffer]: https://nodejs.org/api/buffer.html#buffer
[sharp issue #1219]: https://github.com/lovell/sharp/issues/1219#issuecomment-392299058
[sharp toBuffer]: https://sharp.pixelplumbing.com/api-output#tobuffer
[`toUint8Array()`]: https://sharp.pixelplumbing.com/api-output#touint8array
[`Buffer.isBuffer()`]: https://nodejs.org/api/buffer.html#static-method-bufferisbufferobj

Co-Authored-By: Claude Code with DeepSeek