### PR TITLE
Revert "fix(deps): resolve `browser-sync`'s `immutable@^3` to 4.3.9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "parse/@babel/runtime": "7.27.6",
     "parse/@babel/runtime-corejs3": "7.29.7",
     "node-fetch": "2.7.0",
-    "universal-router/path-to-regexp": "3.3.0",
-    "immutable": "4.3.9"
+    "universal-router/path-to-regexp": "3.3.0"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6420,10 +6420,10 @@ immer@^9.0.7:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
-immutable@4.3.9, immutable@^3:
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
-  integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
+immutable@^3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
+  integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
 
 import-fresh@^3.1.0:
   version "3.3.0"


### PR DESCRIPTION
Reverts josephfrazier/reported-web#936, as it broke `yarn start` according to Claude Code / DeepSeek:

> The `immutable: 4.3.9` resolution silently broke `yarn start`: every
> URL (`/`, `/submissions-map`, even `favicon.ico` and the webpack
> bundles served by `webpack-dev-middleware`) returned browser-sync's
> `Cannot GET /...` page, because the Express app passed as
> `middleware: [server]` in `tools/start.js` never made it into
> browser-sync's middleware stack.
> 
> How it breaks: browser-sync's options pipeline
> (`node_modules/browser-sync/dist/cli/cli-options.js`) computes
> `Immutable.fromJS(defaultConfig).mergeDeep(userOptions)`. With
> `immutable@3`, `mergeDeep` coerces the plain array in
> `middleware: [server]` into an `Immutable.List`, so the subsequent
> `listMerge()` step in `dist/options.js` (inside browser-sync's
> misspelled `getMiddlwares()` helper, sic) recognizes it via
> `Immutable.List.isList(item)` and merges it into the options'
> `middleware` list. `immutable@4` removed that implicit plain-JS
> coercion from `mergeDeep` — see the [immutable v4 docs] — so the
> value stays a plain `Array`, `Immutable.List.isList()` returns false,
> and `listMerge()` silently drops it. The result is
> `bs.options.get("middleware")` being an empty `List`,
> `getMiddlewares()` (`dist/server/utils.js`) building `bs.app.stack`
> without any user middleware, and every request falling through to
> browser-sync's built-in serve-static middleware. That middleware's
> `baseDir` comes from `handleServerOption()`
> (`dist/cli/transforms/handleServerOption.js`), which turns the string
> form `server: 'src/server.js'` into `baseDir: ['src/server.js']` — a
> file, not a directory — so nothing matches and connect answers
> `Cannot GET /...` for every path.
> 
> Verified by running the same options pipeline against both versions:
> 
> - `immutable@3.8.3`: `mergeDeep({ middleware: [app] })` yields an
>   `Immutable.List` (`isList` → true) → middleware mounted → the
>   Express app answers `GET /` with 200
> - `immutable@4.3.9`: `mergeDeep({ middleware: [app] })` yields a
>   plain `Array` (`isList` → false) → middleware dropped → `GET /`
>   answers 404 `Cannot GET /`
> 
> `browser-sync@3.0.4` (the current latest release) still declares
> `"immutable": "^3"` in its [package.json][browser-sync dependencies],
> so no published browser-sync version works with `immutable@4`, and
> keeping the resolution breaks the dev server entirely. This
> reintroduces the `immutable@3` hash-collision DoS exposure from
> [GHSA-xvcm-6775-5m9r], but `immutable` is only reachable through the
> dev-only browser-sync chain used by `yarn start` — not the production
> build or any CI job.
> 
> This reverts commit 0339b4fdbcc3db65a14e0f03ac501f45dac84acf.
> 
> [browser-sync dependencies]: https://unpkg.com/browser-sync@3.0.4/package.json
> [immutable v4 docs]: https://immutable-js.com/docs/v4.3.9/
> [GHSA-xvcm-6775-5m9r]: https://github.com/advisories/GHSA-xvcm-6775-5m9r