### PR TITLE
fix: use wreq-js + GraphQL to bypass Cloudflare on LookupAPlate

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "util.promisify": "^1.0.0",
     "video-extensions": "^1.1.0",
     "whatwg-fetch": "^3.0.0",
+    "wreq-js": "^3.0.0",
     "zip-array": "^1.0.1"
   },
   "devDependencies": {

--- a/src/__snapshots__/getVehicleType.test.js.snap
+++ b/src/__snapshots__/getVehicleType.test.js.snap
@@ -3,12 +3,12 @@
 exports[`getVehicleType returns the right object 1`] = `
 {
   "result": {
-    "licensePlate": "TEST",
+    "licensePlate": "T144594C",
     "licenseState": "NY",
-    "vehicleBody": "Coupe",
-    "vehicleMake": "BMW",
-    "vehicleModel": "135i",
-    "vehicleYear": "2010",
+    "vehicleBody": "Minivan",
+    "vehicleMake": "TOYOTA",
+    "vehicleModel": "Sienna",
+    "vehicleYear": "2020",
   },
 }
 `;

--- a/src/getVehicleType.js
+++ b/src/getVehicleType.js
@@ -15,39 +15,58 @@ function getSession() {
 }
 
 // ported from https://github.com/jeffrono/Reported/blob/19b588171315a3093d53986f9fb995059f5084b4/v2/enrich_functions.rb#L325-L346
+//
+// Switched from the deprecated REST endpoint (/api/v1/wait_for_vehicle_details/)
+// to the current GraphQL API at /graphql.
 export default async function getVehicleType({ licensePlate, licenseState }) {
-  const url = `https://api.lookupaplate.com/api/v1/wait_for_vehicle_details/${licenseState}/${licensePlate}/`;
+  const url = 'https://api.lookupaplate.com/graphql';
 
-  console.time(url); // eslint-disable-line no-console
+  console.time(`getVehicleType ${licenseState}/${licensePlate}`); // eslint-disable-line no-console
 
   const session = await getSession();
 
   try {
     const res = await session.fetch(url, {
+      method: 'POST',
       headers: {
         Accept: 'application/json',
+        'Content-Type': 'application/json',
         Referer: 'https://lookupaplate.com/',
       },
+      body: JSON.stringify({
+        query: `{
+          licensePlate(licensePlate: "${licensePlate}", stateCode: "${licenseState}") {
+            vehicle {
+              make
+              model
+              year
+            }
+            vehicleJson
+          }
+        }`,
+      }),
     });
 
     if (!res.ok) {
       throw new Error(`LookupAPlate returned ${res.status} ${res.statusText}`);
     }
 
-    const data = await res.json();
-    const vehicleJson = data.vehicle_json || {};
+    const { data } = await res.json();
+    const lp = data?.licensePlate;
+    const vehicle = lp?.vehicle || {};
+    const vehicleJson = lp?.vehicleJson || {};
 
     return {
       result: {
-        vehicleYear: vehicleJson['29'] || undefined,
-        vehicleMake: vehicleJson['26'] || undefined,
-        vehicleModel: vehicleJson['28'] || undefined,
+        vehicleYear: vehicle.year || vehicleJson['29'] || undefined,
+        vehicleMake: vehicle.make || vehicleJson['26'] || undefined,
+        vehicleModel: vehicle.model || vehicleJson['28'] || undefined,
         vehicleBody: vehicleJson['5'] || undefined,
         licensePlate,
         licenseState,
       },
     };
   } finally {
-    console.timeEnd(url); // eslint-disable-line no-console
+    console.timeEnd(`getVehicleType ${licenseState}/${licensePlate}`); // eslint-disable-line no-console
   }
 }

--- a/src/getVehicleType.js
+++ b/src/getVehicleType.js
@@ -1,4 +1,18 @@
-import axios from 'axios';
+import { createSession } from 'wreq-js';
+
+// Lazily-created persistent session reused across calls.
+// Firefox TLS impersonation is needed to bypass Cloudflare anti-bot
+// detection on api.lookupaplate.com. The session is shared so that
+// subsequent requests reuse the same TLS session cache and cookies,
+// which reduces the chance of being challenged.
+let sessionPromise = null;
+
+function getSession() {
+  if (!sessionPromise) {
+    sessionPromise = createSession({ browser: 'firefox_151', os: 'macos' });
+  }
+  return sessionPromise;
+}
 
 // ported from https://github.com/jeffrono/Reported/blob/19b588171315a3093d53986f9fb995059f5084b4/v2/enrich_functions.rb#L325-L346
 export default async function getVehicleType({ licensePlate, licenseState }) {
@@ -6,27 +20,21 @@ export default async function getVehicleType({ licensePlate, licenseState }) {
 
   console.time(url); // eslint-disable-line no-console
 
+  const session = await getSession();
+
   try {
-    const { data } = await axios.get(url, {
+    const res = await session.fetch(url, {
       headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:132.0) Gecko/20100101 Firefox/132.0',
-        Accept:
-          'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.5',
-        'Accept-Encoding': 'gzip, deflate',
-        DNT: '1',
-        'Sec-GPC': '1',
-        Connection: 'keep-alive',
-        'Upgrade-Insecure-Requests': '1',
-        'Sec-Fetch-Dest': 'document',
-        'Sec-Fetch-Mode': 'navigate',
-        'Sec-Fetch-Site': 'none',
-        'Sec-Fetch-User': '?1',
-        Priority: 'u=0, i',
+        Accept: 'application/json',
+        Referer: 'https://lookupaplate.com/',
       },
     });
 
+    if (!res.ok) {
+      throw new Error(`LookupAPlate returned ${res.status} ${res.statusText}`);
+    }
+
+    const data = await res.json();
     const vehicleJson = data.vehicle_json || {};
 
     return {

--- a/src/getVehicleType.test.js
+++ b/src/getVehicleType.test.js
@@ -7,7 +7,7 @@ import getVehicleType from './getVehicleType.js';
 describe('getVehicleType', () => {
   test('returns the right object', async () => {
     const result = await getVehicleType({
-      licensePlate: 'TEST',
+      licensePlate: 'T144594C',
       licenseState: 'NY',
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11272,6 +11272,11 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
+wreq-js@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/wreq-js/-/wreq-js-3.0.0.tgz#450e0bf32a7a9b9c2df145e93a3f9b1f5facfa88"
+  integrity sha512-RZCoRSevVPpH4A4B4MxbFGo/pVPFveWd2gbe4ENKpPWlKXEYklZSDESOjBMmrIsmnkHh+nhM4PNJvG+NL7wBPA==
+
 write-file-atomic@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"


### PR DESCRIPTION
This tries to address https://github.com/josephfrazier/Reported-Web/issues/295,
but I suspect it might still get rate-limited, we'll see:

`api.lookupaplate.com` moved behind Cloudflare and retired its old REST
endpoint, breaking `getVehicleType`.  Two fixes:

**1. TLS impersonation via `wreq-js` instead of `axios`**

Node's default TLS fingerprint triggers Cloudflare's anti-bot challenge.
`wreq-js` impersonates a real browser at the transport layer (Firefox 151
on macOS), so requests pass through without being challenged.

**2. GraphQL instead of the defunct REST endpoint**

`/api/v1/wait_for_vehicle_details/` now returns 404 for every plate. The
actual endpoint is a GraphQL API at `/graphql`:

```graphql
licensePlate(licensePlate: "…", stateCode: "…") {
  vehicle { make model year }
  vehicleJson  # raw NMVTIS data — body class at key "5"
}
```

The response shape is backward-compatible — the function still returns
`{ result: { vehicleYear, vehicleMake, vehicleModel, vehicleBody,
licensePlate, licenseState } }`.

`wreq-js` uses native Rust bindings so it compiles from source if
prebuilt binaries aren't available for the platform (Heroku Linux x64
is prebuilt).

[`wreq-js`]: https://www.npmjs.com/package/wreq-js

Co-Authored-By: Claude Code with DeepSeek