### PR TITLE
fix(deps): upgrade transitive `brace-expansion` to fix GHSA-rgw5-rvv9-x895

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3377,17 +3377,17 @@ boolbase@^1.0.0:
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
Dependabot reports that `brace-expansion` is vulnerable to a DoS via
unbounded intermediate arrays (GHSA-rgw5-rvv9-x895, high, CVSS 7.5),
bypassing the CVE-2026-14257 mitigation.

Both instances pinned in `yarn.lock` are vulnerable:

- `brace-expansion@1.1.15`, required by `minimatch@3` (via
  `@eslint/eslintrc`, `eslint`, `babel-jest`, and others) — fixed in
  1.1.18
- `brace-expansion@2.0.1`, required by `minimatch@9` (via `glob` and
  `jest`) — fixed in 2.1.4

Both fixes satisfy the semver ranges that `minimatch` already declares
(`^1.1.7` and `^2.0.1`), so no `package.json` changes are needed — only
the `yarn.lock` resolutions were updated (version, `resolved`, and
`integrity` from the npm registry), and `yarn install` verified the
tarballs against the new integrity hashes.

[GHSA-rgw5-rvv9-x895]: https://github.com/advisories/GHSA-rgw5-rvv9-x895

Co-Authored-By: Claude Code with DeepSeek