### PR TITLE
fix(deps): upgrade transitive `minimatch` to fix the Feb 2026 advisories

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8154,9 +8154,9 @@ min-indent@^1.0.1:
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@^3.0.2, minimatch@^3.0.5:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -8168,9 +8168,9 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^3.1.5:
     brace-expansion "^1.1.7"
 
 minimatch@^9.0.4:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
     brace-expansion "^2.0.1"
 


### PR DESCRIPTION
Dependabot flagged `minimatch` through three high-severity advisories
with 21 affected paths in `yarn audit`:

- [GHSA-3ppc-4f35-3m26]
- [GHSA-7r86-cg39-jmmj]
- [GHSA-23c5-xmqv-rm74]

Two vulnerable resolutions were locked:

- `minimatch@3.1.2`, required by `browser-sync#resp-modifier` and
  `react-dev-utils#recursive-readdir` — upgraded to 3.1.5 (the version
  other 3.x dependents already used); see the [npm diff][minimatch-3]
- `minimatch@9.0.5`, required by `glob` — upgraded to 9.0.9; see the
  [npm diff][minimatch-9]

Both satisfy the semver ranges the dependents already declare
(`^3.0.2`/`^3.0.5` and `^9.0.4`), so this is a `yarn.lock`-only change,
edited directly (version, `resolved`, and `integrity` from the npm
registry) since `yarn upgrade` does not re-resolve transitive entries.
`yarn install` verified the tarballs against the new integrity hashes.

`yarn audit` now reports 0 `minimatch` findings, and `yarn build`, the
SSR CSS checks (7/7), the client smoke test (3/3), and
`yarn test:no-flaky` all pass.

[GHSA-3ppc-4f35-3m26]: https://github.com/advisories/GHSA-3ppc-4f35-3m26
[GHSA-7r86-cg39-jmmj]: https://github.com/advisories/GHSA-7r86-cg39-jmmj
[GHSA-23c5-xmqv-rm74]: https://github.com/advisories/GHSA-23c5-xmqv-rm74
[minimatch-3]: https://my.diffend.io/npm/minimatch/3.1.2/3.1.5
[minimatch-9]: https://my.diffend.io/npm/minimatch/9.0.5/9.0.9

Co-Authored-By: Claude Code with DeepSeek