### PR TITLE
fix(deps): resolve `universal-router`'s `path-to-regexp@^2.1.0` to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "parse/ws": "7.5.13",
     "parse/@babel/runtime": "7.27.6",
     "parse/@babel/runtime-corejs3": "7.29.7",
-    "node-fetch": "2.7.0"
+    "node-fetch": "2.7.0",
+    "universal-router/path-to-regexp": "3.3.0"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8600,9 +8600,10 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
+path-to-regexp@3.3.0, path-to-regexp@^2.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
+  integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
 
 path-to-regexp@~0.1.12:
   version "0.1.13"


### PR DESCRIPTION
`universal-router@6.0.0` pins `path-to-regexp@^2.1.0`, which resolves
to `2.2.1` — vulnerable to [GHSA-rhx6-c78j-4q9w] (CVE-2024-52798,
"path-to-regexp outputs backtracking regular expressions"), fixed in
`3.3.0` for the 2.x line. `universal-router` is effectively unmaintained
(6.0.0 is its last release, 2019), so there is no upstream upgrade to
take.

Add a `universal-router/path-to-regexp` resolution to [path-to-regexp]
`3.3.0`. The 3.x breaking changes do not touch universal-router's usage
— it calls `pathToRegexp(path, keys, opts)` (the `keys` second argument,
removed only in 6.x) and `parse()`/`tokensToFunction()` — and both
shapes were verified against `3.3.0` directly.

Dependency changes:

- [path-to-regexp] `2.2.1` → `3.3.0` — [on npm][npm]

Verified:
- `yarn audit`: path-to-regexp advisory gone (8 → 7 vulnerabilities)
- `yarn build`
- `yarn test:ssr-css` (7/7)
- `yarn test:client-smoke` (3/3)
- `yarn test:no-flaky` (6 suites, 20 tests)

[GHSA-rhx6-c78j-4q9w]: https://github.com/advisories/GHSA-rhx6-c78j-4q9w
[path-to-regexp]: https://my.diffend.io/npm/path-to-regexp/2.2.1/3.3.0
[npm]: https://www.npmjs.com/package/path-to-regexp?activeTab=versions

Co-Authored-By: Claude Code with DeepSeek