### PR TITLE
fix: stop geolocation ipapi fallback from crashing tests

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -682,9 +682,9 @@ class Home extends React.Component {
   // Request the browser's geolocation permission and update coordinates.
   // Deferred until after login so the permission prompt appears in a trusted
   // context rather than on the first page visit.
-  geolocateAndSetCoords = () => {
-    geolocate().then(
-      ({ coords: { latitude, longitude }, ipProvenance = 'device' }) => {
+  geolocateAndSetCoords = () =>
+    geolocate()
+      .then(({ coords: { latitude, longitude }, ipProvenance = 'device' }) => {
         // if there's no attachments or a location couldn't be extracted, just use here
         if (
           this.state.attachmentData.length === 0 ||
@@ -697,9 +697,13 @@ class Home extends React.Component {
             addressProvenance: `(from ${ipProvenance}: ${latitude}, ${longitude})`,
           });
         }
-      },
-    );
-  };
+      })
+      .catch(err => {
+        // Both browser geolocation and the ipapi.co fallback can fail (e.g.
+        // permission denied plus rate limiting). Log instead of leaving an
+        // unhandled rejection; the form defaults to NYC coordinates anyway.
+        console.error(err);
+      });
 
   setCoords = (
     { latitude, longitude, addressProvenance } = { addressProvenance: '' },

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -37,6 +37,20 @@ const typeofcomplaintValues = [
 
 const insertCss = () => {};
 
+// jsdom has no navigator.geolocation, so promisedLocation() rejects and the
+// component falls back to ipapi.co over the network, making these tests
+// depend on a third-party service (and crash on its rate limits). Stub
+// geolocation with NYC's default coordinates so the fallback is never hit.
+beforeAll(() => {
+  navigator.geolocation = {
+    getCurrentPosition(success) {
+      success({
+        coords: { latitude: 40.7128, longitude: -74.006 },
+      });
+    },
+  };
+});
+
 function renderHome({ initialState, homeRef } = {}) {
   return renderer.create(
     <StyleContext.Provider value={{ insertCss }}>
@@ -166,6 +180,39 @@ describe('Home', () => {
 
     expect(tree.toJSON()).toMatchSnapshot();
 
+    tree.unmount();
+  });
+
+  test('handles geolocation and its ipapi fallback both failing', async () => {
+    const geolocationStub = navigator.geolocation;
+    navigator.geolocation = {
+      getCurrentPosition(success, failure) {
+        failure(new Error('Geolocation permission denied'));
+      },
+    };
+    const axiosGet = jest
+      .spyOn(axios, 'get')
+      .mockRejectedValue(new Error('ipapi.co rate limited'));
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ homeRef });
+    });
+
+    // This must not leave an unhandled rejection behind.
+    await renderer.act(async () => {
+      await homeRef.current.geolocateAndSetCoords();
+    });
+
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+    axiosGet.mockRestore();
+    navigator.geolocation = geolocationStub;
     tree.unmount();
   });
 


### PR DESCRIPTION
geolocateAndSetCoords never handled geolocate() rejecting, so when
both browser geolocation and the ipapi.co fallback failed (e.g.
permission denied plus rate limiting), the rejection went unhandled
and crashed the test process. Catch it and log instead.

Also stub navigator.geolocation in the Home tests with NYC's default
coordinates, so tests never hit ipapi.co over the network in the
first place.

Co-Authored-By: Claude Code with DeepSeek