### PR TITLE
feat: add "My Submissions" mode to `submissions-map.html`

### DIFF
--- a/public/submissions-map.html
+++ b/public/submissions-map.html
@@ -332,8 +332,6 @@
 
   .popup-meta .val { color: var(--text); }
 
-  #popup-meta a { color: var(--accent); }
-
   .popup-photos { display: flex; }
 
   .popup-photos img {
@@ -581,29 +579,6 @@ function positionPopup(clientX, clientY) {
   popup.style.top  = y + 'px';
 }
 
-// Link a submission's `objectId` to its Back4App browser view so it can
-// be found in the database directly from the map popup.
-const BACK4APP_APP_ID = '932de73d-5214-4a3e-aec5-5c9be0055dac';
-const BACK4APP_SUBMISSION_URL = `https://backend.back4app.com/apps/${BACK4APP_APP_ID}/browser/submission`;
-
-function back4appSubmissionUrl(objectId) {
-  const filters = encodeURIComponent(
-    JSON.stringify([
-      { field: 'objectId', constraint: 'eq', compareTo: objectId },
-    ]),
-  );
-  return `${BACK4APP_SUBMISSION_URL}?filters=${filters}`;
-}
-
-function escapeHtml(text) {
-  return String(text)
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
-
 function populatePopup(s) {
   const photos = [s.photoData0, s.photoData1, s.photoData2].filter(p => p && p.url);
   const color  = colorFor(s.typeofcomplaint);
@@ -617,11 +592,6 @@ function populatePopup(s) {
   const d = formatDate(s.timeofreport?.iso);
   if (d) rows.push(d);
   if (s.reqnumber) rows.push(`req <span class="val">${s.reqnumber}</span>`);
-  if (s.objectId) {
-    rows.push(
-      `id <a href="${back4appSubmissionUrl(s.objectId)}" target="_blank" rel="noopener noreferrer">${escapeHtml(s.objectId)}</a>`,
-    );
-  }
   popupMeta.innerHTML = rows.join('<br>');
 
   if (photos.length > 0) {

--- a/public/submissions-map.html
+++ b/public/submissions-map.html
@@ -89,7 +89,7 @@
   .tab + .tab { border-left: 1px solid var(--border2); }
 
   /* ── PANEL SHARED ── */
-  #panel-paste, #panel-draw {
+  #panel-paste, #panel-draw, #panel-my-submissions {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -98,7 +98,7 @@
     max-width: 640px;
   }
 
-  #panel-draw { display: none; }
+  #panel-draw, #panel-my-submissions { display: none; }
 
   #paste-screen p {
     font-size: 0.7rem;
@@ -145,7 +145,7 @@
     max-width: 640px;
   }
 
-  #load-btn {
+  #load-btn, #load-my-submissions-btn {
     background: var(--accent);
     color: #ffffff;
     border: none;
@@ -160,8 +160,9 @@
     transition: opacity 0.15s, transform 0.1s;
   }
 
-  #load-btn:hover { opacity: 0.85; transform: translateY(-1px); }
-  #load-btn:active { transform: translateY(0); }
+  #load-btn:hover, #load-my-submissions-btn:hover { opacity: 0.85; transform: translateY(-1px); }
+  #load-btn:active, #load-my-submissions-btn:active { transform: translateY(0); }
+  #load-my-submissions-btn:disabled { opacity: 0.5; cursor: default; transform: none; }
 
   /* ── MAP SCREEN ── */
   #map-screen {
@@ -397,6 +398,18 @@
     letter-spacing: 0.04em;
     text-align: center;
   }
+
+  #my-submissions-status {
+    font-size: 0.65rem;
+    color: var(--muted);
+    letter-spacing: 0.04em;
+    text-align: center;
+    min-height: 1.5em;
+  }
+
+  #my-submissions-status a { color: var(--accent); }
+  #my-submissions-login-prompt { display: none; }
+  #my-submissions-login-prompt a { color: var(--accent); }
 </style>
 </head>
 <body>
@@ -407,6 +420,7 @@
   <div class="tabs">
     <button class="tab active" id="tab-paste">Paste JSON</button>
     <button class="tab" id="tab-draw">Draw Area</button>
+    <button class="tab" id="tab-my-submissions">My Submissions</button>
   </div>
 
   <div id="panel-paste">
@@ -437,12 +451,22 @@
     <div id="draw-map"></div>
     <div id="draw-status">Select the polygon tool and draw a shape on the map.</div>
   </div>
+
+  <div id="panel-my-submissions">
+    <p>Load all of your own submissions onto the map — no polygon needed. Sign in on the home page first if you haven't already.</p>
+    <div id="my-submissions-status"></div>
+    <button id="load-my-submissions-btn">Load My Submissions →</button>
+    <div id="my-submissions-login-prompt">
+      <p>You need to be logged in to view your submissions. <a href="/">Log in or sign up on the home page</a>, then come back and load them.</p>
+    </div>
+  </div>
 </div>
 
 <!-- MAP SCREEN -->
 <div id="map-screen">
   <header>
     <h1>Complaint Map</h1>
+    <span class="count-badge" id="mode-label"></span>
     <span class="count-badge" id="count-badge"></span>
     <div class="legend">
       <div class="legend-item"><div class="legend-dot" style="background:var(--crosswalk)"></div>Blocked crosswalk</div>
