### PR TITLE
fix: only register the service worker in production

### DIFF
--- a/src/components/Html.js
+++ b/src/components/Html.js
@@ -82,14 +82,16 @@ class Html extends React.Component {
               defer
             />
           )}
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `if ('serviceWorker' in navigator) {
+          {process.env.NODE_ENV === 'production' && (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `if ('serviceWorker' in navigator) {
                   // sw.js can literally be empty, but must exist
                   navigator.serviceWorker.register('/sw.js');
                 }`,
-            }}
-          />
+              }}
+            />
+          )}
         </body>
       </html>
     );

--- a/tools/test-ssr-css.js
+++ b/tools/test-ssr-css.js
@@ -106,6 +106,16 @@ const CHECKS = [
       );
     },
   },
+  {
+    name: 'service worker registration matches the build mode',
+    fn: html => {
+      // Debug builds name module classes `Home-<local>-<hash>`, so the
+      // prefixed form identifies the build mode the way checks 5-6 do.
+      const isDebug = /class="Home-[a-zA-Z][a-zA-Z0-9_-]*-/.test(html);
+      const registers = html.includes('serviceWorker');
+      return isDebug ? !registers : registers;
+    },
+  },
 ];
 
 const run = async () => {


### PR DESCRIPTION
The SSR HTML unconditionally registered `/sw.js` on every page load,
including from the development server. Browsersync-based dev servers
reuse the same origin (`localhost:3000`), so a service worker from one
dev session intercepts asset requests in every later one and serves
stale hashed bundles — which presents as runtime errors and the `/error`
page after hot restarts.

Registering a placeholder service worker during development has no
upside, so `src/components/Html.js` now only emits the registration
script when the server bundle was built for production:

```jsx
{process.env.NODE_ENV === 'production' && (
  <script
    dangerouslySetInnerHTML={{
      __html: `if ('serviceWorker' in navigator) { ... }`,
    }}
  />
)}
```

`process.env.NODE_ENV` is replaced at build time (webpack mode), so
`yarn build` output contains no service-worker code at all, while
`yarn build --release` keeps it. The condition must live in real JSX,
not inside the template literal — DefinePlugin does not rewrite
identifiers that appear as template-string text.

`tools/test-ssr-css.js` gains a check asserting the registration matches
the build mode (detected via debug-style class names, like the locals
checks): debug pages must not register, release pages must. Verified
four ways — debug without SW and release with SW pass; a real
regression build (with the unconditional registration restored) fails
the check with exit code 1, and release-without-SW fails as well.

Co-Authored-By: Claude Code with DeepSeek