### PR TITLE
feat: show the highest-resolution plate crop beside the plate input

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1404,17 +1404,30 @@ class Home extends React.Component {
   };
 
   findMatchingPlateThumbnail() {
+    let bestPlateCropDataUrl = null;
+    let bestResolution = -1;
     for (const data of Object.values(this.state.plateDataByAttachmentName)) {
       for (const result of data.results || []) {
         if (
           result.plate?.toUpperCase() === this.state.plate?.toUpperCase() &&
           result.plateCropDataUrl
         ) {
-          return result.plateCropDataUrl;
+          // The same plate can be detected in multiple photos (or multiple
+          // times in one photo). Show the highest-resolution crop beside the
+          // plate input, since more pixels make the plate easier to read.
+          // `box` is in the same downscaled image space the crop was cut from
+          // in src/alpr.js, so its area in pixels is the crop's resolution.
+          const { xmin, ymin, xmax, ymax } = result.box || {};
+          const resolution = (xmax - xmin) * (ymax - ymin) || 0;
+
+          if (resolution > bestResolution) {
+            bestResolution = resolution;
+            bestPlateCropDataUrl = result.plateCropDataUrl;
+          }
         }
       }
     }
-    return null;
+    return bestPlateCropDataUrl;
   }
 
   maybeGeneratePassword() {

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -323,6 +323,64 @@ describe('Home', () => {
     global.URL.createObjectURL = originalCreateObjectURL;
   });
 
+  test('shows the highest-resolution crop beside the plate input when multiple crops match the plate', () => {
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+      plate: 'ABC123',
+    };
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ initialState, homeRef });
+    });
+    renderer.act(() => {
+      homeRef.current.setState({
+        attachmentData: [
+          new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+        ],
+        plateDataByAttachmentName: {
+          'small.jpg': {
+            results: [
+              {
+                plate: 'abc123',
+                box: { xmin: 100, ymin: 100, xmax: 200, ymax: 110 },
+                plateCropDataUrl: 'data:image/jpeg;base64,small',
+              },
+            ],
+          },
+          'big.jpg': {
+            results: [
+              {
+                plate: 'ABC123',
+                box: { xmin: 100, ymin: 100, xmax: 400, ymax: 250 },
+                plateCropDataUrl: 'data:image/jpeg;base64,big',
+              },
+              {
+                // Not the selected plate, so its larger box must be ignored.
+                plate: 'XYZ789',
+                box: { xmin: 0, ymin: 0, xmax: 1000, ymax: 1000 },
+                plateCropDataUrl: 'data:image/jpeg;base64,other',
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    const thumbnail = tree.root.findByProps({
+      alt: 'Detected license plate',
+    });
+    expect(thumbnail.props.src).toBe('data:image/jpeg;base64,big');
+
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
   test('renders Edit Profile UI', () => {
     const initialState = {
       email: 'test@example.com',


### PR DESCRIPTION
When the same plate is detected in multiple photos (or multiple times in one photo), findMatchingPlateThumbnail() used to return the first matching crop. Pick the one with the largest box area instead, since more pixels make the plate easier to read. The box is in the same downscaled image space the crop was cut from in src/alpr.js, so its area is the crop's resolution.

Co-Authored-By: Claude Code with DeepSeek