@@ -529,6 +553,7 @@ let currentPolygonStr = null;
 let loadedPolygonStr = null;
 let photosOnly = false;
 let isMapScreenVisible = false;
+let currentMode = null; // null | 'paste' | 'polygon' | 'my'
 
 const popup     = document.getElementById('popup');
 const popupComp = document.getElementById('popup-complaint');
@@ -536,6 +561,10 @@ const popupMeta = document.getElementById('popup-meta');
 const popupPics = document.getElementById('popup-photos');
 const closeBtn  = document.getElementById('popup-close');
 const photosOnlyCheckbox = document.getElementById('photos-only-checkbox');
+const mySubmissionsStatusEl = document.getElementById('my-submissions-status');
+const mySubmissionsPromptEl = document.getElementById('my-submissions-login-prompt');
+const mySubmissionsLoadBtn  = document.getElementById('load-my-submissions-btn');
+const modeLabelEl           = document.getElementById('mode-label');
 
 let hideTimer = null;
 let pinned    = false;
@@ -626,6 +655,7 @@ function polygonToString(vertices) {
 function updateUrlFromState(shouldPushToHistory = true) {
   const params = new URLSearchParams();
   if (currentPolygonStr) params.set('polygon', currentPolygonStr);
+  if (currentMode === 'my') params.set('mySubmissions', '1');
   if (photosOnly) params.set('photosOnly', '1');
   const nextUrl = params.toString() ? `?${params}` : window.location.pathname;
   if (shouldPushToHistory) history.pushState(null, '', nextUrl);
@@ -638,6 +668,9 @@ function renderMap(submissions) {
   mapScreen.style.display = 'flex';
   isMapScreenVisible = true;
   document.getElementById('count-badge').textContent = `${submissions.length} report${submissions.length !== 1 ? 's' : ''}`;
+  modeLabelEl.textContent = currentMode === 'polygon'
+    ? 'Drawn area'
+    : currentMode === 'my' ? 'My submissions' : '';
 
   if (!map) {
     map = L.map('map', { zoomControl: true });
@@ -695,6 +728,7 @@ document.getElementById('load-btn').addEventListener('click', () => {
   try {
     const data = parseInput(raw);
     if (!Array.isArray(data) || data.length === 0) throw new Error('Expected a non-empty array of submission objects.');
+    currentMode = 'paste';
     currentPolygonStr = null;
     loadedPolygonStr = null;
     updateUrlFromState(true);
@@ -714,30 +748,31 @@ document.getElementById('reset-btn').addEventListener('click', () => {
   if (drawnItems) drawnItems.clearLayers();
   document.getElementById('draw-status').textContent = 'Select the polygon tool and draw a shape on the map.';
   allSubmissions = [];
+  currentMode = null;
   currentPolygonStr = null;
   loadedPolygonStr = null;
   photosOnly = false;
   photosOnlyCheckbox.checked = false;
+  mySubmissionsStatusEl.textContent = '';
+  mySubmissionsPromptEl.style.display = 'none';
+  mySubmissionsLoadBtn.disabled = false;
   clearUrlParams();
 });
 
 // ── TAB SWITCHING ──
-document.getElementById('tab-paste').addEventListener('click', () => {
-  document.getElementById('tab-paste').classList.add('active');
-  document.getElementById('tab-draw').classList.remove('active');
-  document.getElementById('panel-paste').style.display = 'flex';
-  document.getElementById('panel-draw').style.display = 'none';
-  document.getElementById('paste-screen').classList.remove('draw-active');
-});
+function selectTab(tabId) {
+  document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
+  document.getElementById(tabId).classList.add('active');
+  document.getElementById('panel-paste').style.display = tabId === 'tab-paste' ? 'flex' : 'none';
+  document.getElementById('panel-draw').style.display = tabId === 'tab-draw' ? 'flex' : 'none';
+  document.getElementById('panel-my-submissions').style.display = tabId === 'tab-my-submissions' ? 'flex' : 'none';
+  document.getElementById('paste-screen').classList.toggle('draw-active', tabId === 'tab-draw');
+  if (tabId === 'tab-draw') initDrawMap();
+}
 
-document.getElementById('tab-draw').addEventListener('click', () => {
-  document.getElementById('tab-draw').classList.add('active');
-  document.getElementById('tab-paste').classList.remove('active');
-  document.getElementById('panel-paste').style.display = 'none';
-  document.getElementById('panel-draw').style.display = 'flex';
-  document.getElementById('paste-screen').classList.add('draw-active');
-  initDrawMap();
-});
+document.getElementById('tab-paste').addEventListener('click', () => selectTab('tab-paste'));
+document.getElementById('tab-draw').addEventListener('click', () => selectTab('tab-draw'));
+document.getElementById('tab-my-submissions').addEventListener('click', () => selectTab('tab-my-submissions'));
 
 // ── DRAW MAP ──
 let drawMap = null;
@@ -784,6 +819,7 @@ function initDrawMap() {
       polygonLatLngs[0].lng === last.lng
         ? polygonLatLngs.slice(0, -1)
         : polygonLatLngs;
+    currentMode = 'polygon';
     currentPolygonStr = polygonToString(vertices);
     updateUrlFromState(true);
     await fetchAndLoadPolygon(vertices);
@@ -828,6 +864,88 @@ async function fetchAndLoadPolygon(vertices) {
   }
 }
 
+// ── MY SUBMISSIONS ──
+const HOME_STATE_COOKIE = 'reportedWebHomeState';
+
+function getHomeStateCookie() {
+  try {
+    const entry = document.cookie
+      .split('; ')
+      .find(c => c.startsWith(`${HOME_STATE_COOKIE}=`));
+    if (!entry) return null;
+    return JSON.parse(decodeURIComponent(entry.slice(HOME_STATE_COOKIE.length + 1)));
+  } catch {
+    return null; // corrupt/undecodable cookie → treat as logged out
+  }
+}
+
+function getCredentials() {
+  const state = getHomeStateCookie();
+  if (!state) return null;
+  const { email, password, FirstName, LastName, Phone, testify } = state;
+  if (!email || !password || !FirstName || !LastName || !Phone) return null;
+  return { email, password, FirstName, LastName, Phone, testify: Boolean(testify) };
+}
+
+function showMySubmissionsLoginPrompt() {
+  mySubmissionsStatusEl.textContent = '';
+  mySubmissionsPromptEl.style.display = 'block';
+  mySubmissionsLoadBtn.disabled = false;
+}
+
+async function loadMySubmissions() {
+  const credentials = getCredentials();
+  if (!credentials) {
+    showMySubmissionsLoginPrompt();
+    return;
+  }
+  mySubmissionsPromptEl.style.display = 'none';
+  mySubmissionsStatusEl.textContent = 'Loading your submissions…';
+  mySubmissionsLoadBtn.disabled = true;
+  try {
+    const resp = await fetch('/submissions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(credentials),
+    });
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({}));
+      throw new Error(body.error || `Unexpected server error (HTTP ${resp.status}). Please try again.`);
+    }
+    const data = await resp.json();
+    const submissions = Array.isArray(data.submissions) ? data.submissions : [];
+    mySubmissionsStatusEl.textContent = '';
+    if (submissions.length === 0) {
+      // Stay on the selection screen (mirrors polygon empty-state behavior)
+      mySubmissionsStatusEl.textContent = 'No submissions found yet.';
+    } else {
+      loadMap(submissions); // map screen, count badge, popups, photos-only filter all work unchanged
+    }
+  } catch (e) {
+    const isNetworkError = e instanceof TypeError;
+    if (isNetworkError) {
+      mySubmissionsStatusEl.textContent = 'Network error: could not reach the server. Please check your connection and try again.';
+    } else {
+      // e.message may be server-supplied text (e.g. the email-verification message)
+      mySubmissionsStatusEl.innerHTML =
+        `Could not load your submissions.${e.message ? ` ${e.message}` : ''} ` +
+        `<a href="/">Log in again on the home page</a> and try again.`;
+    }
+  } finally {
+    mySubmissionsLoadBtn.disabled = false;
+  }
+}
+
+mySubmissionsLoadBtn.addEventListener('click', () => {
+  if (!getCredentials()) {
+    showMySubmissionsLoginPrompt();
+    return;
+  }
+  currentMode = 'my';
+  updateUrlFromState(true); // push ?mySubmissions=1 (user-action sites push, like the polygon draw handler)
+  loadMySubmissions();
+});
+
 // ── URL PARAMS ──
 function clearUrlParams() {
   history.pushState(null, '', window.location.pathname);
@@ -843,6 +961,7 @@ function applyUrlState() {
 
   if (polygonStr) {
     const shouldFetchNewPolygonData = polygonStr !== loadedPolygonStr;
+    currentMode = 'polygon';
     currentPolygonStr = polygonStr;
     document.getElementById('map-screen').style.display = 'none';
     document.getElementById('paste-screen').style.display = 'flex';
@@ -866,8 +985,24 @@ function applyUrlState() {
     } else {
       applyPhotoFilter();
     }
+  } else if (params.get('mySubmissions') === '1') {
+    currentPolygonStr = null;
+    loadedPolygonStr = null;
+    // Keep the current map visible when only the photosOnly URL param changes
+    // (mirrors the keep-visible logic below for manually loaded data).
+    if (currentMode === 'my' && allSubmissions.length > 0 && isMapScreenVisible) {
+      applyPhotoFilter();
+      return;
+    }
+    document.getElementById('map-screen').style.display = 'none';
+    document.getElementById('paste-screen').style.display = 'flex';
+    isMapScreenVisible = false;
+    currentMode = 'my';
+    document.getElementById('tab-my-submissions').click();
+    loadMySubmissions(); // restore paths never pushState
   } else {
     currentPolygonStr = null;
+    currentMode = null;
     // Keep the current map visible when only the photosOnly URL param changes for manually loaded data.
     if (
       loadedPolygonStr === null &&
@@ -890,8 +1025,10 @@ function applyUrlState() {
 window.addEventListener('popstate', applyUrlState);
 
 // On load: apply the URL state (handles direct links with polygon params)
-const hasPolygonParam = new URLSearchParams(window.location.search).has('polygon');
-if (!hasPolygonParam) {
+const urlParams = new URLSearchParams(window.location.search);
+const hasPolygonParam = urlParams.has('polygon');
+const hasMySubmissionsParam = urlParams.has('mySubmissions');
+if (!hasPolygonParam && !hasMySubmissionsParam) {
   const tabDraw = document.getElementById('tab-draw');
   if (tabDraw) tabDraw.click();
 }

--- a/public/submissions-map.html
+++ b/public/submissions-map.html
@@ -332,6 +332,8 @@
 
   .popup-meta .val { color: var(--text); }
 
+  #popup-meta a { color: var(--accent); }
+
   .popup-photos { display: flex; }
 
   .popup-photos img {
@@ -580,6 +582,29 @@ function positionPopup(clientX, clientY) {
   popup.style.top  = y + 'px';
 }
 
+// Link a submission's `objectId` to its Back4App browser view so it can
+// be found in the database directly from the map popup.
+const BACK4APP_APP_ID = '932de73d-5214-4a3e-aec5-5c9be0055dac';
+const BACK4APP_SUBMISSION_URL = `https://backend.back4app.com/apps/${BACK4APP_APP_ID}/browser/submission`;
+
+function back4appSubmissionUrl(objectId) {
+  const filters = encodeURIComponent(
+    JSON.stringify([
+      { field: 'objectId', constraint: 'eq', compareTo: objectId },
+    ]),
+  );
+  return `${BACK4APP_SUBMISSION_URL}?filters=${filters}`;
+}
+
+function escapeHtml(text) {
+  return String(text)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
 function populatePopup(s) {
   const photos = [s.photoData0, s.photoData1, s.photoData2].filter(p => p && p.url);
   const color  = colorFor(s.typeofcomplaint);
@@ -593,6 +618,11 @@ function populatePopup(s) {
   const d = formatDate(s.timeofreport?.iso);
   if (d) rows.push(d);
   if (s.reqnumber) rows.push(`req <span class="val">${s.reqnumber}</span>`);
+  if (s.objectId) {
+    rows.push(
+      `id <a href="${back4appSubmissionUrl(s.objectId)}" target="_blank" rel="noopener noreferrer">${escapeHtml(s.objectId)}</a>`,
+    );
+  }
   popupMeta.innerHTML = rows.join('<br>');
 
   if (photos.length > 0) {

--- a/public/submissions-map.html
+++ b/public/submissions-map.html
@@ -508,6 +508,7 @@ const COMPLAINT_COLORS = {
 
 const DEFAULT_MAP_CENTER = [40.72, -73.98];
 const DEFAULT_MAP_ZOOM = 12;
+const NYC_BOUNDS = L.latLngBounds([40.4774, -74.2591], [40.9176, -73.7004]);
 
 function colorFor(complaint) {
   if (!complaint) return '#7b8698';
@@ -699,7 +700,27 @@ function renderMap(submissions) {
     markerLayer.addLayer(marker);
   });
 
-  if (bounds.length > 0) map.fitBounds(bounds, { padding: [40, 40] });
+  if (bounds.length > 0) {
+    if (currentMode === 'my') {
+      // "My submissions" can include points far outside the city (e.g.
+      // mis-geocoded submissions), which would fit the view to the whole
+      // country. Keep the initial view on NYC instead.
+      const submissionBounds = L.latLngBounds(bounds);
+      const south = Math.max(submissionBounds.getSouth(), NYC_BOUNDS.getSouth());
+      const north = Math.min(submissionBounds.getNorth(), NYC_BOUNDS.getNorth());
+      const west = Math.max(submissionBounds.getWest(), NYC_BOUNDS.getWest());
+      const east = Math.min(submissionBounds.getEast(), NYC_BOUNDS.getEast());
+      const fitBounds =
+        north > south && east > west
+          ? L.latLngBounds([south, west], [north, east])
+          : NYC_BOUNDS;
+      map.fitBounds(fitBounds, { padding: [40, 40] });
+    } else {
+      map.fitBounds(bounds, { padding: [40, 40] });
+    }
+  } else if (currentMode === 'my') {
+    map.fitBounds(NYC_BOUNDS, { padding: [40, 40] });
+  }
   setTimeout(() => map.invalidateSize(), 60);
 }
 

--- a/public/submissions-map.html
+++ b/public/submissions-map.html
@@ -510,7 +510,6 @@ const COMPLAINT_COLORS = {
 
 const DEFAULT_MAP_CENTER = [40.72, -73.98];
 const DEFAULT_MAP_ZOOM = 12;
-const NYC_BOUNDS = L.latLngBounds([40.4774, -74.2591], [40.9176, -73.7004]);
 
 function colorFor(complaint) {
   if (!complaint) return '#7b8698';
@@ -730,27 +729,7 @@ function renderMap(submissions) {
     markerLayer.addLayer(marker);
   });
 
-  if (bounds.length > 0) {
-    if (currentMode === 'my') {
-      // "My submissions" can include points far outside the city (e.g.
-      // mis-geocoded submissions), which would fit the view to the whole
-      // country. Keep the initial view on NYC instead.
-      const submissionBounds = L.latLngBounds(bounds);
-      const south = Math.max(submissionBounds.getSouth(), NYC_BOUNDS.getSouth());
-      const north = Math.min(submissionBounds.getNorth(), NYC_BOUNDS.getNorth());
-      const west = Math.max(submissionBounds.getWest(), NYC_BOUNDS.getWest());
-      const east = Math.min(submissionBounds.getEast(), NYC_BOUNDS.getEast());
-      const fitBounds =
-        north > south && east > west
-          ? L.latLngBounds([south, west], [north, east])
-          : NYC_BOUNDS;
-      map.fitBounds(fitBounds, { padding: [40, 40] });
-    } else {
-      map.fitBounds(bounds, { padding: [40, 40] });
-    }
-  } else if (currentMode === 'my') {
-    map.fitBounds(NYC_BOUNDS, { padding: [40, 40] });
-  }
+  if (bounds.length > 0) map.fitBounds(bounds, { padding: [40, 40] });
   setTimeout(() => map.invalidateSize(), 60);
 }
 

--- a/tools/test-client-smoke.js
+++ b/tools/test-client-smoke.js
@@ -176,19 +176,6 @@ const run = async () => {
     await mapPage.waitForFunction(
       () => document.querySelectorAll('.leaflet-marker-icon').length === 2,
     );
-
-    // The first marker belongs to `sub_1`; its popup should link that
-    // objectId to the Back4App browser view.
-    await mapPage.locator('#map .leaflet-marker-icon').first().hover();
-    await mapPage.waitForSelector('#popup.visible');
-    const objectIdHref = await mapPage
-      .locator('#popup-meta a')
-      .first()
-      .getAttribute('href');
-    const objectIdText = await mapPage
-      .locator('#popup-meta a')
-      .first()
-      .textContent();
     const countBadge = await mapPage.locator('#count-badge').textContent();
     const modeLabel = await mapPage.locator('#mode-label').textContent();
     const loggedInPromptVisible = await mapPage
@@ -218,16 +205,6 @@ const run = async () => {
         // Counts all submissions; geoless ones are skipped only for markers
         ok: countBadge === '3 reports',
         detail: `count-badge: ${countBadge}`,
-      },
-      {
-        name: 'submissions map: popup links objectId to the Back4App browser',
-        ok:
-          objectIdHref?.startsWith(
-            'https://backend.back4app.com/apps/932de73d-5214-4a3e-aec5-5c9be0055dac/browser/submission?filters=',
-          ) &&
-          objectIdHref.includes('compareTo%22%3A%22sub_1%22') &&
-          objectIdText === 'sub_1',
-        detail: JSON.stringify({ objectIdHref, objectIdText }),
       },
       {
         name: 'submissions map: shows My submissions mode label',

--- a/tools/test-client-smoke.js
+++ b/tools/test-client-smoke.js
@@ -161,17 +161,6 @@ const run = async () => {
               photoData2: null,
             },
             { objectId: 'sub_3' }, // no location → skipped by renderMap
-            {
-              objectId: 'sub_4',
-              // Far outside NYC — without the NYC view clamp in "My
-              // submissions" mode this fits the whole USA into view
-              location: {
-                __type: 'GeoPoint',
-                latitude: 39.8,
-                longitude: -98.5,
-              },
-              typeofcomplaint: 'Ran red light',
-            },
           ],
         }),
       });
@@ -185,26 +174,8 @@ const run = async () => {
     await mapPage.click('#tab-my-submissions');
     await mapPage.click('#load-my-submissions-btn');
     await mapPage.waitForFunction(
-      () => document.querySelectorAll('.leaflet-marker-icon').length === 3,
+      () => document.querySelectorAll('.leaflet-marker-icon').length === 2,
     );
-    // Leaflet tile URLs embed the zoom level ({z}); wait for an
-    // NYC-scale view (zoom >= 10 — a USA-wide fit is zoom ~4) before
-    // asserting it.
-    await mapPage.waitForFunction(() => {
-      // Scope to the main map: the draw map's tiles (created at zoom
-      // 12 on page load) would otherwise satisfy the check.
-      const tile = document.querySelector('#map .leaflet-tile');
-      if (!tile) return false;
-      const parts = tile.src.split('/');
-      return Number(parts[parts.length - 3]) >= 10;
-    });
-
-    const tileZoom = await mapPage.evaluate(() => {
-      const tile = document.querySelector('#map .leaflet-tile');
-      if (!tile) return null;
-      const parts = tile.src.split('/');
-      return Number(parts[parts.length - 3]);
-    });
 
     // The first marker belongs to `sub_1`; its popup should link that
     // objectId to the Back4App browser view.
@@ -218,7 +189,6 @@ const run = async () => {
       .locator('#popup-meta a')
       .first()
       .textContent();
-
     const countBadge = await mapPage.locator('#count-badge').textContent();
     const modeLabel = await mapPage.locator('#mode-label').textContent();
     const loggedInPromptVisible = await mapPage
@@ -246,13 +216,8 @@ const run = async () => {
       {
         name: 'submissions map: renders markers and count badge',
         // Counts all submissions; geoless ones are skipped only for markers
-        ok: countBadge === '4 reports',
+        ok: countBadge === '3 reports',
         detail: `count-badge: ${countBadge}`,
-      },
-      {
-        name: 'submissions map: keeps the view on NYC despite a far-away submission',
-        ok: tileZoom !== null && tileZoom >= 10,
-        detail: `tile zoom: ${tileZoom}`,
       },
       {
         name: 'submissions map: popup links objectId to the Back4App browser',

--- a/tools/test-client-smoke.js
+++ b/tools/test-client-smoke.js
@@ -8,6 +8,10 @@
  * null` when the browser evaluated a chunk, while the server kept
  * returning a healthy 200 page.
  *
+ * Also exercises `/submissions-map`: both the logged-in "My Submissions"
+ * flow (with the `/submissions` POST mocked via route interception) and
+ * the logged-out login-prompt flow.
+ *
  * Run after `yarn build`; see `tools/test-ssr-css.js` for the server
  * lifecycle pattern this mirrors.
  */
@@ -20,19 +24,43 @@ const BASE_URL = `http://localhost:${PORT}`;
 
 process.env.PORT = PORT;
 
+// The map page loads Leaflet (CDN) and OSM tiles immediately; failed
+// image/tile fetches surface as "Failed to load resource" console errors
+// without breaking the page, so skip those when checking for real errors.
+function attachErrorListeners(page, errors) {
+  page.on('pageerror', error => errors.push(`pageerror: ${error.message}`));
+  page.on('console', message => {
+    if (
+      message.type() === 'error' &&
+      !/Failed to load resource/.test(message.text())
+    ) {
+      errors.push(`console.error: ${message.text()}`);
+    }
+  });
+}
+
+function runChecks(checks) {
+  let failures = 0;
+  for (const { name, ok, detail } of checks) {
+    console.info(`${ok ? '✓' : '✗'} ${name}`);
+    if (!ok && detail) {
+      console.error(detail);
+    }
+    if (!ok) failures += 1;
+  }
+  return failures;
+}
+
 const run = async () => {
   const server = await runServer();
   const browser = await chromium.launch();
+  let failures = 0;
   try {
+    // ── Home page ──
     const page = await browser.newPage();
 
     const errors = [];
-    page.on('pageerror', error => errors.push(`pageerror: ${error.message}`));
-    page.on('console', message => {
-      if (message.type() === 'error') {
-        errors.push(`console.error: ${message.text()}`);
-      }
-    });
+    attachErrorListeners(page, errors);
 
     const response = await page.goto(BASE_URL, { waitUntil: 'load' });
 
@@ -42,7 +70,7 @@ const run = async () => {
       .textContent()
       .catch(() => null);
 
-    const checks = [
+    failures += runChecks([
       {
         name: 'page responds',
         ok: response !== null && response.ok(),
@@ -57,19 +85,185 @@ const run = async () => {
         ok: typeof heading === 'string' && heading.length > 0,
         detail: heading,
       },
-    ];
+    ]);
 
-    let failures = 0;
-    for (const { name, ok, detail } of checks) {
-      console.info(`${ok ? '✓' : '✗'} ${name}`);
-      if (!ok && detail) {
-        console.error(detail);
+    // ── Submissions map: logged in ──
+    const homeState = {
+      email: 'test@example.com',
+      password: 'password123',
+      FirstName: 'Test',
+      LastName: 'User',
+      Phone: '555-555-5555',
+      testify: false,
+      loginSuccessful: true,
+    };
+    const loggedInContext = await browser.newContext();
+    await loggedInContext.addCookies([
+      {
+        name: 'reportedWebHomeState',
+        // Home.js serializes the cookie value with `cookie.serialize`,
+        // which URI-encodes the JSON
+        value: encodeURIComponent(JSON.stringify(homeState)),
+        url: BASE_URL,
+        sameSite: 'Lax',
+      },
+    ]);
+
+    let submissionsPostCount = 0;
+    let submissionsPostBody = null;
+    await loggedInContext.route('**/submissions', route => {
+      if (route.request().method() !== 'POST') {
+        route.continue();
+        return;
       }
-      if (!ok) failures += 1;
-    }
+      submissionsPostCount += 1;
+      submissionsPostBody = route.request().postDataJSON();
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          submissions: [
+            {
+              objectId: 'sub_1',
+              location: {
+                __type: 'GeoPoint',
+                latitude: 40.686,
+                longitude: -73.979,
+              },
+              typeofcomplaint: 'Blocked the crosswalk',
+              license: 'T794438C',
+              state: 'NY',
+              loc1_address: '64 Flatbush Ave, Brooklyn',
+              timeofreport: { __type: 'Date', iso: '2023-04-28T17:04:00.000Z' },
+              reqnumber: 'REQ-1',
+              photoData0: {
+                __type: 'File',
+                url: 'https://example.com/photo.jpg',
+                name: 'photo.jpg',
+              },
+              photoData1: null,
+              photoData2: null,
+            },
+            {
+              objectId: 'sub_2',
+              location: {
+                __type: 'GeoPoint',
+                latitude: 40.7,
+                longitude: -73.99,
+              },
+              typeofcomplaint: 'Ran red light',
+              license: 'ABC1234',
+              state: 'NY',
+              loc1_address: '2nd Ave & St Marks Pl, Manhattan',
+              timeofreport: { __type: 'Date', iso: '2023-05-01T10:00:00.000Z' },
+              photoData0: null,
+              photoData1: null,
+              photoData2: null,
+            },
+            { objectId: 'sub_3' }, // no location → skipped by renderMap
+          ],
+        }),
+      });
+    });
+
+    const mapPage = await loggedInContext.newPage();
+    const mapErrors = [];
+    attachErrorListeners(mapPage, mapErrors);
+
+    await mapPage.goto(`${BASE_URL}/submissions-map`, { waitUntil: 'load' });
+    await mapPage.click('#tab-my-submissions');
+    await mapPage.click('#load-my-submissions-btn');
+    await mapPage.waitForFunction(
+      () => document.querySelectorAll('.leaflet-marker-icon').length === 2,
+    );
+
+    const countBadge = await mapPage.locator('#count-badge').textContent();
+    const modeLabel = await mapPage.locator('#mode-label').textContent();
+    const loggedInPromptVisible = await mapPage
+      .locator('#my-submissions-login-prompt')
+      .isVisible()
+      .catch(() => false);
+
+    failures += runChecks([
+      {
+        name: 'submissions map: no page or console errors (logged in)',
+        ok: mapErrors.length === 0,
+        detail: mapErrors.join('\n'),
+      },
+      {
+        name: 'submissions map: POSTs cookie credentials to /submissions',
+        ok:
+          submissionsPostCount === 1 &&
+          submissionsPostBody?.email === homeState.email &&
+          submissionsPostBody?.password === homeState.password &&
+          submissionsPostBody?.FirstName === homeState.FirstName &&
+          submissionsPostBody?.LastName === homeState.LastName &&
+          submissionsPostBody?.Phone === homeState.Phone,
+        detail: JSON.stringify({ submissionsPostCount, submissionsPostBody }),
+      },
+      {
+        name: 'submissions map: renders markers and count badge',
+        // Counts all submissions; geoless ones are skipped only for markers
+        ok: countBadge === '3 reports',
+        detail: `count-badge: ${countBadge}`,
+      },
+      {
+        name: 'submissions map: shows My submissions mode label',
+        ok: modeLabel === 'My submissions',
+        detail: `mode-label: ${modeLabel}`,
+      },
+      {
+        name: 'submissions map: URL persists mySubmissions=1',
+        ok: new URL(mapPage.url()).searchParams.get('mySubmissions') === '1',
+        detail: mapPage.url(),
+      },
+      {
+        name: 'submissions map: login prompt stays hidden when logged in',
+        ok: !loggedInPromptVisible,
+      },
+    ]);
+
+    // ── Submissions map: logged out ──
+    const loggedOutContext = await browser.newContext();
+    const loggedOutPage = await loggedOutContext.newPage();
+    const loggedOutErrors = [];
+    attachErrorListeners(loggedOutPage, loggedOutErrors);
+
+    let submissionsRequests = 0;
+    loggedOutPage.on('request', request => {
+      if (request.url().endsWith('/submissions')) submissionsRequests += 1;
+    });
+
+    await loggedOutPage.goto(`${BASE_URL}/submissions-map`, {
+      waitUntil: 'load',
+    });
+    await loggedOutPage.click('#tab-my-submissions');
+    await loggedOutPage.click('#load-my-submissions-btn');
+
+    const loggedOutPromptVisible = await loggedOutPage
+      .locator('#my-submissions-login-prompt')
+      .isVisible()
+      .catch(() => false);
+
+    failures += runChecks([
+      {
+        name: 'submissions map: no page or console errors (logged out)',
+        ok: loggedOutErrors.length === 0,
+        detail: loggedOutErrors.join('\n'),
+      },
+      {
+        name: 'submissions map: logged out shows login prompt',
+        ok: loggedOutPromptVisible,
+      },
+      {
+        name: 'submissions map: logged out makes no /submissions request',
+        ok: submissionsRequests === 0,
+        detail: `requests: ${submissionsRequests}`,
+      },
+    ]);
 
     if (failures) {
-      console.error(`${failures}/${checks.length} client smoke checks failed`);
+      console.error(`${failures} client smoke checks failed`);
       process.exitCode = 1;
     }
   } finally {

--- a/tools/test-client-smoke.js
+++ b/tools/test-client-smoke.js
@@ -205,6 +205,20 @@ const run = async () => {
       const parts = tile.src.split('/');
       return Number(parts[parts.length - 3]);
     });
+
+    // The first marker belongs to `sub_1`; its popup should link that
+    // objectId to the Back4App browser view.
+    await mapPage.locator('#map .leaflet-marker-icon').first().hover();
+    await mapPage.waitForSelector('#popup.visible');
+    const objectIdHref = await mapPage
+      .locator('#popup-meta a')
+      .first()
+      .getAttribute('href');
+    const objectIdText = await mapPage
+      .locator('#popup-meta a')
+      .first()
+      .textContent();
+
     const countBadge = await mapPage.locator('#count-badge').textContent();
     const modeLabel = await mapPage.locator('#mode-label').textContent();
     const loggedInPromptVisible = await mapPage
@@ -239,6 +253,16 @@ const run = async () => {
         name: 'submissions map: keeps the view on NYC despite a far-away submission',
         ok: tileZoom !== null && tileZoom >= 10,
         detail: `tile zoom: ${tileZoom}`,
+      },
+      {
+        name: 'submissions map: popup links objectId to the Back4App browser',
+        ok:
+          objectIdHref?.startsWith(
+            'https://backend.back4app.com/apps/932de73d-5214-4a3e-aec5-5c9be0055dac/browser/submission?filters=',
+          ) &&
+          objectIdHref.includes('compareTo%22%3A%22sub_1%22') &&
+          objectIdText === 'sub_1',
+        detail: JSON.stringify({ objectIdHref, objectIdText }),
       },
       {
         name: 'submissions map: shows My submissions mode label',

--- a/tools/test-client-smoke.js
+++ b/tools/test-client-smoke.js
@@ -161,6 +161,17 @@ const run = async () => {
               photoData2: null,
             },
             { objectId: 'sub_3' }, // no location → skipped by renderMap
+            {
+              objectId: 'sub_4',
+              // Far outside NYC — without the NYC view clamp in "My
+              // submissions" mode this fits the whole USA into view
+              location: {
+                __type: 'GeoPoint',
+                latitude: 39.8,
+                longitude: -98.5,
+              },
+              typeofcomplaint: 'Ran red light',
+            },
           ],
         }),
       });
@@ -174,9 +185,26 @@ const run = async () => {
     await mapPage.click('#tab-my-submissions');
     await mapPage.click('#load-my-submissions-btn');
     await mapPage.waitForFunction(
-      () => document.querySelectorAll('.leaflet-marker-icon').length === 2,
+      () => document.querySelectorAll('.leaflet-marker-icon').length === 3,
     );
+    // Leaflet tile URLs embed the zoom level ({z}); wait for an
+    // NYC-scale view (zoom >= 10 — a USA-wide fit is zoom ~4) before
+    // asserting it.
+    await mapPage.waitForFunction(() => {
+      // Scope to the main map: the draw map's tiles (created at zoom
+      // 12 on page load) would otherwise satisfy the check.
+      const tile = document.querySelector('#map .leaflet-tile');
+      if (!tile) return false;
+      const parts = tile.src.split('/');
+      return Number(parts[parts.length - 3]) >= 10;
+    });
 
+    const tileZoom = await mapPage.evaluate(() => {
+      const tile = document.querySelector('#map .leaflet-tile');
+      if (!tile) return null;
+      const parts = tile.src.split('/');
+      return Number(parts[parts.length - 3]);
+    });
     const countBadge = await mapPage.locator('#count-badge').textContent();
     const modeLabel = await mapPage.locator('#mode-label').textContent();
     const loggedInPromptVisible = await mapPage
@@ -204,8 +232,13 @@ const run = async () => {
       {
         name: 'submissions map: renders markers and count badge',
         // Counts all submissions; geoless ones are skipped only for markers
-        ok: countBadge === '3 reports',
+        ok: countBadge === '4 reports',
         detail: `count-badge: ${countBadge}`,
+      },
+      {
+        name: 'submissions map: keeps the view on NYC despite a far-away submission',
+        ok: tileZoom !== null && tileZoom >= 10,
+        detail: `tile zoom: ${tileZoom}`,
       },
       {
         name: 'submissions map: shows My submissions mode label',


### PR DESCRIPTION
`submissions-map.html` had only two ways to get submissions onto the map: pasted JSON, or public submissions fetched from `/api/submissions-in-polygon` after drawing a polygon. A logged-in user had no way to see their own submissions (including non-public ones) without drawing a polygon over them.

Add a third "My Submissions" tab next to "Paste JSON" / "Draw Area". Clicking "Load My Submissions →" POSTs the user's credentials to the existing `/submissions` endpoint and loads all of their submissions onto the map — no polygon needed. The anonymous polygon UX is unchanged, and the mode survives reload/back-forward via a `?mySubmissions=1` URL param (mirroring the existing `?polygon` handling in `applyUrlState`).

Credentials come from the `reportedWebHomeState` cookie, which the home page already writes via `cookie.serialize` (URI-encoded JSON, see [cookie]) in `setHomeStateCookie`. The page reads it with `document.cookie`, decodes with `decodeURIComponent`, and treats any parse failure as logged out — the page can never crash on a corrupt cookie. When logged out, the panel shows a login prompt linking to `/` instead of fetching, and no request is made. `loginSuccessful` is deliberately not checked, mirroring the home page's self-healing retry heuristic in `componentDidMount`.

The `/submissions` response is Parse-shaped: `location` is a GeoPoint object and `timeofreport` a Date object, which the existing `renderMap`/`populatePopup` code already reads, so markers, the photos-only filter, popups, and the count badge all work unchanged. The response is unbounded, unlike the polygon endpoint's 10000 cap — accepted for now, since `PreviousSubmissionsList` consumes the same endpoint the same way.

A `#mode-label` in the map header shows "My submissions" or "Drawn area" so it's clear which dataset is displayed. Inline status text (rather than `window.alert`) reports loading/error/empty states on the selection screen, matching the paste flow's `#error-msg`.

`tools/test-client-smoke.js` now also exercises the page in Playwright: a logged-in scenario (cookie + mocked `/submissions` POST, asserting the credential body, markers, count badge, mode label, and URL state) and a logged-out scenario (asserting the login prompt and that no request is made). See [Playwright network mocking].

[cookie]: https://www.npmjs.com/package/cookie
[Playwright network mocking]: https://playwright.dev/docs/mock

Co-Authored-By: Claude Code with DeepSeek