### PR TITLE
fix(deps): resolve `browser-sync`'s `immutable@^3` to 4.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "parse/@babel/runtime": "7.27.6",
     "parse/@babel/runtime-corejs3": "7.29.7",
     "node-fetch": "2.7.0",
-    "universal-router/path-to-regexp": "3.3.0"
+    "universal-router/path-to-regexp": "3.3.0",
+    "immutable": "4.3.9"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6458,10 +6458,10 @@ immer@^9.0.7:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
-immutable@^3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
-  integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
+immutable@4.3.9, immutable@^3:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
+  integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
 
 import-fresh@^3.1.0:
   version "3.3.0"


### PR DESCRIPTION
`browser-sync` (used only by the `yarn start` dev server) depends on
`immutable@^3`, resolving to `3.8.3`, which is vulnerable to
[GHSA-xvcm-6775-5m9r] (CVE-2026-59880, hash-collision DoS in
`Map`/`Set`) and [GHSA-v56q-mh7h-f735] (CVE-2026-59879, `List` trie
overflow DoS), both fixed in `4.3.9`.

Add a bare `immutable` resolution to [immutable] `4.3.9`, covering both
the `browser-sync` and `browser-sync-ui` chains. browser-sync's runtime
API surface (`Map`, `List`, `fromJS`, `is`, `Record`, `OrderedSet`,
`Set`) all exists in 4.x; its only `Immutable.Iterable` reference is a
JSDoc comment, not runtime code.

Dependency changes:

- [immutable] `3.8.3` → `4.3.9` — [on npm][npm]

Verified:
- `yarn audit`: immutable advisories gone (7 → 3 vulnerabilities)
- `yarn start --silent`: Browsersync boots on :3000, UI on :3001,
  "Server launched after 1656 ms"
- `yarn build`
- `yarn test:ssr-css` (7/7)
- `yarn test:client-smoke` (3/3)
- `yarn test:no-flaky` (6 suites, 20 tests)

[GHSA-xvcm-6775-5m9r]: https://github.com/advisories/GHSA-xvcm-6775-5m9r
[GHSA-v56q-mh7h-f735]: https://github.com/advisories/GHSA-v56q-mh7h-f735
[immutable]: https://my.diffend.io/npm/immutable/3.8.3/4.3.9
[npm]: https://www.npmjs.com/package/immutable?activeTab=versions

Co-Authored-By: Claude Code with DeepSeek