### PR TITLE
test(ci): assert the `yarn start` dev server actually serves pages

### DIFF
--- a/.github/workflows/start.yml
+++ b/.github/workflows/start.yml
@@ -20,6 +20,4 @@ jobs:
     - run: curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.19
     - run: export PATH=$HOME/.yarn/bin:$PATH
     - run: yarn
-    - run: timeout 20 yarn start > timeout.20.yarn.start.txt || true
-    - run: cat timeout.20.yarn.start.txt
-    - run: cat timeout.20.yarn.start.txt | grep "Finished 'start' after"
+    - run: yarn test:dev-server-smoke

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "test:no-flaky": "yarn run test --testPathIgnorePatterns='src/alpr.test.js|src/getVehicleType.test.js'",
     "test:ssr-css": "babel-node tools/test-ssr-css.js",
     "test:client-smoke": "babel-node tools/test-client-smoke.js",
+    "test:dev-server-smoke": "babel-node tools/test-dev-server-smoke.js",
     "test-watch": "yarn run test --watch --notify",
     "test-cover": "yarn run test --coverage",
     "coverage": "yarn run test-cover && open coverage/lcov-report/index.html",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "parse/@babel/runtime": "7.27.6",
     "parse/@babel/runtime-corejs3": "7.29.7",
     "node-fetch": "2.7.0",
-    "universal-router/path-to-regexp": "3.3.0",
-    "immutable": "4.3.9"
+    "universal-router/path-to-regexp": "3.3.0"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "parse/@babel/runtime": "7.27.6",
     "parse/@babel/runtime-corejs3": "7.29.7",
     "node-fetch": "2.7.0",
