### PR TITLE
fix: bundle complaint categories instead of fetching them from Parse

### DIFF
--- a/src/routes/home/categories.json
+++ b/src/routes/home/categories.json
@@ -1,0 +1,44 @@
+{
+  "categories": [
+    {
+      "objectId": "Z8vjWz8uYr",
+      "createdAt": "2016-10-23T18:14:34.030Z",
+      "updatedAt": "2019-01-09T18:55:27.008Z",
+      "text": "Blocked the bike lane",
+      "typeofreport": "complaint",
+      "typeofuser": "cyclist, walker, pedestrian, passenger"
+    },
+    {
+      "objectId": "GzRxlMN1vl",
+      "createdAt": "2016-10-23T18:16:21.828Z",
+      "updatedAt": "2019-01-09T18:55:35.349Z",
+      "text": "Blocked the crosswalk",
+      "typeofreport": "complaint",
+      "typeofuser": "cyclist, walker, pedestrian, passenger"
+    },
+    {
+      "objectId": "WstZSmJr4t",
+      "createdAt": "2016-10-26T07:20:17.693Z",
+      "updatedAt": "2016-10-29T07:56:06.719Z",
+      "text": "Drove recklessly",
+      "typeofreport": "complaint",
+      "typeofuser": "passenger"
+    },
+    {
+      "objectId": "0iEd9qaziB",
+      "text": "Parked illegally",
+      "createdAt": "2018-03-20T16:19:48.664Z",
+      "updatedAt": "2019-01-09T18:54:56.176Z",
+      "typeofreport": "complaint",
+      "typeofuser": "cyclist, walker, pedestrian, passenger"
+    },
+    {
+      "objectId": "DauBz1MDhJ",
+      "text": "Ran a red light or stop sign",
+      "createdAt": "2018-04-14T18:44:39.024Z",
+      "updatedAt": "2018-04-14T18:47:32.149Z",
+      "typeofreport": "complaint",
+      "typeofuser": "cyclist, walker, pedestrian, passenger"
+    }
+  ]
+}

--- a/src/routes/home/index.js
+++ b/src/routes/home/index.js
@@ -12,14 +12,15 @@ import sortBy from 'lodash.sortby';
 import Home from './Home.js';
 import Layout from '../../components/Layout/Layout.js';
 import boroughBoundariesFeatureCollection from '../../../public/borough-boundaries-clipped-to-shoreline.geo.json';
+import categoriesData from './categories.json';
 
-async function action({ fetch, commitHash, cookies }) {
-  // get complaint categories from server
-  const resp = await fetch('/api/categories');
-  const { categories } = await resp.json();
-  const typeofcomplaintValues = sortBy(categories, 'createdAt').map(
-    ({ text }) => text,
-  );
+async function action({ commitHash, cookies }) {
+  // The complaint categories haven't changed in Parse for years, so a
+  // snapshot of them is bundled instead of fetched at render time.
+  const typeofcomplaintValues = sortBy(
+    categoriesData.categories,
+    'createdAt',
+  ).map(({ text }) => text);
 
   // Parse persistent state from cookie set by the client
   let initialState = null;

--- a/src/server.js
+++ b/src/server.js
@@ -208,21 +208,6 @@ app.use('/saveUser', (req, res) => {
     .catch(handlePromiseRejection(res));
 });
 
-app.use('/api/categories', (req, res) => {
-  const Category = Parse.Object.extend('Category');
-  const query = new Parse.Query(Category);
-  query
-    .find()
-    .then(results => {
-      const categories = results.map(({ id, attributes }) => ({
-        objectId: id,
-        ...attributes,
-      }));
-      res.json({ categories });
-    })
-    .catch(handlePromiseRejection(res));
-});
-
 app.use('/api/geosearch', (req, res) => {
   const { lat, long } = req.body;
   geosearch({ lat, long })


### PR DESCRIPTION
The complaint categories have not changed in Parse since 2019, but the
home route's SSR `action()` fetched them from `/api/categories` on every
render. That made the homepage SSR depend on Parse credentials and
availability — environments without them (like CI) got a 500, because
`resp.json()` parsed the error page as JSON and threw.

A snapshot of the production response is now bundled as
`src/routes/home/categories.json` and used directly, and the
`/api/categories` endpoint is removed from `src/server.js`. The SSR no
longer makes any network call for categories, so the homepage renders
hermetically — verified with `.env` moved aside: `GET /` returns 200 and
`build/server.js` contains no reference to the endpoint.

This also removes a render-time dependency on Parse for the initial page
load: a Back4App outage can no longer take down SSR.

`yarn test:no-flaky` passes.

Co-Authored-By: Claude Code with DeepSeek