### PR TITLE
fix(deps): upgrade transitive `ajv` to fix GHSA-2g4f-4pwh-qvx6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3194,9 +3194,9 @@ ajv-keywords@^5.1.0:
     fast-deep-equal "^3.1.3"
 
 ajv@^6.1.0, ajv@^6.12.2, ajv@^6.12.5:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
+  integrity sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -3224,9 +3224,9 @@ ajv@^8.0.0:
     require-from-string "^2.0.2"
 
 ajv@^8.0.1, ajv@^8.9.0:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
-  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"


### PR DESCRIPTION
Dependabot flagged `ajv` through [GHSA-2g4f-4pwh-qvx6], with 5 affected
paths in `yarn audit`. Two vulnerable resolutions were locked:

- `ajv@6.12.6`, required by the schema-utils 1.x/2.x chains
  (`file-loader`, `url-loader`, `webpack-assets-manifest`,
  `fork-ts-checker-webpack-plugin`) — upgraded to 6.15.0, the version
  eslint's chain already used; see the npm diff:
  [ajv 6.12.6 → 6.15.0]
- `ajv@8.17.1`, required by `schema-utils` (webpack 5) — upgraded to
  8.20.0, the version `ajv-formats` already used; see the npm diff:
  [ajv 8.17.1 → 8.20.0]

Both satisfy the semver ranges the dependents already declare
(`^6.1.0`/`^6.12.x` and `^8.9.0`), so this is a `yarn.lock`-only
change. `yarn install` verified the tarballs against the integrity
hashes.

`yarn audit` now reports 0 `ajv` findings, and `yarn build`, the SSR
CSS checks (7/7), the client smoke test (3/3), and `yarn test:no-flaky`
all pass.

[ajv 6.12.6 → 6.15.0]: https://my.diffend.io/npm/ajv/6.12.6/6.15.0
[ajv 8.17.1 → 8.20.0]: https://my.diffend.io/npm/ajv/8.17.1/8.20.0
[GHSA-2g4f-4pwh-qvx6]: https://github.com/advisories/GHSA-2g4f-4pwh-qvx6

Co-Authored-By: Claude Code with DeepSeek