### PR TITLE
fix(deps): upgrade transitive `js-yaml` to fix GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7103,17 +7103,17 @@ js-tokens@^3.0.2:
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
 js-yaml@^3.10.0, js-yaml@^3.13.1:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
-  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Dependabot alerts #459 and #460 report that `js-yaml` is vulnerable to
GHSA-5p4m-2wfm-xmqj (CVE-2026-59870 fix not backported): quadratic CPU
consumption when resolving `!!omap` YAML tags, exploitable as a DoS
(CVSS 7.5, high severity).

The advisory covers two version ranges, each of which produced its own
alert because both were pinned in `yarn.lock`:

- `js-yaml@4.3.0` (alert #459), required by `eslint`, `@eslint/eslintrc`,
  `stylelint`, and `postcss-loader` (via `cosmiconfig`) — fixed in 4.3.1
- `js-yaml@3.15.0` (alert #460), required by `front-matter` and
  `babel-jest` (via `@istanbuljs/load-nyc-config`) — fixed in 3.15.1

Dependabot couldn't auto-update because the alerts were filed the same
day the advisory was published, before the patched releases hit the npm
registry. Both patched releases now exist and satisfy the existing
semver ranges (`^4.1.0`, `^3.10.0`, `^3.13.1`), so no `package.json`
changes are needed — only the `yarn.lock` resolutions.

Since `yarn@1` refused to re-resolve the transitive entries via
`yarn upgrade js-yaml`, the two `js-yaml` entries in `yarn.lock` were
updated directly (version, `resolved`, and `integrity` from the npm
registry) and `yarn install` verified the tarballs against the new
integrity hashes.

[GHSA-5p4m-2wfm-xmqj]: https://github.com/advisories/GHSA-5p4m-2wfm-xmqj

Co-Authored-By: Claude Code with DeepSeek