### PR TITLE
fix: keep the caret put when typing letters into `License/Medallion`

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -218,39 +218,6 @@ function linkifyText(text) {
   );
 }
 
-// Uppercase what the user typed into a controlled <input>, without letting the
-// caret jump to the end of the field.
-//
-// React only writes to a DOM input's `value` when it differs from the value it
-// is rendering, and writing to `value` puts the caret at the end. Uppercasing
-// in an onChange handler causes exactly that: typing "b" into "A|Z" leaves the
-// DOM at "AbZ" while React renders "ABZ", so React rewrites the value and the
-// caret lands after the "Z". Digits are unaffected by toUpperCase(), which is
-// why they seem to behave.
-//
-// Writing the uppercased value back here — with the caret where the user left
-// it — means React finds the value it's about to render already in place, so it
-// leaves both the value and the caret alone.
-function upperCaseInputValueInPlace(input) {
-  const { value, selectionStart, selectionEnd } = input;
-  const upperCased = value.toUpperCase();
-
-  if (upperCased !== value) {
-    input.value = upperCased; // eslint-disable-line no-param-reassign
-
-    if (selectionStart !== null && selectionEnd !== null) {
-      // Uppercasing can change a character's length (e.g. "ß" -> "SS"), so map
-      // each offset through toUpperCase() instead of reusing it as-is.
-      input.setSelectionRange(
-        value.slice(0, selectionStart).toUpperCase().length,
-        value.slice(0, selectionEnd).toUpperCase().length,
-      );
-    }
-  }
-
-  return upperCased;
-}
-
 async function fetchPlateResults({
   attachmentFile,
   attachmentBuffer,
@@ -2216,9 +2183,7 @@ class Home extends React.Component {
                               ref={this.plateRef}
                               placeholder={this.state.allPlateData?.results?.[0]?.plate?.toUpperCase()}
                               onChange={event => {
-                                const plate = upperCaseInputValueInPlace(
-                                  event.target,
-                                );
+                                const plate = event.target.value.toUpperCase();
                                 const matchedResult =
                                   this.state.allPlateData?.results?.find(
                                     r => r.plate?.toUpperCase() === plate,

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -218,6 +218,39 @@ function linkifyText(text) {
   );
 }
 
+// Uppercase what the user typed into a controlled <input>, without letting the
+// caret jump to the end of the field.
+//
+// React only writes to a DOM input's `value` when it differs from the value it
+// is rendering, and writing to `value` puts the caret at the end. Uppercasing
+// in an onChange handler causes exactly that: typing "b" into "A|Z" leaves the
+// DOM at "AbZ" while React renders "ABZ", so React rewrites the value and the
+// caret lands after the "Z". Digits are unaffected by toUpperCase(), which is
+// why they seem to behave.
+//
+// Writing the uppercased value back here — with the caret where the user left
+// it — means React finds the value it's about to render already in place, so it
+// leaves both the value and the caret alone.
+function upperCaseInputValueInPlace(input) {
+  const { value, selectionStart, selectionEnd } = input;
+  const upperCased = value.toUpperCase();
+
+  if (upperCased !== value) {
+    input.value = upperCased; // eslint-disable-line no-param-reassign
+
+    if (selectionStart !== null && selectionEnd !== null) {
+      // Uppercasing can change a character's length (e.g. "ß" -> "SS"), so map
+      // each offset through toUpperCase() instead of reusing it as-is.
+      input.setSelectionRange(
+        value.slice(0, selectionStart).toUpperCase().length,
+        value.slice(0, selectionEnd).toUpperCase().length,
+      );
+    }
+  }
+
+  return upperCased;
+}
+
 async function fetchPlateResults({
   attachmentFile,
   attachmentBuffer,
@@ -2183,7 +2216,9 @@ class Home extends React.Component {
                               ref={this.plateRef}
                               placeholder={this.state.allPlateData?.results?.[0]?.plate?.toUpperCase()}
                               onChange={event => {
-                                const plate = event.target.value.toUpperCase();
+                                const plate = upperCaseInputValueInPlace(
+                                  event.target,
+                                );
                                 const matchedResult =
                                   this.state.allPlateData?.results?.find(
                                     r => r.plate?.toUpperCase() === plate,

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -52,6 +52,71 @@ function renderHome({ initialState, homeRef } = {}) {
   );
 }
 
+// Stand-in for a text <input> DOM node: reading/writing `value` works, and
+// writing it moves the caret to the end of the field, just like the real thing.
+function createFakeInput({ value, caret }) {
+  let currentValue = value;
+  const input = {
+    selectionStart: caret,
+    selectionEnd: caret,
+    setSelectionRange(selectionStart, selectionEnd) {
+      input.selectionStart = selectionStart;
+      input.selectionEnd = selectionEnd;
+    },
+  };
+  Object.defineProperty(input, 'value', {
+    get: () => currentValue,
+    set: newValue => {
+      currentValue = newValue;
+      input.selectionStart = newValue.length;
+      input.selectionEnd = newValue.length;
+    },
+  });
+  return input;
+}
+
+// Stand-in for React re-rendering a controlled input: it writes to the DOM
+// node's value only when it differs from the value being rendered. That write
+// is what moves the caret to the end of the field.
+function reRenderControlledInput(input, value) {
+  if (input.value !== value) {
+    input.value = value; // eslint-disable-line no-param-reassign
+  }
+}
+
+// Renders the form (which needs a photo attached) and returns the plate input.
+function renderPlateInput() {
+  const initialState = {
+    email: 'test@example.com',
+    loginSuccessful: true,
+  };
+
+  const originalCreateObjectURL = global.URL.createObjectURL;
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+  let tree;
+  const homeRef = React.createRef();
+  renderer.act(() => {
+    tree = renderHome({ initialState, homeRef });
+  });
+  renderer.act(() => {
+    homeRef.current.setState({
+      attachmentData: [
+        new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+      ],
+    });
+  });
+
+  return {
+    homeRef,
+    plateInput: tree.root.findByProps({ name: 'plate' }),
+    cleanup: () => {
+      tree.unmount();
+      global.URL.createObjectURL = originalCreateObjectURL;
+    },
+  };
+}
+
 describe('Home', () => {
   test('renders submission form and Previous Submissions when logged in with photos', () => {
     const initialState = {
@@ -308,5 +373,81 @@ describe('Home', () => {
     expect(homeRef.current.getPreviousSubmissionsSummary()).toBe(2);
 
     tree.unmount();
+  });
+
+  test('keeps the caret in place when typing a letter into the middle of the plate', () => {
+    const { homeRef, plateInput, cleanup } = renderPlateInput();
+
+    // The user typed "b" between the "A" and the "Z" of "AZ".
+    const input = createFakeInput({ value: 'AbZ', caret: 2 });
+    renderer.act(() => {
+      plateInput.props.onChange({ target: input });
+    });
+    reRenderControlledInput(input, homeRef.current.state.plate);
+
+    expect(homeRef.current.state.plate).toBe('ABZ');
+    expect(input.value).toBe('ABZ');
+    // ...and the caret stays after the "B", rather than jumping to the end.
+    expect(input.selectionStart).toBe(2);
+    expect(input.selectionEnd).toBe(2);
+
+    cleanup();
+  });
+
+  test('keeps the caret in place when typing a digit into the middle of the plate', () => {
+    const { homeRef, plateInput, cleanup } = renderPlateInput();
+
+    // The user typed "2" between the "A" and the "Z" of "AZ". Digits are
+    // unaffected by toUpperCase(), so this case already worked.
+    const input = createFakeInput({ value: 'A2Z', caret: 2 });
+    renderer.act(() => {
+      plateInput.props.onChange({ target: input });
+    });
+    reRenderControlledInput(input, homeRef.current.state.plate);
+
+    expect(homeRef.current.state.plate).toBe('A2Z');
+    expect(input.value).toBe('A2Z');
+    expect(input.selectionStart).toBe(2);
+    expect(input.selectionEnd).toBe(2);
+
+    cleanup();
+  });
+
+  test('keeps the caret after characters that grow when uppercased', () => {
+    const { homeRef, plateInput, cleanup } = renderPlateInput();
+
+    // "ß".toUpperCase() is "SS", so the caret has to move right by one to stay
+    // after the character the user just typed.
+    const input = createFakeInput({ value: 'AßZ', caret: 2 });
+    renderer.act(() => {
+      plateInput.props.onChange({ target: input });
+    });
+    reRenderControlledInput(input, homeRef.current.state.plate);
+
+    expect(homeRef.current.state.plate).toBe('ASSZ');
+    expect(input.value).toBe('ASSZ');
+    expect(input.selectionStart).toBe(3);
+    expect(input.selectionEnd).toBe(3);
+
+    cleanup();
+  });
+
+  test('tolerates inputs that do not report a selection', () => {
+    const { homeRef, plateInput, cleanup } = renderPlateInput();
+
+    // selectionStart/selectionEnd are null for input types that don't support
+    // text selection, and setSelectionRange throws on them.
+    const input = createFakeInput({ value: 'abc', caret: null });
+    input.setSelectionRange = () => {
+      throw new Error('setSelectionRange should not be called');
+    };
+    renderer.act(() => {
+      plateInput.props.onChange({ target: input });
+    });
+
+    expect(homeRef.current.state.plate).toBe('ABC');
+    expect(input.value).toBe('ABC');
+
+    cleanup();
   });
 });


### PR DESCRIPTION
Typing a letter into the middle of the `License/Medallion` field moved the
text cursor to the end of the field, but typing a digit did not. With the
caret at `A|Z`, typing `b` produced `ABZ|` instead of `AB|Z`, so entering a
plate out of order meant re-positioning the caret after every letter.

The asymmetry between letters and digits is the tell. The `plate` `<input>`
is a [controlled component][], and its `onChange` uppercases what the user
typed before storing it in state. React only assigns to a DOM input's `value`
when it differs from the value being rendered, and assigning to `value`
[moves the caret to the end][selectionStart]:

- Typing `b` leaves the DOM at `AbZ` while React renders `ABZ`. The two
  differ, so React rewrites `value`, and the caret lands after the `Z`.
- Typing `2` leaves the DOM at `A2Z` and React renders `A2Z`. Digits are
  unaffected by `toUpperCase()`, so the values match, React leaves the node
  alone, and the caret stays where the user left it.

The fix uppercases the DOM node in place inside the handler, restoring the
caret afterwards, so React finds the value it is about to render already
there and skips the write — leaving both the value and the caret alone:

```js
// before
onChange={event => {
  const plate = event.target.value.toUpperCase();
  // ...
}}

// after
onChange={event => {
  const plate = upperCaseInputValueInPlace(event.target);
  // ...
}}
```

`upperCaseInputValueInPlace()` maps the caret offsets through `toUpperCase()`
rather than reusing them as-is, because uppercasing can change a character's
length (`"ß"` becomes `"SS"`), and skips [`setSelectionRange`][] entirely when
`selectionStart`/`selectionEnd` are `null`, which is what inputs that don't
support text selection report.

Verified in Chromium with real keystrokes against real React DOM: the old
handler turns `A|Z` into `ABZ|` for `b` and `A2|Z` for `2` — reproducing the
report exactly — while the new handler gives `AB|Z` and `A2|Z`. The added
tests in `Home.test.js` drive the input's `onChange` with a stand-in DOM node
and then re-render it the way React would; they fail on the caret assertion
without this fix.

[controlled component]: https://react.dev/reference/react-dom/components/input#controlling-an-input-with-a-state-variable
[selectionStart]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/selectionStart
[`setSelectionRange`]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange

Co-Authored-By: Claude Code with DeepSeek