### PR TITLE
fix(deps): resolve parse's exact `@babel/runtime` pins to patched 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "not ie < 9"
   ],
   "resolutions": {
-    "parse/ws": "7.5.13"
+    "parse/ws": "7.5.13",
+    "parse/@babel/runtime": "7.27.6",
+    "parse/@babel/runtime-corejs3": "7.29.7"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,22 +1051,14 @@
     pirates "^4.0.6"
     source-map-support "^0.5.16"
 
-"@babel/runtime-corejs3@7.7.4":
-  version "7.7.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.7.4.tgz#f861adc1cecb9903dfd66ea97917f02ff8d79888"
-  integrity sha512-BBIEhzk8McXDcB3IbOi8zQPzzINUp4zcLesVlBSOcyGhzPUU8Xezk5GAG7Sy5GVhGmAO0zGd2qRSeY2g4Obqxw==
+"@babel/runtime-corejs3@7.29.7", "@babel/runtime-corejs3@7.7.4":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz#2030fda34f3433647818660093751fb1ca2debf0"
+  integrity sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==
   dependencies:
-    core-js-pure "^3.0.0"
-    regenerator-runtime "^0.13.2"
+    core-js-pure "^3.48.0"
 
-"@babel/runtime@7.7.4":
-  version "7.7.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.4.tgz#b23a856751e4bf099262f867767889c0e3fe175b"
-  integrity sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==
-  dependencies:
-    regenerator-runtime "^0.13.2"
-
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.27.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+"@babel/runtime@7.27.6", "@babel/runtime@7.7.4", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.27.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
@@ -4285,10 +4277,10 @@ core-js-compat@^3.48.0:
   dependencies:
     browserslist "^4.28.1"
 
-core-js-pure@^3.0.0:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.3.tgz#10e9e3b2592ecaede4283e8f3ad7020811587c02"
-  integrity sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==
+core-js-pure@^3.48.0:
+  version "3.50.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.50.0.tgz#263313e83606cb527005885da5be36c0a28f65ef"
+  integrity sha512-6GP3Pxz4IKyWjAfa747vIu/jilB5z29JWROLqH/b+pXVcpgh6tM06ZIBwSuglgVqzDYURhOK6oEzTrG0bCHitA==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -9826,11 +9818,6 @@ regenerate@^1.4.2:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-
-regenerator-runtime@^0.13.2:
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
-  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-runtime@^0.13.4:
   version "0.13.11"


### PR DESCRIPTION
Dependabot flagged `@babel/runtime` and `@babel/runtime-corejs3` through
[GHSA-968p-4wvh-cqc8]. Both findings came from parse, which pins them to
exactly 7.7.4 — a 2019-era release the advisory covers. The rest of the
tree was already on 7.27.6.

Per-path resolutions force the patched 7.x lines instead; see the npm
diffs: [@babel/runtime 7.7.4 → 7.27.6] and
[@babel/runtime-corejs3 7.7.4 → 7.29.7]

```json
"resolutions": {
  "parse/@babel/runtime": "7.27.6",
  "parse/@babel/runtime-corejs3": "7.29.7"
}
```

This is safe because @babel/runtime helpers only accumulate within a
major (7.27 still contains every 7.7-era helper), and @babel/runtime has
no `exports` map restricting parse's deep helper imports — unlike the
`uuid/v4` case that made a similar resolution unsafe. Verified by
instantiating a Parse.Object against the forced versions.

`yarn audit` now reports 0 `@babel/runtime` and 0
`@babel/runtime-corejs3` findings, and `yarn build`, the SSR CSS checks
(7/7), the client smoke test (3/3), and `yarn test:no-flaky` all pass.

[@babel/runtime 7.7.4 → 7.27.6]: https://my.diffend.io/npm/@babel/runtime/7.7.4/7.27.6
[@babel/runtime-corejs3 7.7.4 → 7.29.7]: https://my.diffend.io/npm/@babel/runtime-corejs3/7.7.4/7.29.7
[GHSA-968p-4wvh-cqc8]: https://github.com/advisories/GHSA-968p-4wvh-cqc8

Co-Authored-By: Claude Code with DeepSeek