### PR TITLE
fix: position plate overlays with the uploaded image size

### DIFF
--- a/src/__snapshots__/alpr.test.js.snap
+++ b/src/__snapshots__/alpr.test.js.snap
@@ -121,6 +121,8 @@ exports[`readLicenseViaALPR falling back to the second token 1`] = `
     },
   ],
   "timestamp": "timestamp REMOVED BECAUSE IT CHANGES",
+  "uploadHeight": 2731,
+  "uploadWidth": 2048,
   "version": 1,
 }
 `;
@@ -246,6 +248,8 @@ exports[`readLicenseViaALPR using only the first token 1`] = `
     },
   ],
   "timestamp": "timestamp REMOVED BECAUSE IT CHANGES",
+  "uploadHeight": 2731,
+  "uploadWidth": 2048,
   "version": 1,
 }
 `;

--- a/src/alpr.js
+++ b/src/alpr.js
@@ -144,6 +144,20 @@ export default function readLicenseViaALPR({
           return platerecognizerRes.json();
         })
         .then(async data => {
+          // Plate Recognizer resizes uploads before processing and reports the
+          // resized size as image_width/image_height (e.g. a 2048x2731 upload
+          // comes back as 1919x2560), but `box` coordinates stay in the pixel
+          // space of the image we sent -- the same space cropBox() extracts
+          // from below. Pass that size along so the client can place plate
+          // overlays on the picture without guessing at the difference.
+          const { width: uploadWidth, height: uploadHeight } = await sharp(
+            attachmentBufferRotated,
+          )
+            .metadata()
+            // orientImageBuffer() falls back to the unprocessed buffer when
+            // sharp cannot read it; don't fail the whole request over sizing.
+            .catch(() => ({}));
+
           async function cropBox(box) {
             if (!box) return null;
             const { xmin, ymin, xmax, ymax } = box;
@@ -171,7 +185,12 @@ export default function readLicenseViaALPR({
               return { ...result, ...crops };
             }),
           );
-          return { ...data, results: resultsWithCrops };
+          return {
+            ...data,
+            results: resultsWithCrops,
+            uploadWidth,
+            uploadHeight,
+          };
         })
         .finally(() => console.timeEnd(`/platerecognizer plate-reader`)); // eslint-disable-line no-console
     });

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -773,22 +773,30 @@ class Home extends React.Component {
     attachmentPlateData?.results?.map(result => {
       const { box } = result;
       const plate = result.plate?.toUpperCase();
-      const { image_width: imageWidth, image_height: imageHeight } =
-        attachmentPlateData;
-      if (!box || !plate || !imageWidth || !imageHeight) {
+      // `box` is in pixels of the image src/alpr.js uploaded to Plate
+      // Recognizer, so `uploadWidth`/`uploadHeight` are the denominators that
+      // turn it into a fraction of the picture. Percentages are
+      // scale-invariant, so that fraction is right however large the browser
+      // renders the original file -- do NOT reach for the <img>'s
+      // naturalWidth/naturalHeight, which is the pre-downscale size.
+      //
+      // image_width/image_height are only a fallback for plate data cached
+      // before uploadWidth existed. They are NOT interchangeable: Plate
+      // Recognizer resizes uploads before processing and reports the resized
+      // size (a 2048x2731 upload comes back as 1919x2560), so dividing by them
+      // stretches every percentage ~6.7% down and to the right.
+      const {
+        image_width: imageWidth,
+        image_height: imageHeight,
+        uploadWidth,
+        uploadHeight,
+      } = attachmentPlateData;
+      const boxWidth = uploadWidth || imageWidth;
+      const boxHeight = uploadHeight || imageHeight;
+      if (!box || !plate || !boxWidth || !boxHeight) {
         return null;
       }
       const licenseState = getLicenseStateFromPlateResult(result);
-
-      // `box` is in pixels of the image the server actually sent to Plate
-      // Recognizer (after `sharp().rotate()` and `downscaleForPlateRecognizer`
-      // in src/alpr.js), and `image_width`/`image_height` describe that same
-      // image. So `box / image_*` is the fraction of the picture, and these
-      // percentages are correct no matter what pixel size the browser renders
-      // the original file at -- percentages are scale-invariant. Do NOT switch
-      // these denominators to the <img>'s naturalWidth/naturalHeight: the
-      // original file is typically ~1.5x larger than the downscaled upload, so
-      // that shrinks every percentage and drags overlays up and to the left.
 
       return (
         <button
@@ -796,10 +804,10 @@ class Home extends React.Component {
           key={`${plate}-${box.xmin}-${box.ymin}`}
           className={homeStyles['plate-overlay']}
           style={{
-            left: `${(box.xmin / imageWidth) * 100}%`,
-            top: `${(box.ymin / imageHeight) * 100}%`,
-            width: `${((box.xmax - box.xmin) / imageWidth) * 100}%`,
-            height: `${((box.ymax - box.ymin) / imageHeight) * 100}%`,
+            left: `${(box.xmin / boxWidth) * 100}%`,
+            top: `${(box.ymin / boxHeight) * 100}%`,
+            width: `${((box.xmax - box.xmin) / boxWidth) * 100}%`,
+            height: `${((box.ymax - box.ymin) / boxHeight) * 100}%`,
           }}
           aria-label={`Select license plate ${plate}`}
           onClick={() => {

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -525,7 +525,6 @@ class Home extends React.Component {
     this.plateRef = React.createRef();
     this.loginEmailRef = React.createRef();
     this.signupEmailRef = React.createRef();
-    this.imageNaturalSizes = {};
   }
 
   componentDidMount() {
@@ -770,7 +769,7 @@ class Home extends React.Component {
     });
   };
 
-  renderPlateOverlays = ({ attachmentName, attachmentPlateData }) =>
+  renderPlateOverlays = ({ attachmentPlateData }) =>
     attachmentPlateData?.results?.map(result => {
       const { box } = result;
       const plate = result.plate?.toUpperCase();
@@ -781,9 +780,15 @@ class Home extends React.Component {
       }
       const licenseState = getLicenseStateFromPlateResult(result);
 
-      const naturalSize = this.imageNaturalSizes[attachmentName];
-      const effectiveWidth = naturalSize?.width || imageWidth;
-      const effectiveHeight = naturalSize?.height || imageHeight;
+      // `box` is in pixels of the image the server actually sent to Plate
+      // Recognizer (after `sharp().rotate()` and `downscaleForPlateRecognizer`
+      // in src/alpr.js), and `image_width`/`image_height` describe that same
+      // image. So `box / image_*` is the fraction of the picture, and these
+      // percentages are correct no matter what pixel size the browser renders
+      // the original file at -- percentages are scale-invariant. Do NOT switch
+      // these denominators to the <img>'s naturalWidth/naturalHeight: the
+      // original file is typically ~1.5x larger than the downscaled upload, so
+      // that shrinks every percentage and drags overlays up and to the left.
 
       return (
         <button
@@ -791,10 +796,10 @@ class Home extends React.Component {
           key={`${plate}-${box.xmin}-${box.ymin}`}
           className={homeStyles['plate-overlay']}
           style={{
-            left: `${(box.xmin / effectiveWidth) * 100}%`,
-            top: `${(box.ymin / effectiveHeight) * 100}%`,
-            width: `${((box.xmax - box.xmin) / effectiveWidth) * 100}%`,
-            height: `${((box.ymax - box.ymin) / effectiveHeight) * 100}%`,
+            left: `${(box.xmin / imageWidth) * 100}%`,
+            top: `${(box.ymin / imageHeight) * 100}%`,
+            width: `${((box.xmax - box.xmin) / imageWidth) * 100}%`,
+            height: `${((box.ymax - box.ymin) / imageHeight) * 100}%`,
           }}
           aria-label={`Select license plate ${plate}`}
           onClick={() => {
@@ -2086,13 +2091,6 @@ class Home extends React.Component {
                                       src={src}
                                       alt={name}
                                       style={{ display: 'block' }}
-                                      onLoad={e => {
-                                        const img = e.target;
-                                        this.imageNaturalSizes[name] = {
-                                          width: img.naturalWidth,
-                                          height: img.naturalHeight,
-                                        };
-                                      }}
                                     />
                                   ) : (
                                     /* eslint-disable-next-line jsx-a11y/media-has-caption */
@@ -2101,7 +2099,6 @@ class Home extends React.Component {
                                 </a>
                                 {isImg &&
                                   this.renderPlateOverlays({
-                                    attachmentName: name,
                                     attachmentPlateData,
                                   })}
                               </div>

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -291,6 +291,8 @@ describe('Home', () => {
                 box: { xmin: 100, ymin: 200, xmax: 300, ymax: 250 },
               },
             ],
+            // No uploadWidth/uploadHeight, as in plate data cached before
+            // src/alpr.js started reporting them: fall back to the API's.
             image_width: 1000,
             image_height: 500,
           },
@@ -323,12 +325,15 @@ describe('Home', () => {
     global.URL.createObjectURL = originalCreateObjectURL;
   });
 
-  test('positions plate overlays with API dimensions, not the rendered file size', () => {
-    // Plate Recognizer sees the image *after* src/alpr.js rotates and
-    // downscales it (~2048px wide), while the browser renders the original
-    // file (3024x4032 here). `box` and `image_width`/`image_height` share that
-    // downscaled coordinate space, so dividing by the <img>'s natural size
-    // shrinks every percentage by ~1.5x and drags overlays up and to the left.
+  test('positions plate overlays with the uploaded image dimensions', () => {
+    // Three sizes are in play for one photo, and only one of them is the space
+    // `box` is measured in:
+    //   3024x4032  the original file, which is what the browser renders
+    //   2048x2731  what src/alpr.js uploaded, and what `box` is relative to
+    //   1919x2560  what Plate Recognizer reports as image_width/image_height,
+    //              having resized the upload again before processing it
+    // Dividing by the rendered size drags overlays ~1.5x up and to the left;
+    // dividing by image_width pushes them ~6.7% down and to the right.
     const initialState = {
       email: 'test@example.com',
       loginSuccessful: true,
@@ -352,8 +357,10 @@ describe('Home', () => {
             box: { xmin: 1114, ymin: 1266, xmax: 1188, ymax: 1304 },
           },
         ],
-        image_width: 2048,
-        image_height: 2731,
+        uploadWidth: 2048,
+        uploadHeight: 2731,
+        image_width: 1919,
+        image_height: 2560,
       },
     };
 

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -323,6 +323,79 @@ describe('Home', () => {
     global.URL.createObjectURL = originalCreateObjectURL;
   });
 
+  test('positions plate overlays with API dimensions, not the rendered file size', () => {
+    // Plate Recognizer sees the image *after* src/alpr.js rotates and
+    // downscales it (~2048px wide), while the browser renders the original
+    // file (3024x4032 here). `box` and `image_width`/`image_height` share that
+    // downscaled coordinate space, so dividing by the <img>'s natural size
+    // shrinks every percentage by ~1.5x and drags overlays up and to the left.
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+    };
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ initialState, homeRef });
+    });
+
+    const plateDataByAttachmentName = {
+      'photo.jpg': {
+        results: [
+          {
+            plate: 'kna6960',
+            region: { code: 'us-ny' },
+            box: { xmin: 1114, ymin: 1266, xmax: 1188, ymax: 1304 },
+          },
+        ],
+        image_width: 2048,
+        image_height: 2731,
+      },
+    };
+
+    renderer.act(() => {
+      homeRef.current.setState({
+        attachmentData: [
+          new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+        ],
+        plateDataByAttachmentName,
+      });
+    });
+
+    // Report a rendered size larger than the uploaded one, the way loading the
+    // original file would, then re-render so any size cached from it is used.
+    const img = tree.root
+      .findAllByType('img')
+      .find(node => node.props.alt === 'photo.jpg');
+    if (img.props.onLoad) {
+      renderer.act(() => {
+        img.props.onLoad({
+          target: { naturalWidth: 3024, naturalHeight: 4032 },
+        });
+      });
+    }
+    renderer.act(() => {
+      homeRef.current.setState({ plateDataByAttachmentName });
+    });
+
+    const overlay = tree.root.findByProps({
+      'aria-label': 'Select license plate KNA6960',
+    });
+    expect(overlay.props.style).toEqual({
+      left: '54.39453125%',
+      top: '46.35664591724643%',
+      width: '3.61328125%',
+      height: '1.3914317099963385%',
+    });
+
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
   test('renders Edit Profile UI', () => {
     const initialState = {
       email: 'test@example.com',

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -1262,7 +1262,6 @@ exports[`Home renders submission form and Previous Submissions when logged in wi
                 >
                   <img
                     alt="photo.jpg"
-                    onLoad={[Function]}
                     src="blob:mock"
                     style={
                       {
@@ -1973,7 +1972,6 @@ exports[`Home renders with allPlateResults entry missing plate and photos 1`] = 
                 >
                   <img
                     alt="photo.jpg"
-                    onLoad={[Function]}
                     src="blob:mock"
                     style={
                       {
@@ -2684,7 +2682,6 @@ exports[`Home renders with undefined allPlateResults and photos 1`] = `
                 >
                   <img
                     alt="photo.jpg"
-                    onLoad={[Function]}
                     src="blob:mock"
                     style={
                       {


### PR DESCRIPTION
The overlay for `KNA6960` landed ~6.7% down and to the right of the plate,
rendering at `left: 58.03%` where the plate sits at 54.39%. An earlier fix
(0c390ab3) corrected a much larger offset in the other direction, but picked
the wrong denominator to do it.

Three sizes are in play for one photo, and only one of them is the space
`box` is measured in:

    3024x4032  the original file, which is what the browser renders
    2048x2731  what src/alpr.js uploads, and what `box` is relative to
    1919x2560  what Plate Recognizer reports as image_width/image_height

Plate Recognizer resizes the upload again before processing and reports those
resized dimensions, while returning `box` in the coordinate space of the image
it was sent. `src/__snapshots__/alpr.test.js.snap` shows this directly: that
test uploads a 2048x2731 image and the recorded response says `image_width`
1919, `image_height` 2560. Cropping `box` straight out of the 2048x2731 buffer
-- which is what `cropBox()` does, and its plate thumbnails are framed
correctly -- confirms which space `box` is in.

So neither size the client already had is the right denominator. Report the
uploaded image's own dimensions from `src/alpr.js` as `uploadWidth`/
`uploadHeight` and divide by those, falling back to `image_width`/
`image_height` for plate data cached before the fields existed.

This also accounts for the "~1.56x too far right and down" that aa2c6407
measured before switching the denominators to the `<img>`'s
`naturalWidth`/`naturalHeight`: that photo was under the 2.41MB downscale
threshold, so the upload was the original 3024-wide file and 3024/1919 =
1.576. Dividing by `naturalWidth` happened to be right for that one photo and
wrong for every photo large enough to be downscaled, which is how this ended
up wrong in both directions.

## Testing

- The overlay test now pins all three sizes and fails if `image_width` is used
  as the denominator (verified by temporarily flipping the code back).
- `src/routes/home/Home.test.js`: 16/16 pass, 8 snapshots pass.
- `src/alpr.test.js` passes against the live Plate Recognizer API, including
  the two new snapshot fields.
- eslint and prettier clean.

Co-Authored-By: Claude Code with DeepSeek