### PR TITLE
test: add SSR CSS pipeline regression checks

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,3 +23,6 @@ jobs:
     - run: yarn build --release
       env:
         CI: true
+    - run: yarn test:ssr-css
+      env:
+        CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,9 @@ jobs:
     - run: yarn test:ssr-css
       env:
         CI: true
+    - run: yarn build --release
+      env:
+        CI: true
+    - run: yarn test:ssr-css
+      env:
+        CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,3 @@ jobs:
     - run: yarn test:ssr-css
       env:
         CI: true
-    - run: yarn build --release
-      env:
-        CI: true
-    - run: yarn test:ssr-css
-      env:
-        CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,6 @@ jobs:
     - run: yarn build
       env:
         CI: true
+    - run: yarn test:ssr-css
+      env:
+        CI: true

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,8 +30,8 @@ module.exports = [
     },
   },
 
-  // Build scripts: Node.js 24 globals, and allowed to reference build
-  // output and use dynamic requires
+  // Build scripts: allowed to reference build output and use dynamic requires
+  // and reference Node.js globals
   {
     files: ['tools/**/*.js'],
     languageOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,9 +30,15 @@ module.exports = [
     },
   },
 
-  // Build scripts: allowed to reference build output and use dynamic requires
+  // Build scripts: Node.js 24 globals, and allowed to reference build
+  // output and use dynamic requires
   {
     files: ['tools/**/*.js'],
+    languageOptions: {
+      globals: {
+        globalThis: 'readonly',
+      },
+    },
     rules: {
       'import/no-unresolved': 'off',
       'import/no-extraneous-dependencies': 'off',

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "test": "node -r dotenv/config node_modules/.bin/jest",
     "test:flaky": "yarn run test src/alpr.test.js src/getVehicleType.test.js",
     "test:no-flaky": "yarn run test --testPathIgnorePatterns='src/alpr.test.js|src/getVehicleType.test.js'",
+    "test:ssr-css": "babel-node tools/test-ssr-css.js",
     "test-watch": "yarn run test --watch --notify",
     "test-cover": "yarn run test --coverage",
     "coverage": "yarn run test-cover && opn coverage/lcov-report/index.html",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,6 @@
     "test:flaky": "yarn run test src/alpr.test.js src/getVehicleType.test.js",
     "test:no-flaky": "yarn run test --testPathIgnorePatterns='src/alpr.test.js|src/getVehicleType.test.js'",
     "test:ssr-css": "babel-node tools/test-ssr-css.js",
-    "test:ssr-css:release": "yarn run build --release && babel-node tools/test-ssr-css.js",
     "test-watch": "yarn run test --watch --notify",
     "test-cover": "yarn run test --coverage",
     "coverage": "yarn run test-cover && opn coverage/lcov-report/index.html",

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "test:flaky": "yarn run test src/alpr.test.js src/getVehicleType.test.js",
     "test:no-flaky": "yarn run test --testPathIgnorePatterns='src/alpr.test.js|src/getVehicleType.test.js'",
     "test:ssr-css": "babel-node tools/test-ssr-css.js",
+    "test:ssr-css:release": "yarn run build --release && babel-node tools/test-ssr-css.js",
     "test-watch": "yarn run test --watch --notify",
     "test-cover": "yarn run test --coverage",
     "coverage": "yarn run test-cover && opn coverage/lcov-report/index.html",

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -14,19 +14,12 @@ import Layout from '../../components/Layout/Layout.js';
 import boroughBoundariesFeatureCollection from '../../../public/borough-boundaries-clipped-to-shoreline.geo.json';
 
 async function action({ fetch, commitHash, cookies }) {
-  // get complaint categories from server. The form can render without
-  // them, so a Parse/API failure must not take down SSR — the action
-  // fetches them again on client-side navigation.
-  let typeofcomplaintValues = [];
-  try {
-    const resp = await fetch('/api/categories');
-    const { categories } = await resp.json();
-    typeofcomplaintValues = sortBy(categories, 'createdAt').map(
-      ({ text }) => text,
-    );
-  } catch {
-    // fall back to the empty list above
-  }
+  // get complaint categories from server
+  const resp = await fetch('/api/categories');
+  const { categories } = await resp.json();
+  const typeofcomplaintValues = sortBy(categories, 'createdAt').map(
+    ({ text }) => text,
+  );
 
   // Parse persistent state from cookie set by the client
   let initialState = null;

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -14,12 +14,19 @@ import Layout from '../../components/Layout/Layout.js';
 import boroughBoundariesFeatureCollection from '../../../public/borough-boundaries-clipped-to-shoreline.geo.json';
 
 async function action({ fetch, commitHash, cookies }) {
-  // get complaint categories from server
-  const resp = await fetch('/api/categories');
-  const { categories } = await resp.json();
-  const typeofcomplaintValues = sortBy(categories, 'createdAt').map(
-    ({ text }) => text,
-  );
+  // get complaint categories from server. The form can render without
+  // them, so a Parse/API failure must not take down SSR — the action
+  // fetches them again on client-side navigation.
+  let typeofcomplaintValues = [];
+  try {
+    const resp = await fetch('/api/categories');
+    const { categories } = await resp.json();
+    typeofcomplaintValues = sortBy(categories, 'createdAt').map(
+      ({ text }) => text,
+    );
+  } catch {
+    // fall back to the empty list above
+  }
 
   // Parse persistent state from cookie set by the client
   let initialState = null;

--- a/tools/test-ssr-css.js
+++ b/tools/test-ssr-css.js
@@ -1,0 +1,105 @@
+/**
+ * React Starter Kit (https://www.reactstarterkit.com/)
+ *
+ * Copyright © 2014-present Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+/**
+ * Render the built app server-side and assert on the CSS pipeline output.
+ *
+ * The regular jest suite mocks CSS imports (identity-obj-proxy), so it cannot
+ * see the regressions that have historically shipped through the webpack CSS
+ * pipeline, e.g.:
+ *
+ * - css-loader 4+ emitting ES modules by default, which made
+ *   isomorphic-style-loader's `'' + css` stringify an ESM namespace object
+ *   into the literal text `[object Module]` in the critical `<style>` tag,
+ *   dropping every third-party stylesheet (marx, normalize, toastify)
+ * - css-loader 4+ camelCasing exported locals, breaking dashed lookups like
+ *   `homeStyles['plate-overlay']`
+ * - `composes:` chains silently breaking when module exports change shape
+ *
+ * Each check below catches one of those failure modes by rendering the
+ * homepage and inspecting the HTML. Run after `yarn build` (the built
+ * `build/server.js` is what gets exercised).
+ */
+
+import runServer from './runServer.js';
+
+const PORT = process.env.TEST_PORT || '3100';
+const BASE_URL = `http://localhost:${PORT}`;
+
+// runServer spawns the built server with this process's env, so PORT reaches
+// it through here.
+process.env.PORT = PORT;
+
+const criticalCss = html => {
+  const match = html.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+  return match ? match[1] : '';
+};
+
+const CHECKS = [
+  {
+    name: 'critical CSS contains no "[object Module]"',
+    fn: html => !html.includes('[object Module]'),
+  },
+  {
+    name: "marx.css element rule ('button, input, optgroup' selector) is present",
+    fn: html => /button,\s*input,\s*optgroup/.test(criticalCss(html)),
+  },
+  {
+    name: "normalize.css element rule ('html' with line-height 1.15) is present",
+    fn: html => /line-height:\s*1\.15/.test(criticalCss(html)),
+  },
+  {
+    name: 'react-toastify styles are present',
+    fn: html => /\.Toastify__/.test(criticalCss(html)),
+  },
+  {
+    name: 'dashed CSS-module locals resolve to scoped class names',
+    fn: html => /class="Home-[a-z-]+-[A-Za-z0-9]{5}"/.test(html),
+  },
+  {
+    name: 'CSS-module composes: chains are intact',
+    fn: html =>
+      html.includes('Home-status-bar-btn-primary') &&
+      html.includes('Home-status-bar-btn'),
+  },
+];
+
+const run = async () => {
+  const server = await runServer();
+  try {
+    const response = await globalThis.fetch(BASE_URL);
+    const html = await response.text();
+    if (!response.ok) {
+      console.error(`GET / returned ${response.status}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    let failures = 0;
+    for (const { name, fn } of CHECKS) {
+      const ok = fn(html);
+      console.info(`${ok ? '✓' : '✗'} ${name}`);
+      if (!ok) failures += 1;
+    }
+
+    if (failures) {
+      console.error(`${failures}/${CHECKS.length} SSR CSS checks failed`);
+      process.exitCode = 1;
+    }
+  } finally {
+    // The server child process keeps this process's event loop alive, so it
+    // must be killed explicitly for the script to exit.
+    server.kill('SIGTERM');
+  }
+};
+
+run().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/test-ssr-css.js
+++ b/tools/test-ssr-css.js
@@ -1,13 +1,4 @@
 /**
- * React Starter Kit (https://www.reactstarterkit.com/)
- *
- * Copyright © 2014-present Kriasoft, LLC. All rights reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE.txt file in the root directory of this source tree.
- */
-
-/**
  * Render the built app server-side and assert on the CSS pipeline output.
  *
  * The regular jest suite mocks CSS imports (identity-obj-proxy), so it cannot

--- a/tools/test-ssr-css.js
+++ b/tools/test-ssr-css.js
@@ -44,6 +44,43 @@ const criticalCss = html => {
   return match ? match[1] : '';
 };
 
+// A CSS-module scoped class, in either naming scheme: debug builds emit
+// `Home-<local>-<hash>`, release builds bare `<hash>` (5-6 chars of the
+// base64url alphabet).
+const looksScoped = token =>
+  /^(?:Home-[a-zA-Z][a-zA-Z0-9_-]*-)?[A-Za-z0-9_-]{4,8}$/.test(token);
+
+// The single-class guard additionally requires a digit and an uppercase
+// letter, so stable non-module classes (`no-js`, `Toastify`) and utility
+// words (`w-100`) can never satisfy it — scoped hashes virtually always
+// contain both. The doubled-class guard skips those requirements: a
+// two-token attribute whose tokens are both real CSS selectors is already a
+// strong signal, and requiring digits there would reject legitimate hash
+// pairs (e.g. `_19lsC HVlXE`).
+const isScopedClass = token =>
+  looksScoped(token) && /[0-9]/.test(token) && /[A-Z]/.test(token);
+
+// Class selectors found in the critical CSS (`.foo` in `.foo:hover { ... }`,
+// minus a leading dot; decimal values like `.15em` cannot satisfy
+// `isScopedClass`, so they never count).
+const cssClassSelectors = html =>
+  new Set(
+    (criticalCss(html).match(/\.([A-Za-z0-9_-]+)/g) || []).map(s => s.slice(1)),
+  );
+
+// Every class token used by the markup.
+const markupClassTokens = html =>
+  [...html.matchAll(/class="([^"]+)"/g)].flatMap(match => match[1].split(' '));
+
+// A scoped class that is actually *wired up*: emitted as a selector in the
+// critical CSS and used by the markup. This is what the camelCased-exports
+// regression breaks (the class attributes vanish), so shape alone is not
+// enough of a guard.
+const linkedClasses = html =>
+  markupClassTokens(html).filter(
+    token => isScopedClass(token) && cssClassSelectors(html).has(token),
+  );
+
 const CHECKS = [
   {
     name: 'critical CSS contains no "[object Module]"',
@@ -62,18 +99,21 @@ const CHECKS = [
     fn: html => /\.Toastify__/.test(criticalCss(html)),
   },
   {
-    name: 'CSS-module locals resolve to scoped class names',
-    fn: html =>
-      /class="(?:Home-[a-zA-Z][a-zA-Z0-9_-]*-)?(?=[A-Za-z0-9_-]*[0-9])[A-Za-z0-9_-]{4,8}"/.test(
-        html,
-      ),
+    name: 'CSS-module locals resolve (a scoped class appears in CSS and markup)',
+    fn: html => linkedClasses(html).length > 0,
   },
   {
     name: 'CSS-module composes: chains are intact',
-    fn: html =>
-      /class="(?:Home-[a-zA-Z][a-zA-Z0-9_-]*-)?[A-Za-z0-9_-]{4,8} (?:Home-[a-zA-Z][a-zA-Z0-9_-]*-)?[A-Za-z0-9_-]{4,8}"/.test(
-        html,
-      ),
+    fn: html => {
+      const selectors = cssClassSelectors(html);
+      return [...html.matchAll(/class="([^"]+)"/g)].some(
+        match =>
+          match[1]
+            .split(' ')
+            .filter(token => looksScoped(token) && selectors.has(token))
+            .length >= 2,
+      );
+    },
   },
 ];
 

--- a/tools/test-ssr-css.js
+++ b/tools/test-ssr-css.js
@@ -65,8 +65,9 @@ const CHECKS = [
   {
     name: 'CSS-module composes: chains are intact',
     fn: html =>
-      html.includes('Home-status-bar-btn-primary') &&
-      html.includes('Home-status-bar-btn'),
+      /class="Home-[a-z-]+-[A-Za-z0-9]{5} Home-[a-z-]+-[A-Za-z0-9]{5}"/.test(
+        html,
+      ),
   },
 ];
 

--- a/tools/test-ssr-css.js
+++ b/tools/test-ssr-css.js
@@ -2,8 +2,8 @@
  * Render the built app server-side and assert on the CSS pipeline output.
  *
  * The regular jest suite mocks CSS imports (identity-obj-proxy), so it cannot
- * see the regressions that have historically shipped through the webpack CSS
- * pipeline, e.g.:
+ * see the regressions that would have shipped through the webpack CSS
+ * pipeline in https://github.com/josephfrazier/reported-web/pull/920, e.g.:
  *
  * - css-loader 4+ emitting ES modules by default, which made
  *   isomorphic-style-loader's `'' + css` stringify an ESM namespace object

--- a/tools/test-ssr-css.js
+++ b/tools/test-ssr-css.js
@@ -24,7 +24,10 @@
  *
  * Each check below catches one of those failure modes by rendering the
  * homepage and inspecting the HTML. Run after `yarn build` (the built
- * `build/server.js` is what gets exercised).
+ * `build/server.js` is what gets exercised). The checks are mode-agnostic:
+ * they pass against both debug builds (`[name]-[local]-[hash]` class names)
+ * and release builds (bare base64 hashes, minified CSS), so CI runs the
+ * same script after both `yarn build` and `yarn build --release`.
  */
 
 import runServer from './runServer.js';
@@ -60,12 +63,15 @@ const CHECKS = [
   },
   {
     name: 'CSS-module locals resolve to scoped class names',
-    fn: html => /class="Home-[a-zA-Z][a-zA-Z0-9-]*-[A-Za-z0-9]{5}"/.test(html),
+    fn: html =>
+      /class="(?:Home-[a-zA-Z][a-zA-Z0-9_-]*-)?(?=[A-Za-z0-9_-]*[0-9])[A-Za-z0-9_-]{4,8}"/.test(
+        html,
+      ),
   },
   {
     name: 'CSS-module composes: chains are intact',
     fn: html =>
-      /class="Home-[a-zA-Z][a-zA-Z0-9-]*-[A-Za-z0-9]{5} Home-[a-zA-Z][a-zA-Z0-9-]*-[A-Za-z0-9]{5}"/.test(
+      /class="(?:Home-[a-zA-Z][a-zA-Z0-9_-]*-)?[A-Za-z0-9_-]{4,8} (?:Home-[a-zA-Z][a-zA-Z0-9_-]*-)?[A-Za-z0-9_-]{4,8}"/.test(
         html,
       ),
   },

--- a/tools/test-ssr-css.js
+++ b/tools/test-ssr-css.js
@@ -59,13 +59,13 @@ const CHECKS = [
     fn: html => /\.Toastify__/.test(criticalCss(html)),
   },
   {
-    name: 'dashed CSS-module locals resolve to scoped class names',
-    fn: html => /class="Home-[a-z-]+-[A-Za-z0-9]{5}"/.test(html),
+    name: 'CSS-module locals resolve to scoped class names',
+    fn: html => /class="Home-[a-zA-Z][a-zA-Z0-9-]*-[A-Za-z0-9]{5}"/.test(html),
   },
   {
     name: 'CSS-module composes: chains are intact',
     fn: html =>
-      /class="Home-[a-z-]+-[A-Za-z0-9]{5} Home-[a-z-]+-[A-Za-z0-9]{5}"/.test(
+      /class="Home-[a-zA-Z][a-zA-Z0-9-]*-[A-Za-z0-9]{5} Home-[a-zA-Z][a-zA-Z0-9-]*-[A-Za-z0-9]{5}"/.test(
         html,
       ),
   },


### PR DESCRIPTION
## What

A build-time smoke test, `tools/test-ssr-css.js`, that renders the built app
server-side and asserts on the CSS pipeline output. The regular jest suite
cannot see this layer — CSS imports are mocked (`identity-obj-proxy`), so
css-loader/isomorphic-style-loader behavior is invisible to it.

## Why

While upgrading css-loader in #920, two regressions nearly shipped through
this pipeline undetected:

- css-loader 4+ emitting ES modules by default made
  isomorphic-style-loader's `'' + css` stringify an ESM namespace object
  into the literal text `[object Module]` in the critical `<style>` tag —
  silently dropping every third-party stylesheet (marx, normalize,
  toastify) and leaving bare `<button>`s unstyled
- css-loader 4+ camelCasing exported locals broke dashed lookups like
  `homeStyles['plate-overlay']`, deleting class attributes from the markup

## The checks

The script starts the built `build/server.js` (via `tools/runServer.js`),
fetches `/`, and asserts:

1. no `[object Module]` in the critical `<style>`
2. marx's `button, input, optgroup` selector is present
3. normalize's `html` rule (`line-height: 1.15`) is present
4. `.Toastify__` classes are present
5. a scoped CSS-module class is *linked* — present both as a selector in
   the critical CSS and as a class attribute in the markup
6. one element carries two linked scoped classes (`composes:` output)

Checks 5–6 assert linkage rather than shape, so utility classes
(`w-100`) and static classes (`no-js`, `Toastify`) can't satisfy them;
they accept both debug class names (`Home-<local>-<hash>`) and release
hashes, and survive class renames to camelCase.

## CI

- `build.yml` runs the check after `yarn build`
- `build-release.yml` runs it after `yarn build --release`
  (the release build is what deploys)

`yarn start` is not tested separately: it compiles the same debug-mode
pipeline, which was verified to render identical critical CSS.

## Verification

- 6/6 checks pass against debug and release builds
- synthetic regression pages (module classes vanished with statics
  remaining, styled utility present) fail checks 5–6
- the captured `[object Module]` page fails checks 1–4

---

Co-Authored-By: Claude Code with DeepSeek