### PR TITLE
style: change plate overlay color from amber to cyan

### DIFF
--- a/src/routes/home/Home.css
+++ b/src/routes/home/Home.css
@@ -45,14 +45,14 @@ input[type='search']::-webkit-search-cancel-button {
 .plate-overlay {
   position: absolute;
   padding: 0;
-  border: 2px solid rgb(255 193 7 / 90%);
-  background: rgb(255 193 7 / 25%);
+  border: 2px solid rgb(0 200 255 / 90%);
+  background: rgb(0 200 255 / 20%);
   cursor: pointer;
 }
 
 .plate-overlay:hover,
 .plate-overlay:focus-visible {
-  background: rgb(255 193 7 / 50%);
+  background: rgb(0 200 255 / 40%);
 }
 
 .plate-overlay-tooltip {


### PR DESCRIPTION
Amber (rgb(255,193,7)) blended in with NYC's yellow license plates.
Cyan (rgb(0,200,255)) is complementary and contrasts well against
common plate colors and car paint.

Co-Authored-By: Claude Code with DeepSeek