### PR TITLE
feat: cache recent submissions in localStorage for instant display

### DIFF
--- a/src/components/PreviousSubmissionsList.js
+++ b/src/components/PreviousSubmissionsList.js
@@ -25,7 +25,9 @@ class PreviousSubmissionsList extends React.Component {
       hasLoadedPreviousSubmissions,
     } = this.props;
 
-    if (isLoading) {
+    // Keep already-rendered (possibly cached) submissions visible while a
+    // background refresh is in flight.
+    if (isLoading && submissions.length === 0) {
       return 'Loading submissions...';
     }
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -2490,24 +2490,23 @@ class Home extends React.Component {
 
                 {this.state.isPreviousSubmissionsOpen && (
                   <>
-                    {this.state.hasLoadedPreviousSubmissions &&
-                      !this.state.isPreviousSubmissionsLoading && (
-                        <label
-                          htmlFor="isLoadPreviousSubmissionsEnabled"
-                          style={{ display: 'block', marginBottom: '1rem' }}
-                        >
-                          <input
-                            id="isLoadPreviousSubmissionsEnabled"
-                            type="checkbox"
-                            checked={
-                              this.state.isLoadPreviousSubmissionsEnabled
-                            }
-                            name="isLoadPreviousSubmissionsEnabled"
-                            onChange={this.handleInputChange}
-                          />{' '}
-                          Load previous submissions immediately next time
-                        </label>
-                      )}
+                    {/* Also show this while cached submissions are being
+                        refreshed in the background. */}
+                    {this.state.hasLoadedPreviousSubmissions && (
+                      <label
+                        htmlFor="isLoadPreviousSubmissionsEnabled"
+                        style={{ display: 'block', marginBottom: '1rem' }}
+                      >
+                        <input
+                          id="isLoadPreviousSubmissionsEnabled"
+                          type="checkbox"
+                          checked={this.state.isLoadPreviousSubmissionsEnabled}
+                          name="isLoadPreviousSubmissionsEnabled"
+                          onChange={this.handleInputChange}
+                        />{' '}
+                        Load previous submissions immediately next time
+                      </label>
+                    )}
                     <PreviousSubmissionsList
                       submissions={this.state.submissions}
                       onDeleteSubmission={this.onDeleteSubmission}

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1347,7 +1347,11 @@ class Home extends React.Component {
     } = this.state;
 
     if (submissions.length > 0) {
-      return submissions.length;
+      // Cached submissions may be visible while the fresh list loads in the
+      // background, so indicate that a load is in progress.
+      return isPreviousSubmissionsLoading
+        ? `${submissions.length}, loading...`
+        : submissions.length;
     }
     if (hasLoadedPreviousSubmissions) {
       return 0;

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1350,7 +1350,7 @@ class Home extends React.Component {
       // Cached submissions may be visible while the fresh list loads in the
       // background, so indicate that a load is in progress.
       return isPreviousSubmissionsLoading
-        ? `${submissions.length}, loading...`
+        ? `at least ${submissions.length}, loading more...`
         : submissions.length;
     }
     if (hasLoadedPreviousSubmissions) {

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1141,7 +1141,7 @@ class Home extends React.Component {
 
     // Show the cached recent submissions (if any) immediately, then replace
     // them with the fresh list once the fetch completes.
-    const cachedSubmissions = readCachedSubmissions(this.state.email);
+    const cachedSubmissions = readCachedSubmissions();
     if (cachedSubmissions) {
       this.setState({
         submissions: cachedSubmissions,
@@ -1162,7 +1162,7 @@ class Home extends React.Component {
           isPreviousSubmissionsLoading: false,
           hasLoadedPreviousSubmissions: true,
         });
-        writeCachedSubmissions(this.state.email, submissions);
+        writeCachedSubmissions(submissions);
       })
       .catch(error => {
         this.setState({
@@ -1276,7 +1276,6 @@ class Home extends React.Component {
   };
 
   handleLogOut = () => {
-    const { email } = this.state;
     this.setState(
       {
         email: '',
@@ -1297,7 +1296,7 @@ class Home extends React.Component {
         localStorage.removeItem('Function');
         localStorage.removeItem('reportedWebHomeState');
         // Don't keep this user's submissions cached after they log out.
-        clearCachedSubmissions(email);
+        clearCachedSubmissions();
       },
     );
   };

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -55,6 +55,11 @@ import { isImage, isVideo } from '../../isImage.js';
 import getNycTimezoneOffset from '../../timezone.js';
 import { getBoroNameMemoized } from '../../getBoroName.js';
 import vehicleTypeUrl from '../../vehicleTypeUrl.js';
+import {
+  clearCachedSubmissions,
+  readCachedSubmissions,
+  writeCachedSubmissions,
+} from './submissionsCache.js';
 
 usStateNames.DC = 'District of Columbia';
 
@@ -1134,6 +1139,16 @@ class Home extends React.Component {
       return;
     }
 
+    // Show the cached recent submissions (if any) immediately, then replace
+    // them with the fresh list once the fetch completes.
+    const cachedSubmissions = readCachedSubmissions(this.state.email);
+    if (cachedSubmissions) {
+      this.setState({
+        submissions: cachedSubmissions,
+        hasLoadedPreviousSubmissions: true,
+      });
+    }
+
     this.setState({
       isPreviousSubmissionsLoading: true,
     });
@@ -1147,6 +1162,7 @@ class Home extends React.Component {
           isPreviousSubmissionsLoading: false,
           hasLoadedPreviousSubmissions: true,
         });
+        writeCachedSubmissions(this.state.email, submissions);
       })
       .catch(error => {
         this.setState({
@@ -1260,6 +1276,7 @@ class Home extends React.Component {
   };
 
   handleLogOut = () => {
+    const { email } = this.state;
     this.setState(
       {
         email: '',
@@ -1279,6 +1296,8 @@ class Home extends React.Component {
         // if the user logs back in later.
         localStorage.removeItem('Function');
         localStorage.removeItem('reportedWebHomeState');
+        // Don't keep this user's submissions cached after they log out.
+        clearCachedSubmissions(email);
       },
     );
   };

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -277,4 +277,32 @@ describe('Home', () => {
 
     tree.unmount();
   });
+
+  test('indicates loading in the submissions summary when showing cached submissions', () => {
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+    };
+
+    const homeRef = React.createRef();
+    const tree = renderHome({ initialState, homeRef });
+    renderer.act(() => {
+      homeRef.current.setState({
+        submissions: [{ objectId: 'cached-1' }, { objectId: 'cached-2' }],
+        isPreviousSubmissionsLoading: true,
+        hasLoadedPreviousSubmissions: true,
+      });
+    });
+
+    expect(homeRef.current.getPreviousSubmissionsSummary()).toBe(
+      '2, loading...',
+    );
+
+    renderer.act(() => {
+      homeRef.current.setState({ isPreviousSubmissionsLoading: false });
+    });
+    expect(homeRef.current.getPreviousSubmissionsSummary()).toBe(2);
+
+    tree.unmount();
+  });
 });

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -296,7 +296,7 @@ describe('Home', () => {
     });
 
     expect(homeRef.current.getPreviousSubmissionsSummary()).toBe(
-      '2, loading...',
+      'at least 2, loading more...',
     );
     expect(
       tree.root.findByProps({ id: 'isLoadPreviousSubmissionsEnabled' }),

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -278,7 +278,7 @@ describe('Home', () => {
     tree.unmount();
   });
 
-  test('indicates loading in the submissions summary when showing cached submissions', () => {
+  test('shows loading summary and auto-load checkbox when refreshing cached submissions', () => {
     const initialState = {
       email: 'test@example.com',
       loginSuccessful: true,
@@ -291,12 +291,16 @@ describe('Home', () => {
         submissions: [{ objectId: 'cached-1' }, { objectId: 'cached-2' }],
         isPreviousSubmissionsLoading: true,
         hasLoadedPreviousSubmissions: true,
+        isPreviousSubmissionsOpen: true,
       });
     });
 
     expect(homeRef.current.getPreviousSubmissionsSummary()).toBe(
       '2, loading...',
     );
+    expect(
+      tree.root.findByProps({ id: 'isLoadPreviousSubmissionsEnabled' }),
+    ).toBeTruthy();
 
     renderer.act(() => {
       homeRef.current.setState({ isPreviousSubmissionsLoading: false });

--- a/src/routes/home/submissionsCache.js
+++ b/src/routes/home/submissionsCache.js
@@ -1,0 +1,83 @@
+/**
+ * Cache of a user's most recent submissions in localStorage.
+ *
+ * Submissions are only cached after a successful fetch, and the cache is
+ * always overwritten by the next successful fetch, so a stale entry never
+ * wins permanently. The cache exists so that the most recent submissions can
+ * be shown instantly while the fresh list loads in the background (see
+ * Home.loadPreviousSubmissions).
+ *
+ * Only a bounded, newest-first prefix is cached: some users have thousands of
+ * submissions, whose JSON exceeds localStorage's ~5MB per-origin quota.
+ * Keeping the cache small also keeps JSON.parse fast on page load.
+ */
+
+const STORAGE_KEY_PREFIX = 'reportedWebSubmissionsCache';
+
+export const MAX_CACHED_SUBMISSIONS = 200;
+export const MAX_CACHE_LENGTH = 2 * 1024 * 1024; // JSON string length
+
+export const getSubmissionsCacheKey = email => `${STORAGE_KEY_PREFIX}:${email}`;
+
+// `submissions` is newest-first (the server sorts by `timeofreport`
+// descending), so keeping the head of the array keeps the most recent ones.
+export const buildCachedSubmissionsJson = submissions => {
+  const cached = [];
+  let length = 0;
+  for (const submission of submissions) {
+    length += JSON.stringify(submission).length;
+    // Always cache at least the newest submission, so the cache is useful
+    // even if a single submission is large.
+    if (length > MAX_CACHE_LENGTH && cached.length > 0) {
+      break;
+    }
+    cached.push(submission);
+    if (cached.length >= MAX_CACHED_SUBMISSIONS) {
+      break;
+    }
+  }
+  return JSON.stringify({ version: 1, submissions: cached });
+};
+
+export const readCachedSubmissions = email => {
+  if (!email) {
+    return null;
+  }
+  try {
+    const raw = localStorage.getItem(getSubmissionsCacheKey(email));
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.submissions)) {
+      return parsed.submissions;
+    }
+    return null;
+  } catch {
+    // Corrupted data or localStorage unavailable (e.g. private browsing).
+    return null;
+  }
+};
+
+export const writeCachedSubmissions = (email, submissions) => {
+  if (!email) {
+    return;
+  }
+  try {
+    const json = buildCachedSubmissionsJson(submissions);
+    localStorage.setItem(getSubmissionsCacheKey(email), json);
+  } catch {
+    // localStorage can throw when full (QuotaExceededError) or unavailable.
+  }
+};
+
+export const clearCachedSubmissions = email => {
+  if (!email) {
+    return;
+  }
+  try {
+    localStorage.removeItem(getSubmissionsCacheKey(email));
+  } catch {
+    // localStorage unavailable (e.g. private browsing).
+  }
+};

--- a/src/routes/home/submissionsCache.js
+++ b/src/routes/home/submissionsCache.js
@@ -1,5 +1,5 @@
 /**
- * Cache of a user's most recent submissions in localStorage.
+ * Cache of the current user's most recent submissions in localStorage.
  *
  * Submissions are only cached after a successful fetch, and the cache is
  * always overwritten by the next successful fetch, so a stale entry never
@@ -7,17 +7,21 @@
  * be shown instantly while the fresh list loads in the background (see
  * Home.loadPreviousSubmissions).
  *
+ * The cache is not keyed per user: the home-state cookie already stores the
+ * user's credentials in plaintext, so anyone who can read localStorage on
+ * this machine can log in as that user anyway. Logging out clears the cache,
+ * which keeps one account's submissions from appearing for another account
+ * that logs in later on the same machine.
+ *
  * Only a bounded, newest-first prefix is cached: some users have thousands of
  * submissions, whose JSON exceeds localStorage's ~5MB per-origin quota.
  * Keeping the cache small also keeps JSON.parse fast on page load.
  */
 
-const STORAGE_KEY_PREFIX = 'reportedWebSubmissionsCache';
+export const STORAGE_KEY = 'reportedWebSubmissionsCache';
 
 export const MAX_CACHED_SUBMISSIONS = 200;
 export const MAX_CACHE_LENGTH = 2 * 1024 * 1024; // JSON string length
-
-export const getSubmissionsCacheKey = email => `${STORAGE_KEY_PREFIX}:${email}`;
 
 // `submissions` is newest-first (the server sorts by `timeofreport`
 // descending), so keeping the head of the array keeps the most recent ones.
@@ -39,12 +43,9 @@ export const buildCachedSubmissionsJson = submissions => {
   return JSON.stringify({ version: 1, submissions: cached });
 };
 
-export const readCachedSubmissions = email => {
-  if (!email) {
-    return null;
-  }
+export const readCachedSubmissions = () => {
   try {
-    const raw = localStorage.getItem(getSubmissionsCacheKey(email));
+    const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) {
       return null;
     }
@@ -59,24 +60,18 @@ export const readCachedSubmissions = email => {
   }
 };
 
-export const writeCachedSubmissions = (email, submissions) => {
-  if (!email) {
-    return;
-  }
+export const writeCachedSubmissions = submissions => {
   try {
     const json = buildCachedSubmissionsJson(submissions);
-    localStorage.setItem(getSubmissionsCacheKey(email), json);
+    localStorage.setItem(STORAGE_KEY, json);
   } catch {
     // localStorage can throw when full (QuotaExceededError) or unavailable.
   }
 };
 
-export const clearCachedSubmissions = email => {
-  if (!email) {
-    return;
-  }
+export const clearCachedSubmissions = () => {
   try {
-    localStorage.removeItem(getSubmissionsCacheKey(email));
+    localStorage.removeItem(STORAGE_KEY);
   } catch {
     // localStorage unavailable (e.g. private browsing).
   }

--- a/src/routes/home/submissionsCache.test.js
+++ b/src/routes/home/submissionsCache.test.js
@@ -1,14 +1,11 @@
 import {
   MAX_CACHED_SUBMISSIONS,
   MAX_CACHE_LENGTH,
+  STORAGE_KEY,
   clearCachedSubmissions,
-  getSubmissionsCacheKey,
   readCachedSubmissions,
   writeCachedSubmissions,
 } from './submissionsCache.js';
-
-const email = 'test@example.com';
-const key = getSubmissionsCacheKey(email);
 
 const makeSubmissions = count =>
   Array.from({ length: count }, (_, i) => ({
@@ -22,19 +19,19 @@ beforeEach(() => {
 
 describe('submissionsCache', () => {
   test('returns null when nothing is cached', () => {
-    expect(readCachedSubmissions(email)).toBeNull();
+    expect(readCachedSubmissions()).toBeNull();
   });
 
   test('round-trips submissions newest-first', () => {
     const submissions = makeSubmissions(3);
-    writeCachedSubmissions(email, submissions);
-    expect(readCachedSubmissions(email)).toEqual(submissions);
+    writeCachedSubmissions(submissions);
+    expect(readCachedSubmissions()).toEqual(submissions);
   });
 
   test('only caches the most recent submissions when there are many', () => {
     const submissions = makeSubmissions(MAX_CACHED_SUBMISSIONS * 2);
-    writeCachedSubmissions(email, submissions);
-    expect(readCachedSubmissions(email)).toEqual(
+    writeCachedSubmissions(submissions);
+    expect(readCachedSubmissions()).toEqual(
       submissions.slice(0, MAX_CACHED_SUBMISSIONS),
     );
   });
@@ -45,55 +42,48 @@ describe('submissionsCache', () => {
       { objectId: 'big', notes: 'x'.repeat(MAX_CACHE_LENGTH) },
       { objectId: 'oldest' },
     ];
-    writeCachedSubmissions(email, submissions);
-    expect(readCachedSubmissions(email)).toEqual([{ objectId: 'newest' }]);
+    writeCachedSubmissions(submissions);
+    expect(readCachedSubmissions()).toEqual([{ objectId: 'newest' }]);
   });
 
   test('returns null for corrupted cache data', () => {
-    localStorage.setItem(key, '{not valid json');
-    expect(readCachedSubmissions(email)).toBeNull();
+    localStorage.setItem(STORAGE_KEY, '{not valid json');
+    expect(readCachedSubmissions()).toBeNull();
   });
 
   test('returns null for cache data in an unexpected shape', () => {
-    localStorage.setItem(key, JSON.stringify({ version: 1, submissions: {} }));
-    expect(readCachedSubmissions(email)).toBeNull();
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 1, submissions: {} }),
+    );
+    expect(readCachedSubmissions()).toBeNull();
   });
 
   test('returns null for cache data from a future version', () => {
-    localStorage.setItem(key, JSON.stringify({ version: 2, submissions: [] }));
-    expect(readCachedSubmissions(email)).toBeNull();
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ version: 2, submissions: [] }),
+    );
+    expect(readCachedSubmissions()).toBeNull();
   });
 
   test('does not throw when localStorage is full', () => {
     jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new Error('QuotaExceededError');
     });
-    expect(() =>
-      writeCachedSubmissions(email, makeSubmissions(3)),
-    ).not.toThrow();
+    expect(() => writeCachedSubmissions(makeSubmissions(3))).not.toThrow();
   });
 
   test('does not throw when localStorage is unavailable', () => {
     jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('SecurityError');
     });
-    expect(readCachedSubmissions(email)).toBeNull();
-  });
-
-  test('keeps different users separate', () => {
-    writeCachedSubmissions(email, makeSubmissions(1));
-    expect(readCachedSubmissions('other@example.com')).toBeNull();
-  });
-
-  test('ignores empty emails', () => {
-    writeCachedSubmissions('', makeSubmissions(1));
-    expect(readCachedSubmissions('')).toBeNull();
-    clearCachedSubmissions('');
+    expect(readCachedSubmissions()).toBeNull();
   });
 
   test('clears the cache', () => {
-    writeCachedSubmissions(email, makeSubmissions(2));
-    clearCachedSubmissions(email);
-    expect(readCachedSubmissions(email)).toBeNull();
+    writeCachedSubmissions(makeSubmissions(2));
+    clearCachedSubmissions();
+    expect(readCachedSubmissions()).toBeNull();
   });
 });

--- a/src/routes/home/submissionsCache.test.js
+++ b/src/routes/home/submissionsCache.test.js
@@ -1,0 +1,99 @@
+import {
+  MAX_CACHED_SUBMISSIONS,
+  MAX_CACHE_LENGTH,
+  clearCachedSubmissions,
+  getSubmissionsCacheKey,
+  readCachedSubmissions,
+  writeCachedSubmissions,
+} from './submissionsCache.js';
+
+const email = 'test@example.com';
+const key = getSubmissionsCacheKey(email);
+
+const makeSubmissions = count =>
+  Array.from({ length: count }, (_, i) => ({
+    objectId: `submission-${i}`,
+    timeofreport: i,
+  }));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('submissionsCache', () => {
+  test('returns null when nothing is cached', () => {
+    expect(readCachedSubmissions(email)).toBeNull();
+  });
+
+  test('round-trips submissions newest-first', () => {
+    const submissions = makeSubmissions(3);
+    writeCachedSubmissions(email, submissions);
+    expect(readCachedSubmissions(email)).toEqual(submissions);
+  });
+
+  test('only caches the most recent submissions when there are many', () => {
+    const submissions = makeSubmissions(MAX_CACHED_SUBMISSIONS * 2);
+    writeCachedSubmissions(email, submissions);
+    expect(readCachedSubmissions(email)).toEqual(
+      submissions.slice(0, MAX_CACHED_SUBMISSIONS),
+    );
+  });
+
+  test('only caches submissions that fit in the size budget', () => {
+    const submissions = [
+      { objectId: 'newest' },
+      { objectId: 'big', notes: 'x'.repeat(MAX_CACHE_LENGTH) },
+      { objectId: 'oldest' },
+    ];
+    writeCachedSubmissions(email, submissions);
+    expect(readCachedSubmissions(email)).toEqual([{ objectId: 'newest' }]);
+  });
+
+  test('returns null for corrupted cache data', () => {
+    localStorage.setItem(key, '{not valid json');
+    expect(readCachedSubmissions(email)).toBeNull();
+  });
+
+  test('returns null for cache data in an unexpected shape', () => {
+    localStorage.setItem(key, JSON.stringify({ version: 1, submissions: {} }));
+    expect(readCachedSubmissions(email)).toBeNull();
+  });
+
+  test('returns null for cache data from a future version', () => {
+    localStorage.setItem(key, JSON.stringify({ version: 2, submissions: [] }));
+    expect(readCachedSubmissions(email)).toBeNull();
+  });
+
+  test('does not throw when localStorage is full', () => {
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() =>
+      writeCachedSubmissions(email, makeSubmissions(3)),
+    ).not.toThrow();
+  });
+
+  test('does not throw when localStorage is unavailable', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    expect(readCachedSubmissions(email)).toBeNull();
+  });
+
+  test('keeps different users separate', () => {
+    writeCachedSubmissions(email, makeSubmissions(1));
+    expect(readCachedSubmissions('other@example.com')).toBeNull();
+  });
+
+  test('ignores empty emails', () => {
+    writeCachedSubmissions('', makeSubmissions(1));
+    expect(readCachedSubmissions('')).toBeNull();
+    clearCachedSubmissions('');
+  });
+
+  test('clears the cache', () => {
+    writeCachedSubmissions(email, makeSubmissions(2));
+    clearCachedSubmissions(email);
+    expect(readCachedSubmissions(email)).toBeNull();
+  });
+});


### PR DESCRIPTION
Show cached recent submissions instantly while the fresh list loads in
the background, so the list appears immediately instead of waiting for
the /submissions fetch.

Only a bounded, newest-first prefix is cached: up to 200 submissions or
2MB of JSON. Some users have thousands of submissions (10MB+), which
would exceed localStorage's quota and make JSON.parse slow.

The cache is overwritten by every successful fetch, so stale data never
wins. It is not keyed per user, since the home-state cookie already
stores credentials in plaintext; logging out clears the cache so one
account's submissions don't appear for another on the same machine.

While the background refresh is in flight, the Previous Submissions
summary shows "at least N, loading more...", and the auto-load checkbox
remains visible.

Co-Authored-By: Claude Code with DeepSeek