### PR TITLE
fix: don't show "undefined" in the Where: address button

### DIFF
--- a/src/formatGeosearchAddress.js
+++ b/src/formatGeosearchAddress.js
@@ -1,0 +1,14 @@
+import capitalize from 'capitalize';
+
+// Format the `properties` of a Pelias reverse-geocoding result as a
+// human-readable address. Some results have no housenumber (e.g. parks and
+// NYCHA buildings come back as venues), so filter out missing parts instead
+// of letting "undefined" show up in the formatted address.
+export default function formatGeosearchAddress({
+  housenumber,
+  street,
+  borough,
+}) {
+  const streetAddress = [housenumber, street].filter(Boolean).join(' ');
+  return capitalize.words([streetAddress, borough].filter(Boolean).join(', '));
+}

--- a/src/formatGeosearchAddress.test.js
+++ b/src/formatGeosearchAddress.test.js
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment node
+ */
+
+import formatGeosearchAddress from './formatGeosearchAddress.js';
+
+describe('formatGeosearchAddress', () => {
+  test('formats an address with a housenumber', () => {
+    expect(
+      formatGeosearchAddress({
+        housenumber: '309',
+        street: 'GOLD STREET',
+        borough: 'Brooklyn',
+      }),
+    ).toBe('309 Gold Street, Brooklyn');
+  });
+
+  test('formats a venue without a housenumber', () => {
+    expect(
+      formatGeosearchAddress({
+        street: 'R INGERSOLL HOUSES BUILDING 23',
+        borough: 'Brooklyn',
+      }),
+    ).toBe('R Ingersoll Houses Building 23, Brooklyn');
+  });
+
+  test('formats an address without a street', () => {
+    expect(
+      formatGeosearchAddress({ housenumber: '309', borough: 'Brooklyn' }),
+    ).toBe('309, Brooklyn');
+  });
+
+  test('formats an empty result', () => {
+    expect(formatGeosearchAddress({})).toBe('');
+  });
+});

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -43,13 +43,13 @@ import { ToastContainer, toast } from 'react-toastify';
 import toastifyStyles from 'react-toastify/dist/ReactToastify.css';
 import { zip } from 'zip-array';
 import PolygonLookup from 'polygon-lookup';
-import capitalize from 'capitalize';
 import CircularProgress from '@mui/material/CircularProgress';
 
 import marx from 'marx-css/css/marx.css';
 import homeStyles from './Home.css';
 
 import PreviousSubmissionsList from '../../components/PreviousSubmissionsList.js';
+import formatGeosearchAddress from '../../formatGeosearchAddress.js';
 import PlatePickerModal from './PlatePickerModal.js';
 import { isImage, isVideo } from '../../isImage.js';
 import getNycTimezoneOffset from '../../timezone.js';
@@ -747,9 +747,7 @@ class Home extends React.Component {
       const { properties } = data.features[0];
 
       this.setState({
-        formatted_address: capitalize.words(
-          `${properties.housenumber} ${properties.street}, ${properties.borough}`,
-        ),
+        formatted_address: formatGeosearchAddress(properties),
       });
     });
   };


### PR DESCRIPTION
Pelias reverse-geocoding results sometimes have no housenumber (e.g.
NYCHA buildings like "R INGERSOLL HOUSES BUILDING 23" come back as
venues), and the template literal stringified the missing property,
showing "undefined" in the formatted address. Filter out missing parts
instead.

Co-Authored-By: Claude Code with DeepSeek