-    "universal-router/path-to-regexp": "3.3.0"
+    "universal-router/path-to-regexp": "3.3.0",
+    "immutable": "4.3.9"
   },
   "dependencies": {
     "@babel/polyfill": "^7.0.0",

--- a/tools/test-dev-server-smoke.js
+++ b/tools/test-dev-server-smoke.js
@@ -1,0 +1,179 @@
+/**
+ * Boot the `yarn start` dev server and assert that it actually serves
+ * pages.
+ *
+ * The previous `start.yml` check only grepped the startup log for
+ * `Finished 'start' after` — browser-sync prints that line even when
+ * its middleware stack is broken and every request 404s (see the
+ * revert of #936/#942, where a forced `immutable@4` resolution made
+ * browser-sync drop the user middleware). This script makes real
+ * HTTP requests instead.
+ *
+ * The probes are network-independent: they only assert status codes
+ * and content on our own routes, so they're safe to run in CI.
+ */
+
+import { spawn } from 'child_process';
+import http from 'http';
+
+const BASE_URL = 'http://localhost:3000';
+const STARTUP_TIMEOUT_MS = 120000;
+const POLL_INTERVAL_MS = 1000;
+
+function request(url) {
+  return new Promise((resolve, reject) => {
+    http
+      .get(url, res => {
+        let body = '';
+        res.on('data', chunk => {
+          body += chunk;
+        });
+        res.on('end', () => resolve({ status: res.statusCode, body }));
+      })
+      .on('error', reject);
+  });
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function runChecks(checks) {
+  let failures = 0;
+  for (const { name, ok, detail } of checks) {
+    console.info(`${ok ? '✓' : '✗'} ${name}`);
+    if (!ok && detail) {
+      console.error(detail);
+    }
+    if (!ok) failures += 1;
+  }
+  return failures;
+}
+
+const run = async () => {
+  // Same command as the `start` npm script, minus `--inspect` and plus
+  // `--silent` so browser-sync doesn't try to open a browser.
+  const child = spawn(
+    'node',
+    [
+      '-r',
+      'dotenv/config',
+      'node_modules/.bin/babel-node',
+      'tools/run',
+      'start',
+      '--silent',
+    ],
+    { detached: true, stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+
+  let output = '';
+  child.stdout.on('data', chunk => {
+    output += chunk;
+  });
+  child.stderr.on('data', chunk => {
+    output += chunk;
+  });
+
+  let exited = false;
+  child.on('exit', () => {
+    exited = true;
+  });
+
+  let failures = 0;
+  try {
+    // Wait for the server to answer anything (even a 404 counts as
+    // "up" — the checks below assert what the responses must be).
+    const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+
+    async function waitForServer() {
+      if (exited || Date.now() > deadline) return false;
+      try {
+        await request(BASE_URL);
+        return true;
+      } catch {
+        await sleep(POLL_INTERVAL_MS);
+        return waitForServer();
+      }
+    }
+
+    const responding = await waitForServer();
+
+    if (!responding) {
+      console.error(
+        `Dev server did not answer within ${
+          STARTUP_TIMEOUT_MS / 1000
+        }s or exited during startup. Last output:\n${output.slice(-2000)}`,
+      );
+      return failures + 1;
+    }
+
+    const home = await request(`${BASE_URL}/`);
+    const favicon = await request(`${BASE_URL}/favicon.ico`);
+    const submissionsMap = await request(`${BASE_URL}/submissions-map`);
+
+    // The SSR HTML references the client bundle compiled by
+    // webpack-dev-middleware; request it to prove that middleware is
+    // in the chain.
+    const assetsMatch = home.body.match(/src="(\/assets\/[^"]+\.js)"/);
+    const asset = assetsMatch
+      ? await request(`${BASE_URL}${assetsMatch[1]}`)
+      : { status: null };
+
+    failures += runChecks([
+      {
+        name: 'dev server responds (any status)',
+        ok: responding,
+      },
+      {
+        name: 'GET / serves the SSR home page',
+        ok:
+          home.status === 200 && home.body.includes('<title>Reported</title>'),
+        detail: `status ${home.status}, body starts: ${home.body.slice(0, 80)}`,
+      },
+      {
+        // Served only by the user `express.static` middleware from
+        // `tools/start.js` — browser-sync's own static server serves
+        // from the vestigial `src/server.js` baseDir, so this 404s
+        // whenever the user middleware stack is dropped.
+        name: 'GET /favicon.ico is served by the user middleware',
+        ok: favicon.status === 200,
+        detail: `status ${favicon.status}`,
+      },
+      {
+        name: 'GET /submissions-map serves the map page',
+        ok:
+          submissionsMap.status === 200 &&
+          submissionsMap.body.includes('id="tab-paste"'),
+        detail: `status ${submissionsMap.status}, body starts: ${submissionsMap.body.slice(0, 80)}`,
+      },
+      {
+        name: 'GET of the client bundle in /assets/ is served by webpack-dev-middleware',
+        ok: asset.status === 200,
+        detail: `asset ${assetsMatch ? assetsMatch[1] : '<none found>'} status ${asset.status}`,
+      },
+    ]);
+
+    if (failures) {
+      console.error(`Last dev server output:\n${output.slice(-2000)}`);
+    }
+    return failures;
+  } finally {
+    try {
+      process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      child.kill('SIGTERM');
+    }
+  }
+};
+
+run()
+  .then(failures => {
+    if (failures) {
+      console.error(`${failures} dev server smoke checks failed`);
+      process.exitCode = 1;
+    }
+  })
+  .catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6420,10 +6420,10 @@ immer@^9.0.7:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
-immutable@^3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
-  integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
+immutable@4.3.9, immutable@^3:
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
+  integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
 
 import-fresh@^3.1.0:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6420,10 +6420,10 @@ immer@^9.0.7:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
-immutable@4.3.9, immutable@^3:
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.9.tgz#c98349e05e9c6e2a4d8fe88ac0b363e0d536b544"
-  integrity sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==
+immutable@^3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.3.tgz#0a8d2494a94d4b2d4f0e99986e74dd25d1e9a859"
+  integrity sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==
 
 import-fresh@^3.1.0:
   version "3.3.0"


### PR DESCRIPTION
`start.yml` previously booted `yarn start` and grepped its log for
`Finished 'start' after`. That line is printed by browser-sync even
when its middleware stack is broken and every request 404s, so the
check passed on a completely broken dev server — the `immutable@4`
resolution regression from [#936] shipped with green CI ([#942]
reverted it).

Replace the log grep with `tools/test-dev-server-smoke.js`, which
boots the dev server (`tools/run start --silent`), waits for it to
answer, and makes real HTTP requests:

- `GET /` returns 200 with SSR content — the compiled `src/server.js`
  app is mounted behind browser-sync
- `GET /favicon.ico` returns 200 — served only by the user
  `express.static` middleware from `tools/start.js`; browser-sync's
  own static server serves from the vestigial `src/server.js`
  baseDir, so this 404s whenever the user middleware is dropped
- `GET /submissions-map` returns 200 — page routes work
- the client bundle referenced from the SSR HTML under `/assets/`
  returns 200 — `webpack-dev-middleware` is in the chain

The probes only assert status codes and content on our own routes,
so the check needs no external network access.

Verified both directions: the new check passes on the reverted tree
(`immutable@3.8.3`) and fails with exactly the #936 signature when
`immutable@4.3.9` is forced back into `node_modules` — "responds"
passes (browser-sync is up) while all four content probes fail.

Adds the `test:dev-server-smoke` script alongside the existing smoke
scripts; `start.yml` runs it instead of `timeout 20 yarn start` plus
the log grep.

[#936]: https://github.com/josephfrazier/reported-web/pull/936
[#942]: https://github.com/josephfrazier/reported-web/pull/942

Co-Authored-By: Claude Code with DeepSeek