### PR TITLE
feat: add zoom in/out buttons to the map modal

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -2527,11 +2527,16 @@ const MyMapComponentPure = props => {
     onPlacesChanged,
   } = props;
 
+  let mapRef;
+
   return (
     <GoogleMap
       defaultZoom={16}
       center={position}
-      ref={onRef}
+      ref={map => {
+        mapRef = map;
+        onRef(map);
+      }}
       onCenterChanged={onCenterChanged}
       options={{ mapTypeControl: false, gestureHandling: 'greedy' }}
     >
@@ -2565,6 +2570,59 @@ const MyMapComponentPure = props => {
           }}
         />
       </SearchBox>
+      <div
+        style={{
+          position: 'absolute',
+          top: '10px',
+          right: '10px',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => mapRef && mapRef.setZoom(mapRef.getZoom() + 1)}
+          style={{
+            width: '40px',
+            height: '40px',
+            background: 'white',
+            border: 'none',
+            borderRadius: '2px 2px 0 0',
+            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.3)',
+            fontSize: '22px',
+            lineHeight: '40px',
+            textAlign: 'center',
+            cursor: 'pointer',
+            color: '#666',
+            padding: 0,
+            margin: 0,
+          }}
+        >
+          +
+        </button>
+        <button
+          type="button"
+          onClick={() => mapRef && mapRef.setZoom(mapRef.getZoom() - 1)}
+          style={{
+            width: '40px',
+            height: '40px',
+            background: 'white',
+            border: 'none',
+            borderTop: '1px solid #e6e6e6',
+            borderRadius: '0 0 2px 2px',
+            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.3)',
+            fontSize: '22px',
+            lineHeight: '40px',
+            textAlign: 'center',
+            cursor: 'pointer',
+            color: '#666',
+            padding: 0,
+            margin: 0,
+          }}
+        >
+          –
+        </button>
+      </div>
     </GoogleMap>
   );
 };

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -2527,18 +2527,17 @@ const MyMapComponentPure = props => {
     onPlacesChanged,
   } = props;
 
-  let mapRef;
-
   return (
     <GoogleMap
       defaultZoom={16}
       center={position}
-      ref={map => {
-        mapRef = map;
-        onRef(map);
-      }}
+      ref={onRef}
       onCenterChanged={onCenterChanged}
-      options={{ mapTypeControl: false, gestureHandling: 'greedy' }}
+      options={{
+        mapTypeControl: false,
+        zoomControl: true,
+        gestureHandling: 'greedy',
+      }}
     >
       <Marker position={position} />
       <SearchBox
@@ -2570,59 +2569,6 @@ const MyMapComponentPure = props => {
           }}
         />
       </SearchBox>
-      <div
-        style={{
-          position: 'absolute',
-          top: '10px',
-          right: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        <button
-          type="button"
-          onClick={() => mapRef && mapRef.setZoom(mapRef.getZoom() + 1)}
-          style={{
-            width: '40px',
-            height: '40px',
-            background: 'white',
-            border: 'none',
-            borderRadius: '2px 2px 0 0',
-            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.3)',
-            fontSize: '22px',
-            lineHeight: '40px',
-            textAlign: 'center',
-            cursor: 'pointer',
-            color: '#666',
-            padding: 0,
-            margin: 0,
-          }}
-        >
-          +
-        </button>
-        <button
-          type="button"
-          onClick={() => mapRef && mapRef.setZoom(mapRef.getZoom() - 1)}
-          style={{
-            width: '40px',
-            height: '40px',
-            background: 'white',
-            border: 'none',
-            borderTop: '1px solid #e6e6e6',
-            borderRadius: '0 0 2px 2px',
-            boxShadow: '0 2px 6px rgba(0, 0, 0, 0.3)',
-            fontSize: '22px',
-            lineHeight: '40px',
-            textAlign: 'center',
-            cursor: 'pointer',
-            color: '#666',
-            padding: 0,
-            margin: 0,
-          }}
-        >
-          –
-        </button>
-      </div>
     </GoogleMap>
   );
 };


### PR DESCRIPTION
The map modal in `MyMapComponentPure` previously had `mapTypeControl: false`
and no `zoomControl` option set, leaving users with only scroll/pinch gestures
to zoom the map. This enables Google Maps' built-in `+`/`–` zoom buttons so
there's an obvious clickable affordance.

**Change:** Add `zoomControl: true` to the `<GoogleMap>` `options` object in `src/routes/home/Home.js`.

```diff
- options={{ mapTypeControl: false, gestureHandling: 'greedy' }}
+ options={{ mapTypeControl: false, zoomControl: true, gestureHandling: 'greedy' }}
```

The built-in control is simpler and more reliable than custom buttons — the
first attempt at custom buttons hit a runtime error because the
`react-google-maps` wrapper doesn't expose `setZoom`/`getZoom` directly on the
component ref (those live on the context object, not the public API). The
native control avoids that entirely.

Co-Authored-By: Claude Code with DeepSeek