### PR TITLE
feat: scroll License/Medallion label into view on plate overlay click

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -523,6 +523,7 @@ class Home extends React.Component {
     this.initialStatePersistent = initialStatePersistent;
     this.isDragging = false;
     this.plateRef = React.createRef();
+    this.plateLabelRef = React.createRef();
     this.loginEmailRef = React.createRef();
     this.signupEmailRef = React.createRef();
   }
@@ -810,6 +811,14 @@ class Home extends React.Component {
           aria-label={`Select license plate ${plate}`}
           onClick={() => {
             this.setLicensePlate({ plate, licenseState });
+            // Bring the License/Medallion label to the top of the screen so
+            // the user can confirm the selected plate. The optional call
+            // keeps this a no-op in the test renderer, where refs point at
+            // non-DOM instances without scrollIntoView.
+            this.plateLabelRef.current?.scrollIntoView?.({
+              block: 'start',
+              behavior: 'smooth',
+            });
           }}
         >
           <span className={homeStyles['plate-overlay-tooltip']}>
@@ -2208,7 +2217,7 @@ class Home extends React.Component {
                         })}
                       </div>
 
-                      <label htmlFor="plate">
+                      <label htmlFor="plate" ref={this.plateLabelRef}>
                         License/Medallion:
                         {this.state.isAlprLoading && (
                           <CircularProgress size="1em" />

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -325,6 +325,62 @@ describe('Home', () => {
     global.URL.createObjectURL = originalCreateObjectURL;
   });
 
+  test('scrolls the License/Medallion label into view when a plate overlay is clicked', () => {
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+    };
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ initialState, homeRef });
+    });
+    renderer.act(() => {
+      homeRef.current.setState({
+        attachmentData: [
+          new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+        ],
+        plateDataByAttachmentName: {
+          'photo.jpg': {
+            results: [
+              {
+                plate: 'abc123',
+                region: { code: 'us-ny' },
+                box: { xmin: 100, ymin: 200, xmax: 300, ymax: 250 },
+              },
+            ],
+            image_width: 1000,
+            image_height: 500,
+          },
+        },
+      });
+    });
+
+    // react-test-renderer doesn't attach refs to host elements, so stand in
+    // for the label with a fake element that has a scrollIntoView to spy on.
+    const scrollIntoView = jest.fn();
+    homeRef.current.plateLabelRef.current = { scrollIntoView };
+
+    const overlay = tree.root.findByProps({
+      'aria-label': 'Select license plate ABC123',
+    });
+    renderer.act(() => {
+      overlay.props.onClick();
+    });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: 'start',
+      behavior: 'smooth',
+    });
+
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
   test('positions plate overlays with the uploaded image dimensions', () => {
     // Three sizes are in play for one photo, and only one of them is the space
     // `box` is measured in:


### PR DESCRIPTION
Selecting a plate from a photo overlay happens at the top of the form,
but the License/Medallion input the selection lands in is below the
photos. Scroll the label to the top of the screen so the user can
confirm the selected plate without scrolling manually.

Co-Authored-By: Claude Code with DeepSeek