### PR TITLE
Hide submission form fields until photos are uploaded

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1961,151 +1961,7 @@ class Home extends React.Component {
                     </button>
                   </FileReaderInput>
 
-                  <div
-                    style={{
-                      clear: 'both',
-                      display: 'flex',
-                      flexWrap: 'wrap',
-                    }}
-                  >
-                    {this.state.attachmentData.map(attachmentFile => {
-                      const { name } = attachmentFile;
-                      const ext = fileExtension(name);
-                      const isImg = isImage({ ext });
-                      const src = getBlobUrl(attachmentFile);
-                      const attachmentPlateData =
-                        this.state.plateDataByAttachmentName[name];
-
-                      return (
-                        <div
-                          key={name}
-                          style={{
-                            width: '33%',
-                            margin: '0.1%',
-                            flexGrow: 1,
-                            position: 'relative',
-                          }}
-                        >
-                          <div
-                            style={{
-                              position: 'relative',
-                              display: 'inline-block',
-                              maxWidth: '100%',
-                            }}
-                          >
-                            <a
-                              href={src}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              style={{ display: 'block' }}
-                            >
-                              {isImg ? (
-                                <img
-                                  src={src}
-                                  alt={name}
-                                  style={{ display: 'block' }}
-                                  onLoad={e => {
-                                    const img = e.target;
-                                    this.imageNaturalSizes[name] = {
-                                      width: img.naturalWidth,
-                                      height: img.naturalHeight,
-                                    };
-                                  }}
-                                />
-                              ) : (
-                                /* eslint-disable-next-line jsx-a11y/media-has-caption */
-                                <video src={src} alt={name} />
-                              )}
-                            </a>
-                            {isImg &&
-                              this.renderPlateOverlays({
-                                attachmentName: name,
-                                attachmentPlateData,
-                              })}
-                          </div>
-
-                          <button
-                            type="button"
-                            style={{
-                              position: 'absolute',
-                              top: 0,
-                              right: 0,
-                              padding: 0,
-                              margin: '1px',
-                              color: 'red', // Ubuntu Chrome shows black otherwise
-                              background: 'white',
-                            }}
-                            onClick={() => {
-                              this.setState(state => {
-                                const attachmentData =
-                                  state.attachmentData.filter(
-                                    file => file.name !== name,
-                                  );
-                                if (attachmentData.length === 0) {
-                                  this.setCoords({
-                                    latitude: defaultLatitude,
-                                    longitude: defaultLongitude,
-                                  });
-                                  this.setCreateDate({
-                                    millisecondsSinceEpoch: Date.now(),
-                                  });
-                                  return {
-                                    attachmentData,
-                                    plate: '',
-                                    licenseState: 'NY',
-                                    allPlateData: null,
-                                    plateDataByAttachmentName: {},
-                                    vehicleInfoComponent: null,
-                                    violationSummaryComponent: null,
-                                  };
-                                }
-                                return {
-                                  attachmentData,
-                                  plateDataByAttachmentName: omit(
-                                    state.plateDataByAttachmentName,
-                                    name,
-                                  ),
-                                };
-                              });
-                            }}
-                          >
-                            <span role="img" aria-label="Delete photo/video">
-                              ❌
-                            </span>
-                          </button>
-
-                          {isImg && (
-                            <button
-                              type="button"
-                              style={{
-                                position: 'absolute',
-                                top: 0,
-                                left: 0,
-                                padding: 0,
-                                margin: '1px',
-                                background: 'white',
-                              }}
-                              onClick={() =>
-                                this.handlePlatePickerClick(attachmentFile)
-                              }
-                              disabled={this.state.platePickerLoading}
-                            >
-                              {this.state.platePickerLoading ? (
-                                <CircularProgress size="1em" />
-                              ) : (
-                                <span
-                                  role="img"
-                                  aria-label="Pick license plate from photo"
-                                >
-                                  🔍
-                                </span>
-                              )}
-                            </button>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
+                  <div style={{ clear: 'both' }} />
 
                   <label htmlFor="isAlprEnabled">
                     <input
@@ -2129,290 +1985,452 @@ class Home extends React.Component {
                     Automatically read addresses from pictures/videos
                   </label>
 
-                  <label htmlFor="plate">
-                    License/Medallion:
-                    {this.state.isAlprLoading && (
-                      <CircularProgress size="1em" />
-                    )}
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        alignItems: 'flex-start',
-                        gap: '0.5rem',
-                      }}
-                    >
-                      <div style={{ minWidth: 0, flex: 1 }}>
-                        <input
-                          required
-                          type="search"
-                          value={this.state.plate}
-                          name="plate"
-                          list="plateSuggestions"
-                          autoComplete="off"
-                          ref={this.plateRef}
-                          placeholder={this.state.allPlateData?.results?.[0]?.plate?.toUpperCase()}
-                          onChange={event => {
-                            const plate = event.target.value.toUpperCase();
-                            const matchedResult =
-                              this.state.allPlateData?.results?.find(
-                                r => r.plate?.toUpperCase() === plate,
-                              );
-                            const licenseState = matchedResult
-                              ? getLicenseStateFromPlateResult(matchedResult)
-                              : null;
-                            this.setLicensePlate({ plate, licenseState });
-                          }}
-                        />
-                        <datalist id="plateSuggestions">
-                          {this.state.allPlateData?.results?.map(result => (
-                            <option value={result.plate?.toUpperCase()} />
-                          ))}
-                        </datalist>
-                        <select
+                  {this.state.attachmentData.length > 0 && (
+                    <React.Fragment>
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexWrap: 'wrap',
+                        }}
+                      >
+                        {this.state.attachmentData.map(attachmentFile => {
+                          const { name } = attachmentFile;
+                          const ext = fileExtension(name);
+                          const isImg = isImage({ ext });
+                          const src = getBlobUrl(attachmentFile);
+                          const attachmentPlateData =
+                            this.state.plateDataByAttachmentName[name];
+
+                          return (
+                            <div
+                              key={name}
+                              style={{
+                                width: '33%',
+                                margin: '0.1%',
+                                flexGrow: 1,
+                                position: 'relative',
+                              }}
+                            >
+                              <div
+                                style={{
+                                  position: 'relative',
+                                  display: 'inline-block',
+                                  maxWidth: '100%',
+                                }}
+                              >
+                                <a
+                                  href={src}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  style={{ display: 'block' }}
+                                >
+                                  {isImg ? (
+                                    <img
+                                      src={src}
+                                      alt={name}
+                                      style={{ display: 'block' }}
+                                      onLoad={e => {
+                                        const img = e.target;
+                                        this.imageNaturalSizes[name] = {
+                                          width: img.naturalWidth,
+                                          height: img.naturalHeight,
+                                        };
+                                      }}
+                                    />
+                                  ) : (
+                                    /* eslint-disable-next-line jsx-a11y/media-has-caption */
+                                    <video src={src} alt={name} />
+                                  )}
+                                </a>
+                                {isImg &&
+                                  this.renderPlateOverlays({
+                                    attachmentName: name,
+                                    attachmentPlateData,
+                                  })}
+                              </div>
+
+                              <button
+                                type="button"
+                                style={{
+                                  position: 'absolute',
+                                  top: 0,
+                                  right: 0,
+                                  padding: 0,
+                                  margin: '1px',
+                                  color: 'red', // Ubuntu Chrome shows black otherwise
+                                  background: 'white',
+                                }}
+                                onClick={() => {
+                                  this.setState(state => {
+                                    const attachmentData =
+                                      state.attachmentData.filter(
+                                        file => file.name !== name,
+                                      );
+                                    if (attachmentData.length === 0) {
+                                      this.setCoords({
+                                        latitude: defaultLatitude,
+                                        longitude: defaultLongitude,
+                                      });
+                                      this.setCreateDate({
+                                        millisecondsSinceEpoch: Date.now(),
+                                      });
+                                      return {
+                                        attachmentData,
+                                        plate: '',
+                                        licenseState: 'NY',
+                                        allPlateData: null,
+                                        plateDataByAttachmentName: {},
+                                        vehicleInfoComponent: null,
+                                        violationSummaryComponent: null,
+                                      };
+                                    }
+                                    return {
+                                      attachmentData,
+                                      plateDataByAttachmentName: omit(
+                                        state.plateDataByAttachmentName,
+                                        name,
+                                      ),
+                                    };
+                                  });
+                                }}
+                              >
+                                <span
+                                  role="img"
+                                  aria-label="Delete photo/video"
+                                >
+                                  ❌
+                                </span>
+                              </button>
+
+                              {isImg && (
+                                <button
+                                  type="button"
+                                  style={{
+                                    position: 'absolute',
+                                    top: 0,
+                                    left: 0,
+                                    padding: 0,
+                                    margin: '1px',
+                                    background: 'white',
+                                  }}
+                                  onClick={() =>
+                                    this.handlePlatePickerClick(attachmentFile)
+                                  }
+                                  disabled={this.state.platePickerLoading}
+                                >
+                                  {this.state.platePickerLoading ? (
+                                    <CircularProgress size="1em" />
+                                  ) : (
+                                    <span
+                                      role="img"
+                                      aria-label="Pick license plate from photo"
+                                    >
+                                      🔍
+                                    </span>
+                                  )}
+                                </button>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+
+                      <label htmlFor="plate">
+                        License/Medallion:
+                        {this.state.isAlprLoading && (
+                          <CircularProgress size="1em" />
+                        )}
+                        <div
                           style={{
-                            marginTop: '0.5rem',
-                          }}
-                          value={this.state.licenseState}
-                          name="licenseState"
-                          onChange={event => {
-                            this.setLicensePlate({
-                              plate: this.state.plate,
-                              licenseState: event.target.value,
-                            });
+                            display: 'flex',
+                            flexWrap: 'wrap',
+                            alignItems: 'flex-start',
+                            gap: '0.5rem',
                           }}
                         >
-                          {Object.entries(usStateNames)
-                            .sort(([, name1], [, name2]) =>
-                              name1
-                                .toUpperCase()
-                                .localeCompare(name2.toUpperCase()),
-                            )
-                            .map(([abbr, name]) => (
-                              <option key={abbr} value={abbr}>
-                                {name}
+                          <div style={{ minWidth: 0, flex: 1 }}>
+                            <input
+                              required
+                              type="search"
+                              value={this.state.plate}
+                              name="plate"
+                              list="plateSuggestions"
+                              autoComplete="off"
+                              ref={this.plateRef}
+                              placeholder={this.state.allPlateData?.results?.[0]?.plate?.toUpperCase()}
+                              onChange={event => {
+                                const plate = event.target.value.toUpperCase();
+                                const matchedResult =
+                                  this.state.allPlateData?.results?.find(
+                                    r => r.plate?.toUpperCase() === plate,
+                                  );
+                                const licenseState = matchedResult
+                                  ? getLicenseStateFromPlateResult(
+                                      matchedResult,
+                                    )
+                                  : null;
+                                this.setLicensePlate({ plate, licenseState });
+                              }}
+                            />
+                            <datalist id="plateSuggestions">
+                              {this.state.allPlateData?.results?.map(result => (
+                                <option value={result.plate?.toUpperCase()} />
+                              ))}
+                            </datalist>
+                            <select
+                              style={{
+                                marginTop: '0.5rem',
+                              }}
+                              value={this.state.licenseState}
+                              name="licenseState"
+                              onChange={event => {
+                                this.setLicensePlate({
+                                  plate: this.state.plate,
+                                  licenseState: event.target.value,
+                                });
+                              }}
+                            >
+                              {Object.entries(usStateNames)
+                                .sort(([, name1], [, name2]) =>
+                                  name1
+                                    .toUpperCase()
+                                    .localeCompare(name2.toUpperCase()),
+                                )
+                                .map(([abbr, name]) => (
+                                  <option key={abbr} value={abbr}>
+                                    {name}
+                                  </option>
+                                ))}
+                            </select>
+                          </div>
+                          {matchingPlateThumbnail && (
+                            <img
+                              src={matchingPlateThumbnail}
+                              alt="Detected license plate"
+                              style={{
+                                maxHeight: '5rem',
+                                maxWidth: '12rem',
+                                objectFit: 'contain',
+                              }}
+                            />
+                          )}
+                        </div>
+                        <div>{this.state.violationSummaryComponent}</div>
+                        <div>{this.state.vehicleInfoComponent}</div>
+                      </label>
+
+                      <label htmlFor="typeofcomplaint">
+                        Type:{' '}
+                        <select
+                          value={this.state.typeofcomplaint}
+                          name="typeofcomplaint"
+                          onChange={this.handleInputChange}
+                        >
+                          {this.props.typeofcomplaintValues.map(
+                            typeofcomplaint => (
+                              <option
+                                key={typeofcomplaint}
+                                value={typeofcomplaint}
+                              >
+                                {typeofcomplaint}
                               </option>
-                            ))}
+                            ),
+                          )}
                         </select>
-                      </div>
-                      {matchingPlateThumbnail && (
-                        <img
-                          src={matchingPlateThumbnail}
-                          alt="Detected license plate"
+                      </label>
+
+                      <label htmlFor="where">
+                        Where: {this.state.addressProvenance}
+                        <br />
+                        <button
+                          type="button"
+                          name="where"
+                          onClick={() => this.setState({ isMapOpen: true })}
                           style={{
-                            maxHeight: '5rem',
-                            maxWidth: '12rem',
-                            objectFit: 'contain',
+                            width: '100%',
+                          }}
+                        >
+                          {this.state.formatted_address
+                            .split(', ')
+                            .slice(0, 2)
+                            .join(', ')}
+                        </button>
+                      </label>
+
+                      <Modal
+                        parentSelector={() =>
+                          document.querySelector(`.${homeStyles.root}`) ||
+                          document.body
+                        }
+                        isOpen={this.state.isMapOpen}
+                        onRequestClose={() =>
+                          this.setState({ isMapOpen: false })
+                        }
+                        style={{
+                          content: {
+                            padding: 0,
+                          },
+                        }}
+                      >
+                        <MyMapComponent
+                          key="map"
+                          position={{
+                            lat: this.state.latitude,
+                            lng: this.state.longitude,
+                          }}
+                          onRef={mapRef => {
+                            this.mapRef = mapRef;
+                          }}
+                          onCenterChanged={() => {
+                            const latitude = this.mapRef.getCenter().lat();
+                            const longitude = this.mapRef.getCenter().lng();
+                            this.setCoords({
+                              latitude,
+                              longitude,
+                              addressProvenance: '(manually set)',
+                            });
+                          }}
+                          onDragStart={() => {
+                            this.isDragging = true;
+                          }}
+                          onDragEnd={() => {
+                            this.isDragging = false;
+                          }}
+                          onSearchBoxMounted={ref => {
+                            this.searchBox = ref;
+                          }}
+                          onPlacesChanged={() => {
+                            const places = this.searchBox.getPlaces();
+
+                            const nextMarkers = places.map(place => ({
+                              position: place.geometry.location,
+                            }));
+                            const { latitude, longitude } =
+                              nextMarkers.length > 0
+                                ? {
+                                    latitude: nextMarkers[0].position.lat(),
+                                    longitude: nextMarkers[0].position.lng(),
+                                  }
+                                : this.state;
+
+                            this.setCoords({
+                              latitude,
+                              longitude,
+                              addressProvenance: '(manually set)',
+                            });
                           }}
                         />
-                      )}
-                    </div>
-                    <div>{this.state.violationSummaryComponent}</div>
-                    <div>{this.state.vehicleInfoComponent}</div>
-                  </label>
 
-                  <label htmlFor="typeofcomplaint">
-                    Type:{' '}
-                    <select
-                      value={this.state.typeofcomplaint}
-                      name="typeofcomplaint"
-                      onChange={this.handleInputChange}
-                    >
-                      {this.props.typeofcomplaintValues.map(typeofcomplaint => (
-                        <option key={typeofcomplaint} value={typeofcomplaint}>
-                          {typeofcomplaint}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-
-                  <label htmlFor="where">
-                    Where: {this.state.addressProvenance}
-                    <br />
-                    <button
-                      type="button"
-                      name="where"
-                      onClick={() => this.setState({ isMapOpen: true })}
-                      style={{
-                        width: '100%',
-                      }}
-                    >
-                      {this.state.formatted_address
-                        .split(', ')
-                        .slice(0, 2)
-                        .join(', ')}
-                    </button>
-                  </label>
-
-                  <Modal
-                    parentSelector={() =>
-                      document.querySelector(`.${homeStyles.root}`) ||
-                      document.body
-                    }
-                    isOpen={this.state.isMapOpen}
-                    onRequestClose={() => this.setState({ isMapOpen: false })}
-                    style={{
-                      content: {
-                        padding: 0,
-                      },
-                    }}
-                  >
-                    <MyMapComponent
-                      key="map"
-                      position={{
-                        lat: this.state.latitude,
-                        lng: this.state.longitude,
-                      }}
-                      onRef={mapRef => {
-                        this.mapRef = mapRef;
-                      }}
-                      onCenterChanged={() => {
-                        const latitude = this.mapRef.getCenter().lat();
-                        const longitude = this.mapRef.getCenter().lng();
-                        this.setCoords({
-                          latitude,
-                          longitude,
-                          addressProvenance: '(manually set)',
-                        });
-                      }}
-                      onDragStart={() => {
-                        this.isDragging = true;
-                      }}
-                      onDragEnd={() => {
-                        this.isDragging = false;
-                      }}
-                      onSearchBoxMounted={ref => {
-                        this.searchBox = ref;
-                      }}
-                      onPlacesChanged={() => {
-                        const places = this.searchBox.getPlaces();
-
-                        const nextMarkers = places.map(place => ({
-                          position: place.geometry.location,
-                        }));
-                        const { latitude, longitude } =
-                          nextMarkers.length > 0
-                            ? {
-                                latitude: nextMarkers[0].position.lat(),
-                                longitude: nextMarkers[0].position.lng(),
-                              }
-                            : this.state;
-
-                        this.setCoords({
-                          latitude,
-                          longitude,
-                          addressProvenance: '(manually set)',
-                        });
-                      }}
-                    />
-
-                    <button
-                      type="button"
-                      style={{
-                        float: 'left',
-                      }}
-                      onClick={() => {
-                        geolocate()
-                          .then(
-                            ({
-                              coords: { latitude, longitude },
-                              ipProvenance = 'device',
-                            }) => {
-                              this.setCoords({
-                                latitude,
-                                longitude,
-                                addressProvenance: `(from ${ipProvenance}: ${latitude}, ${longitude})`,
+                        <button
+                          type="button"
+                          style={{
+                            float: 'left',
+                          }}
+                          onClick={() => {
+                            geolocate()
+                              .then(
+                                ({
+                                  coords: { latitude, longitude },
+                                  ipProvenance = 'device',
+                                }) => {
+                                  this.setCoords({
+                                    latitude,
+                                    longitude,
+                                    addressProvenance: `(from ${ipProvenance}: ${latitude}, ${longitude})`,
+                                  });
+                                },
+                              )
+                              .catch(err => {
+                                Home.notifyError(err.message);
+                                console.error(err);
                               });
-                            },
-                          )
-                          .catch(err => {
-                            Home.notifyError(err.message);
-                            console.error(err);
-                          });
-                      }}
-                    >
-                      Use current location
-                    </button>
+                          }}
+                        >
+                          Use current location
+                        </button>
 
-                    <button
-                      type="button"
-                      onClick={() => this.setState({ isMapOpen: false })}
-                      style={{
-                        float: 'right',
-                      }}
-                    >
-                      Close
-                    </button>
-                  </Modal>
+                        <button
+                          type="button"
+                          onClick={() => this.setState({ isMapOpen: false })}
+                          style={{
+                            float: 'right',
+                          }}
+                        >
+                          Close
+                        </button>
+                      </Modal>
 
-                  <PlatePickerModal
-                    isOpen={this.state.platePickerModalOpen}
-                    results={this.state.platePickerResults}
-                    onSelectPlate={({ plate, licenseState }) => {
-                      this.setLicensePlate({ plate, licenseState });
-                      this.setState({ platePickerModalOpen: false });
-                    }}
-                    onClose={() =>
-                      this.setState({ platePickerModalOpen: false })
-                    }
-                  />
+                      <PlatePickerModal
+                        isOpen={this.state.platePickerModalOpen}
+                        results={this.state.platePickerResults}
+                        onSelectPlate={({ plate, licenseState }) => {
+                          this.setLicensePlate({ plate, licenseState });
+                          this.setState({ platePickerModalOpen: false });
+                        }}
+                        onClose={() =>
+                          this.setState({ platePickerModalOpen: false })
+                        }
+                      />
 
-                  <label htmlFor="CreateDate">
-                    When:{' '}
-                    <input
-                      required
-                      type="datetime-local"
-                      value={this.state.CreateDate}
-                      name="CreateDate"
-                      onChange={this.handleInputChange}
-                    />
-                  </label>
+                      <label htmlFor="CreateDate">
+                        When:{' '}
+                        <input
+                          required
+                          type="datetime-local"
+                          value={this.state.CreateDate}
+                          name="CreateDate"
+                          onChange={this.handleInputChange}
+                        />
+                      </label>
 
-                  <label htmlFor="reportDescription">
-                    Description:{' '}
-                    <textarea
-                      value={this.state.reportDescription}
-                      name="reportDescription"
-                      onChange={this.handleInputChange}
-                      autoComplete="off"
-                    />
-                  </label>
+                      <label htmlFor="reportDescription">
+                        Description:{' '}
+                        <textarea
+                          value={this.state.reportDescription}
+                          name="reportDescription"
+                          onChange={this.handleInputChange}
+                          autoComplete="off"
+                        />
+                      </label>
 
-                  <label htmlFor="can_be_shared_publicly">
-                    <input
-                      id="can_be_shared_publicly"
-                      type="checkbox"
-                      checked={this.state.can_be_shared_publicly}
-                      name="can_be_shared_publicly"
-                      onChange={this.handleInputChange}
-                    />{' '}
-                    Allow the photos/videos, description, category, and location
-                    to be publicly displayed
-                  </label>
+                      <label htmlFor="can_be_shared_publicly">
+                        <input
+                          id="can_be_shared_publicly"
+                          type="checkbox"
+                          checked={this.state.can_be_shared_publicly}
+                          name="can_be_shared_publicly"
+                          onChange={this.handleInputChange}
+                        />{' '}
+                        Allow the photos/videos, description, category, and
+                        location to be publicly displayed
+                      </label>
 
-                  {this.state.isSubmitting ? (
-                    <progress
-                      max={this.state.submitProgressMax}
-                      value={this.state.submitProgressValue}
-                      style={{
-                        width: '100%',
-                      }}
-                    >
-                      {this.state.submitProgressValue}/
-                      {this.state.submitProgressMax}
-                    </progress>
-                  ) : (
-                    <button
-                      type="submit"
-                      disabled={
-                        this.state.isSubmitting || !this.state.coordsAreInNyc
-                      }
-                      style={{
-                        width: '100%',
-                      }}
-                    >
-                      Submit
-                    </button>
+                      {this.state.isSubmitting ? (
+                        <progress
+                          max={this.state.submitProgressMax}
+                          value={this.state.submitProgressValue}
+                          style={{
+                            width: '100%',
+                          }}
+                        >
+                          {this.state.submitProgressValue}/
+                          {this.state.submitProgressMax}
+                        </progress>
+                      ) : (
+                        <button
+                          type="submit"
+                          disabled={
+                            this.state.isSubmitting ||
+                            !this.state.coordsAreInNyc
+                          }
+                          style={{
+                            width: '100%',
+                          }}
+                        >
+                          Submit
+                        </button>
+                      )}
+                    </React.Fragment>
                   )}
                 </fieldset>
               </form>

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -53,16 +53,41 @@ function renderHome({ initialState, homeRef } = {}) {
 }
 
 describe('Home', () => {
-  test('renders submission form and Previous Submissions when logged in', () => {
+  test('renders submission form and Previous Submissions when logged in with photos', () => {
     const initialState = {
       email: 'test@example.com',
       loginSuccessful: true,
     };
 
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
     let tree;
+    const homeRef = React.createRef();
     renderer.act(() => {
-      tree = renderHome({ initialState });
+      tree = renderHome({ initialState, homeRef });
     });
+    renderer.act(() => {
+      homeRef.current.setState({
+        attachmentData: [
+          new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+        ],
+      });
+    });
+
+    expect(tree.toJSON()).toMatchSnapshot();
+
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
+  test('hides form fields when logged in with no photos uploaded', () => {
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+    };
+
+    const tree = renderHome({ initialState });
 
     expect(tree.toJSON()).toMatchSnapshot();
 
@@ -114,11 +139,14 @@ describe('Home', () => {
     tree.unmount();
   });
 
-  test('renders with undefined allPlateResults', () => {
+  test('renders with undefined allPlateResults and photos', () => {
     const initialState = {
       email: 'test@example.com',
       loginSuccessful: true,
     };
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
 
     let tree;
     const homeRef = React.createRef();
@@ -126,19 +154,28 @@ describe('Home', () => {
       tree = renderHome({ initialState, homeRef });
     });
     renderer.act(() => {
-      homeRef.current.setState({ allPlateResults: undefined });
+      homeRef.current.setState({
+        allPlateResults: undefined,
+        attachmentData: [
+          new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+        ],
+      });
     });
 
     expect(tree.toJSON()).toMatchSnapshot();
 
     tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
   });
 
-  test('renders with allPlateResults entry missing plate', () => {
+  test('renders with allPlateResults entry missing plate and photos', () => {
     const initialState = {
       email: 'test@example.com',
       loginSuccessful: true,
     };
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
 
     let tree;
     const homeRef = React.createRef();
@@ -147,12 +184,18 @@ describe('Home', () => {
     });
     // Entry exists but has no .plate — .toUpperCase() on undefined throws
     renderer.act(() => {
-      homeRef.current.setState({ allPlateResults: [{ region: {} }] });
+      homeRef.current.setState({
+        allPlateResults: [{ region: {} }],
+        attachmentData: [
+          new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+        ],
+      });
     });
 
     expect(tree.toJSON()).toMatchSnapshot();
 
     tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
   });
 
   test('renders plate overlays on uploaded images and selects plate on click', () => {

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -1,5 +1,212 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Home hides form fields when logged in with no photos uploaded 1`] = `
+<div
+  aria-disabled={false}
+  className="root"
+  onClick={[Function]}
+  onDragEnter={[Function]}
+  onDragLeave={[Function]}
+  onDragOver={[Function]}
+  onDragStart={[Function]}
+  onDrop={[Function]}
+  style={
+    {
+      "bottom": 0,
+      "left": 0,
+      "overflowY": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    className="container"
+  >
+    <main>
+      <h1>
+        <a
+          href="https://reportedly.weebly.com/"
+          style={
+            {
+              "textDecoration": "underline",
+            }
+          }
+        >
+          Reported
+        </a>
+      </h1>
+      <div
+        className="Toastify"
+      />
+      <div
+        className="user-status-bar"
+      >
+        <div
+          className="user-greeting"
+        >
+          <span
+            aria-label="user"
+            role="img"
+          >
+            👤
+          </span>
+           
+          test@example.com
+        </div>
+        <div
+          className="user-actions"
+        >
+          <button
+            className="status-bar-btn-primary"
+            onClick={[Function]}
+            type="button"
+          >
+            Edit Profile
+          </button>
+          <button
+            className="status-bar-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Log Out
+          </button>
+        </div>
+      </div>
+      <form
+        onSubmit={[Function]}
+      >
+        <fieldset
+          disabled={false}
+        >
+          <div
+            className="_react-file-reader-input"
+            onClick={[Function]}
+            style={
+              {
+                "float": "left",
+                "margin": "1px",
+              }
+            }
+          >
+            <input
+              multiple={true}
+              onChange={[Function]}
+              onClick={[Function]}
+              style={
+                {
+                  "position": "absolute",
+                  "top": "-9999px",
+                }
+              }
+              type="file"
+            />
+            <button
+              style={
+                {
+                  "whiteSpace": "wrap",
+                }
+              }
+              type="button"
+            >
+              Add pictures/videos (up to 3 each, 20MB max each)
+            </button>
+          </div>
+          <div
+            style={
+              {
+                "clear": "both",
+              }
+            }
+          />
+          <label
+            htmlFor="isAlprEnabled"
+          >
+            <input
+              checked={true}
+              id="isAlprEnabled"
+              name="isAlprEnabled"
+              onChange={[Function]}
+              type="checkbox"
+            />
+             
+            Automatically read license plates from pictures/videos
+          </label>
+          <label
+            htmlFor="isReverseGeocodingEnabled"
+          >
+            <input
+              checked={true}
+              id="isReverseGeocodingEnabled"
+              name="isReverseGeocodingEnabled"
+              onChange={[Function]}
+              type="checkbox"
+            />
+             
+            Automatically read addresses from pictures/videos
+          </label>
+        </fieldset>
+      </form>
+      <br />
+      <details
+        onToggle={[Function]}
+      >
+        <summary>
+          Previous Submissions (
+          expand to load
+          )
+        </summary>
+      </details>
+      <div
+        style={
+          {
+            "float": "right",
+          }
+        }
+      >
+        <a
+          href="/submissions-map"
+          style={
+            {
+              "background": "black",
+              "border": "1em solid black",
+              "borderRadius": "2em",
+              "textDecoration": "none",
+            }
+          }
+        >
+          <span
+            aria-label="world map"
+            role="img"
+          >
+            🗺️
+          </span>
+        </a>
+      </div>
+    </main>
+  </div>
+  <input
+    autoComplete="off"
+    disabled={false}
+    multiple={true}
+    onChange={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 0.00001,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="file"
+  />
+</div>
+`;
+
 exports[`Home renders Edit Profile UI 1`] = `
 <div
   aria-disabled={false}
@@ -870,7 +1077,7 @@ exports[`Home renders auth prompt and hides form when logged out 1`] = `
 </div>
 `;
 
-exports[`Home renders submission form and Previous Submissions when logged in 1`] = `
+exports[`Home renders submission form and Previous Submissions when logged in with photos 1`] = `
 <div
   aria-disabled={false}
   className="root"
@@ -987,8 +1194,6 @@ exports[`Home renders submission form and Previous Submissions when logged in 1`
             style={
               {
                 "clear": "both",
-                "display": "flex",
-                "flexWrap": "wrap",
               }
             }
           />
@@ -1018,6 +1223,101 @@ exports[`Home renders submission form and Previous Submissions when logged in 1`
              
             Automatically read addresses from pictures/videos
           </label>
+          <div
+            style={
+              {
+                "display": "flex",
+                "flexWrap": "wrap",
+              }
+            }
+          >
+            <div
+              style={
+                {
+                  "flexGrow": 1,
+                  "margin": "0.1%",
+                  "position": "relative",
+                  "width": "33%",
+                }
+              }
+            >
+              <div
+                style={
+                  {
+                    "display": "inline-block",
+                    "maxWidth": "100%",
+                    "position": "relative",
+                  }
+                }
+              >
+                <a
+                  href="blob:mock"
+                  rel="noopener noreferrer"
+                  style={
+                    {
+                      "display": "block",
+                    }
+                  }
+                  target="_blank"
+                >
+                  <img
+                    alt="photo.jpg"
+                    onLoad={[Function]}
+                    src="blob:mock"
+                    style={
+                      {
+                        "display": "block",
+                      }
+                    }
+                  />
+                </a>
+              </div>
+              <button
+                onClick={[Function]}
+                style={
+                  {
+                    "background": "white",
+                    "color": "red",
+                    "margin": "1px",
+                    "padding": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  aria-label="Delete photo/video"
+                  role="img"
+                >
+                  ❌
+                </span>
+              </button>
+              <button
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  {
+                    "background": "white",
+                    "left": 0,
+                    "margin": "1px",
+                    "padding": 0,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  aria-label="Pick license plate from photo"
+                  role="img"
+                >
+                  🔍
+                </span>
+              </button>
+            </div>
+          </div>
           <label
             htmlFor="plate"
           >
@@ -1488,7 +1788,7 @@ exports[`Home renders submission form and Previous Submissions when logged in 1`
 </div>
 `;
 
-exports[`Home renders with allPlateResults entry missing plate 1`] = `
+exports[`Home renders with allPlateResults entry missing plate and photos 1`] = `
 <div
   aria-disabled={false}
   className="root"
@@ -1605,8 +1905,6 @@ exports[`Home renders with allPlateResults entry missing plate 1`] = `
             style={
               {
                 "clear": "both",
-                "display": "flex",
-                "flexWrap": "wrap",
               }
             }
           />
@@ -1636,6 +1934,101 @@ exports[`Home renders with allPlateResults entry missing plate 1`] = `
              
             Automatically read addresses from pictures/videos
           </label>
+          <div
+            style={
+              {
+                "display": "flex",
+                "flexWrap": "wrap",
+              }
+            }
+          >
+            <div
+              style={
+                {
+                  "flexGrow": 1,
+                  "margin": "0.1%",
+                  "position": "relative",
+                  "width": "33%",
+                }
+              }
+            >
+              <div
+                style={
+                  {
+                    "display": "inline-block",
+                    "maxWidth": "100%",
+                    "position": "relative",
+                  }
+                }
+              >
+                <a
+                  href="blob:mock"
+                  rel="noopener noreferrer"
+                  style={
+                    {
+                      "display": "block",
+                    }
+                  }
+                  target="_blank"
+                >
+                  <img
+                    alt="photo.jpg"
+                    onLoad={[Function]}
+                    src="blob:mock"
+                    style={
+                      {
+                        "display": "block",
+                      }
+                    }
+                  />
+                </a>
+              </div>
+              <button
+                onClick={[Function]}
+                style={
+                  {
+                    "background": "white",
+                    "color": "red",
+                    "margin": "1px",
+                    "padding": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  aria-label="Delete photo/video"
+                  role="img"
+                >
+                  ❌
+                </span>
+              </button>
+              <button
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  {
+                    "background": "white",
+                    "left": 0,
+                    "margin": "1px",
+                    "padding": 0,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  aria-label="Pick license plate from photo"
+                  role="img"
+                >
+                  🔍
+                </span>
+              </button>
+            </div>
+          </div>
           <label
             htmlFor="plate"
           >
@@ -2106,7 +2499,7 @@ exports[`Home renders with allPlateResults entry missing plate 1`] = `
 </div>
 `;
 
-exports[`Home renders with undefined allPlateResults 1`] = `
+exports[`Home renders with undefined allPlateResults and photos 1`] = `
 <div
   aria-disabled={false}
   className="root"
@@ -2223,8 +2616,6 @@ exports[`Home renders with undefined allPlateResults 1`] = `
             style={
               {
                 "clear": "both",
-                "display": "flex",
-                "flexWrap": "wrap",
               }
             }
           />
@@ -2254,6 +2645,101 @@ exports[`Home renders with undefined allPlateResults 1`] = `
              
             Automatically read addresses from pictures/videos
           </label>
+          <div
+            style={
+              {
+                "display": "flex",
+                "flexWrap": "wrap",
+              }
+            }
+          >
+            <div
+              style={
+                {
+                  "flexGrow": 1,
+                  "margin": "0.1%",
+                  "position": "relative",
+                  "width": "33%",
+                }
+              }
+            >
+              <div
+                style={
+                  {
+                    "display": "inline-block",
+                    "maxWidth": "100%",
+                    "position": "relative",
+                  }
+                }
+              >
+                <a
+                  href="blob:mock"
+                  rel="noopener noreferrer"
+                  style={
+                    {
+                      "display": "block",
+                    }
+                  }
+                  target="_blank"
+                >
+                  <img
+                    alt="photo.jpg"
+                    onLoad={[Function]}
+                    src="blob:mock"
+                    style={
+                      {
+                        "display": "block",
+                      }
+                    }
+                  />
+                </a>
+              </div>
+              <button
+                onClick={[Function]}
+                style={
+                  {
+                    "background": "white",
+                    "color": "red",
+                    "margin": "1px",
+                    "padding": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  aria-label="Delete photo/video"
+                  role="img"
+                >
+                  ❌
+                </span>
+              </button>
+              <button
+                disabled={false}
+                onClick={[Function]}
+                style={
+                  {
+                    "background": "white",
+                    "left": 0,
+                    "margin": "1px",
+                    "padding": 0,
+                    "position": "absolute",
+                    "top": 0,
+                  }
+                }
+                type="button"
+              >
+                <span
+                  aria-label="Pick license plate from photo"
+                  role="img"
+                >
+                  🔍
+                </span>
+              </button>
+            </div>
+          </div>
           <label
             htmlFor="plate"
           >


### PR DESCRIPTION
Before, the full form was shown immediately after login — plate input, complaint type, location picker, date, description, and submit button — even before the user had added any photos.

Now, only the "Add pictures/videos" button and the two toggle checkboxes (ALPR and reverse-geocoding) are visible until at least one photo is uploaded. Once a photo is added, the rest of the form appears.

This reduces initial visual clutter and guides the user toward the natural first step: adding evidence before filling in details.

## Changes

- `src/routes/home/Home.js` — wrapped thumbnails and remaining form fields in a conditional that only renders when `attachmentData.length > 0`; added a `clear:both` spacer between the upload button and the always-visible checkboxes
- `src/routes/home/Home.test.js` — added `attachmentData` to 3 existing snapshot tests (renamed with "and photos" suffix) so they continue to verify the full-form state; added one test verifying the hidden state when no photos are uploaded
- Snapshot updates to reflect the new conditional rendering

Co-Authored-By: Claude Code with DeepSeek