### PR TITLE
feat: cache howsmydriving and LookupAPlate lookups per plate+state

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -892,6 +892,14 @@ class Home extends React.Component {
     if (!cachedVehicleInfoComponent) {
       debouncedGetVehicleType({ plate, licenseState })
         .then(({ data }) => {
+          // Don't cache stale responses: the debounced lookup resolves every
+          // selection made while it was pending with the LAST plate's data,
+          // so only the last plate's response belongs in the cache.
+          if (plate !== this.state.plate) {
+            console.info('ignoring stale plate:', plate);
+            return;
+          }
+
           const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
             data.result;
           const vehicleInfoComponent = (
@@ -915,12 +923,6 @@ class Home extends React.Component {
             </React.Fragment>
           );
           this.cachePlateLookup({ plate, licenseState, vehicleInfoComponent });
-
-          if (plate !== this.state.plate) {
-            console.info('ignoring stale plate:', plate);
-            return;
-          }
-
           this.setState({ vehicleInfoComponent });
         })
         .catch(err => {
@@ -983,6 +985,13 @@ class Home extends React.Component {
     if (plate && !cachedViolationSummaryComponent) {
       debouncedGetViolations({ plate, licenseState })
         .then(({ apiUrl, response: { data: responseData } }) => {
+          // Don't cache stale responses: the debounced lookup resolves every
+          // selection made while it was pending with the LAST plate's data,
+          // so only the last plate's response belongs in the cache.
+          if (plate !== this.state.plate) {
+            return;
+          }
+
           const vehicle =
             responseData.data &&
             responseData.data[0] &&
@@ -1032,11 +1041,6 @@ class Home extends React.Component {
             licenseState,
             violationSummaryComponent,
           });
-
-          if (plate !== this.state.plate) {
-            return;
-          }
-
           this.setState({ violationSummaryComponent });
         })
         .catch(err => {

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -87,19 +87,44 @@ const debouncedGeosearch = debounce(async ({ latitude, longitude }) => {
 const howsmydrivingApiUrl = ({ plate, licenseState }) =>
   `https://api.howsmydrivingny.nyc/api/v1/?plate=${plate}:${licenseState}`;
 
-const debouncedGetVehicleType = debounce(
-  ({ plate, licenseState }) =>
-    axios.get(`/getVehicleType/${plate}/${licenseState}`),
-  1000,
-);
+// Fetch and cache per plate+state, so re-selecting a plate that was already
+// looked up skips the network call. Caching here — inside the plain
+// functions debounce() wraps, rather than at the call sites — means the
+// cache is only ever written with the arguments the network request was
+// actually made for, never with plates typed while the request was pending.
+const getVehicleType = async ({ plate, licenseState, cache }) => {
+  const cacheKey = `${plate}:${licenseState}`;
+  const cachedVehicleInfoResponse = cache.get(cacheKey)?.vehicleInfoResponse;
+  if (cachedVehicleInfoResponse) {
+    return cachedVehicleInfoResponse;
+  }
+  const { data } = await axios.get(`/getVehicleType/${plate}/${licenseState}`);
+  cache.set(cacheKey, {
+    ...cache.get(cacheKey),
+    vehicleInfoResponse: data,
+  });
+  return data;
+};
 
-const debouncedGetViolations = debounce(async ({ plate, licenseState }) => {
+const getViolations = async ({ plate, licenseState, cache }) => {
+  const cacheKey = `${plate}:${licenseState}`;
+  const cachedViolationsResponse = cache.get(cacheKey)?.violationsResponse;
+  if (cachedViolationsResponse) {
+    return cachedViolationsResponse;
+  }
   const response = await axios.get(
     howsmydrivingApiUrl({ plate, licenseState }),
   );
+  cache.set(cacheKey, {
+    ...cache.get(cacheKey),
+    violationsResponse: response.data,
+  });
+  return response.data;
+};
 
-  return response;
-}, 1000);
+const debouncedGetVehicleType = debounce(getVehicleType, 1000);
+
+const debouncedGetViolations = debounce(getViolations, 1000);
 
 const debouncedSavePersistentStateToCookie = debounce(self => {
   self.savePersistentStateToCookie();
@@ -934,35 +959,18 @@ class Home extends React.Component {
       return;
     }
 
-    // HTTP responses are cached per plate+state, so re-selecting a plate that
-    // was looked up earlier re-renders its results without hitting the APIs
-    // again.
-    const cacheKey = `${plate}:${licenseState}`;
-    const cachedLookup = plate && this.plateLookupCache.get(cacheKey);
-    const cachedVehicleInfoResponse = cachedLookup?.vehicleInfoResponse;
-    const cachedViolationsResponse = cachedLookup?.violationsResponse;
-
+    // The debounced lookups cache their HTTP responses per plate+state, so
+    // re-selecting a plate that was looked up earlier resolves them without
+    // hitting the APIs again.
     this.setState({
       plate,
       licenseState,
-      vehicleInfoComponent: cachedVehicleInfoResponse
-        ? Home.buildVehicleInfoComponent({
-            plate,
-            licenseState,
-            vehicleInfoResponse: cachedVehicleInfoResponse,
-          })
-        : plate
-          ? `Looking up make/model for ${plate} in ${usStateNames[licenseState]}`
-          : null,
-      violationSummaryComponent: cachedViolationsResponse
-        ? Home.buildViolationSummaryComponent({
-            plate,
-            licenseState,
-            violationsResponse: cachedViolationsResponse,
-          })
-        : plate
-          ? `Looking up violations for ${plate} in ${usStateNames[licenseState]}`
-          : null,
+      vehicleInfoComponent: plate
+        ? `Looking up make/model for ${plate} in ${usStateNames[licenseState]}`
+        : null,
+      violationSummaryComponent: plate
+        ? `Looking up violations for ${plate} in ${usStateNames[licenseState]}`
+        : null,
     });
 
     const selectedDate = new Date(this.state.CreateDate);
@@ -991,103 +999,104 @@ class Home extends React.Component {
       );
     }
 
-    if (!cachedVehicleInfoResponse) {
-      debouncedGetVehicleType({ plate, licenseState })
-        .then(({ data }) => {
-          // Don't cache stale responses: the debounced lookup resolves every
-          // selection made while it was pending with the LAST plate's data,
-          // so only the last plate's response belongs in the cache.
-          if (plate !== this.state.plate) {
-            console.info('ignoring stale plate:', plate);
-            return;
-          }
+    debouncedGetVehicleType({
+      plate,
+      licenseState,
+      cache: this.plateLookupCache,
+    })
+      .then(vehicleInfoResponse => {
+        // Ignore responses for plates the user has moved on from: the
+        // debounced lookup resolves every selection made while it was
+        // pending with the LAST plate's data.
+        if (plate !== this.state.plate) {
+          console.info('ignoring stale plate:', plate);
+          return;
+        }
 
-          const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
-            data.result;
-          // LookupAPlate returns an empty result for plates without vehicle
-          // records (e.g. partial plates typed one character at a time).
-          // Don't cache those; the error path below renders a manual lookup
-          // link instead of "undefined" make/model fields.
-          if (!vehicleYear && !vehicleMake && !vehicleModel && !vehicleBody) {
-            throw new Error(`No vehicle data for ${plate}`);
-          }
+        const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
+          vehicleInfoResponse.result;
+        // LookupAPlate returns an empty result for plates without vehicle
+        // records (e.g. partial plates typed one character at a time). Fall
+        // through to the error path, which renders a manual lookup link
+        // instead of "undefined" make/model fields.
+        if (!vehicleYear && !vehicleMake && !vehicleModel && !vehicleBody) {
+          throw new Error(`No vehicle data for ${plate}`);
+        }
 
-          this.cachePlateLookup({
+        this.setState({
+          vehicleInfoComponent: Home.buildVehicleInfoComponent({
             plate,
             licenseState,
-            vehicleInfoResponse: data,
-          });
-          this.setState({
-            vehicleInfoComponent: Home.buildVehicleInfoComponent({
-              plate,
-              licenseState,
-              vehicleInfoResponse: data,
-            }),
-          });
-        })
-        .catch(err => {
-          console.error(err);
-
-          if (plate !== this.state.plate) {
-            console.info('ignoring stale plate:', plate);
-            return;
-          }
-
-          if (plate) {
-            this.setState({
-              vehicleInfoComponent: (
-                <React.Fragment>
-                  Could not look up make/model of {plate} in{' '}
-                  {usStateNames[licenseState]},{' '}
-                  <a
-                    href="https://github.com/josephfrazier/Reported-Web/issues/295"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    click here for details
-                  </a>
-                  <br />
-                  <a
-                    href="https://www.lookupaplate.com/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Click here to manually look it up
-                  </a>
-                </React.Fragment>
-              ),
-            });
-
-            // autocorrect common license plate typos from ALPR/OCR
-            if (plate.match(/^1\d\d\d\d\d\dC$/)) {
-              this.setLicensePlate({
-                plate: plate.replace('1', 'T'),
-                licenseState,
-              });
-            } else if (plate.match(/^\d\d\d\d\d\dC$/)) {
-              this.setLicensePlate({
-                plate: `T${plate}`,
-                licenseState,
-              });
-            }
-            // Commented out due to https://github.com/josephfrazier/Reported-Web/issues/295
-            //
-            // } else if (licenseState !== 'NY') {
-            //   this.setLicensePlate({
-            //     plate,
-            //     licenseState: 'NY',
-            //   });
-            // }
-          }
+            vehicleInfoResponse,
+          }),
         });
-    }
+      })
+      .catch(err => {
+        console.error(err);
 
-    if (plate && !cachedViolationsResponse) {
-      debouncedGetViolations({ plate, licenseState })
-        .then(({ data: responseData }) => {
-          // Don't cache stale responses: the debounced lookup resolves every
-          // selection made while it was pending with the LAST plate's data,
-          // so only the last plate's response belongs in the cache.
+        if (plate !== this.state.plate) {
+          console.info('ignoring stale plate:', plate);
+          return;
+        }
+
+        if (plate) {
+          this.setState({
+            vehicleInfoComponent: (
+              <React.Fragment>
+                Could not look up make/model of {plate} in{' '}
+                {usStateNames[licenseState]},{' '}
+                <a
+                  href="https://github.com/josephfrazier/Reported-Web/issues/295"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  click here for details
+                </a>
+                <br />
+                <a
+                  href="https://www.lookupaplate.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Click here to manually look it up
+                </a>
+              </React.Fragment>
+            ),
+          });
+
+          // autocorrect common license plate typos from ALPR/OCR
+          if (plate.match(/^1\d\d\d\d\d\dC$/)) {
+            this.setLicensePlate({
+              plate: plate.replace('1', 'T'),
+              licenseState,
+            });
+          } else if (plate.match(/^\d\d\d\d\d\dC$/)) {
+            this.setLicensePlate({
+              plate: `T${plate}`,
+              licenseState,
+            });
+          }
+          // Commented out due to https://github.com/josephfrazier/Reported-Web/issues/295
+          //
+          // } else if (licenseState !== 'NY') {
+          //   this.setLicensePlate({
+          //     plate,
+          //     licenseState: 'NY',
+          //   });
+          // }
+        }
+      });
+
+    if (plate) {
+      debouncedGetViolations({
+        plate,
+        licenseState,
+        cache: this.plateLookupCache,
+      })
+        .then(responseData => {
+          // Ignore responses for plates the user has moved on from: the
+          // debounced lookup resolves every selection made while it was
+          // pending with the LAST plate's data.
           if (plate !== this.state.plate) {
             return;
           }
@@ -1101,11 +1110,6 @@ class Home extends React.Component {
             return;
           }
 
-          this.cachePlateLookup({
-            plate,
-            licenseState,
-            violationsResponse: responseData,
-          });
           this.setState({
             violationSummaryComponent: Home.buildViolationSummaryComponent({
               plate,
@@ -1118,20 +1122,6 @@ class Home extends React.Component {
           console.error(err);
         });
     }
-  };
-
-  cachePlateLookup = ({
-    plate,
-    licenseState,
-    vehicleInfoResponse,
-    violationsResponse,
-  }) => {
-    const cacheKey = `${plate}:${licenseState}`;
-    this.plateLookupCache.set(cacheKey, {
-      ...this.plateLookupCache.get(cacheKey),
-      ...(vehicleInfoResponse && { vehicleInfoResponse }),
-      ...(violationsResponse && { violationsResponse }),
-    });
   };
 
   // adapted from https://github.com/ngokevin/react-file-reader-input/tree/f970257f271b8c3bba9d529ffdbfa4f4731e0799#usage

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -518,6 +518,7 @@ class Home extends React.Component {
     this.initialStatePerSubmission = initialStatePerSubmission;
     this.initialStatePersistent = initialStatePersistent;
     this.isDragging = false;
+    this.plateLookupCache = new Map();
     this.plateRef = React.createRef();
     this.plateLabelRef = React.createRef();
     this.loginEmailRef = React.createRef();
@@ -839,15 +840,27 @@ class Home extends React.Component {
       return;
     }
 
+    // Lookups are cached per plate+state, so re-selecting a plate that was
+    // looked up earlier restores its results without hitting the APIs again.
+    const cacheKey = `${plate}:${licenseState}`;
+    const cachedLookup = plate && this.plateLookupCache.get(cacheKey);
+    const cachedVehicleInfoComponent = cachedLookup?.vehicleInfoComponent;
+    const cachedViolationSummaryComponent =
+      cachedLookup?.violationSummaryComponent;
+
     this.setState({
       plate,
       licenseState,
-      vehicleInfoComponent: plate
-        ? `Looking up make/model for ${plate} in ${usStateNames[licenseState]}`
-        : null,
-      violationSummaryComponent: plate
-        ? `Looking up violations for ${plate} in ${usStateNames[licenseState]}`
-        : null,
+      vehicleInfoComponent:
+        cachedVehicleInfoComponent ||
+        (plate
+          ? `Looking up make/model for ${plate} in ${usStateNames[licenseState]}`
+          : null),
+      violationSummaryComponent:
+        cachedViolationSummaryComponent ||
+        (plate
+          ? `Looking up violations for ${plate} in ${usStateNames[licenseState]}`
+          : null),
     });
 
     const selectedDate = new Date(this.state.CreateDate);
@@ -876,18 +889,12 @@ class Home extends React.Component {
       );
     }
 
-    debouncedGetVehicleType({ plate, licenseState })
-      .then(({ data }) => {
-        const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
-          data.result;
-
-        if (plate !== this.state.plate) {
-          console.info('ignoring stale plate:', plate);
-          return;
-        }
-
-        this.setState({
-          vehicleInfoComponent: (
+    if (!cachedVehicleInfoComponent) {
+      debouncedGetVehicleType({ plate, licenseState })
+        .then(({ data }) => {
+          const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
+            data.result;
+          const vehicleInfoComponent = (
             <React.Fragment>
               <a
                 href={vehicleTypeUrl({ licensePlate: plate, licenseState })}
@@ -906,72 +913,76 @@ class Home extends React.Component {
                 }}
               />
             </React.Fragment>
-          ),
-        });
-      })
-      .catch(err => {
-        console.error(err);
+          );
+          this.cachePlateLookup({ plate, licenseState, vehicleInfoComponent });
 
-        if (plate !== this.state.plate) {
-          console.info('ignoring stale plate:', plate);
-          return;
-        }
-
-        if (plate) {
-          this.setState({
-            vehicleInfoComponent: (
-              <React.Fragment>
-                Could not look up make/model of {plate} in{' '}
-                {usStateNames[licenseState]},{' '}
-                <a
-                  href="https://github.com/josephfrazier/Reported-Web/issues/295"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  click here for details
-                </a>
-                <br />
-                <a
-                  href="https://www.lookupaplate.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Click here to manually look it up
-                </a>
-              </React.Fragment>
-            ),
-          });
-
-          // autocorrect common license plate typos from ALPR/OCR
-          if (plate.match(/^1\d\d\d\d\d\dC$/)) {
-            this.setLicensePlate({
-              plate: plate.replace('1', 'T'),
-              licenseState,
-            });
-          } else if (plate.match(/^\d\d\d\d\d\dC$/)) {
-            this.setLicensePlate({
-              plate: `T${plate}`,
-              licenseState,
-            });
-          }
-          // Commented out due to https://github.com/josephfrazier/Reported-Web/issues/295
-          //
-          // } else if (licenseState !== 'NY') {
-          //   this.setLicensePlate({
-          //     plate,
-          //     licenseState: 'NY',
-          //   });
-          // }
-        }
-      });
-
-    if (plate) {
-      debouncedGetViolations({ plate, licenseState })
-        .then(({ apiUrl, response: { data: responseData } }) => {
           if (plate !== this.state.plate) {
+            console.info('ignoring stale plate:', plate);
             return;
           }
 
+          this.setState({ vehicleInfoComponent });
+        })
+        .catch(err => {
+          console.error(err);
+
+          if (plate !== this.state.plate) {
+            console.info('ignoring stale plate:', plate);
+            return;
+          }
+
+          if (plate) {
+            this.setState({
+              vehicleInfoComponent: (
+                <React.Fragment>
+                  Could not look up make/model of {plate} in{' '}
+                  {usStateNames[licenseState]},{' '}
+                  <a
+                    href="https://github.com/josephfrazier/Reported-Web/issues/295"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    click here for details
+                  </a>
+                  <br />
+                  <a
+                    href="https://www.lookupaplate.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Click here to manually look it up
+                  </a>
+                </React.Fragment>
+              ),
+            });
+
+            // autocorrect common license plate typos from ALPR/OCR
+            if (plate.match(/^1\d\d\d\d\d\dC$/)) {
+              this.setLicensePlate({
+                plate: plate.replace('1', 'T'),
+                licenseState,
+              });
+            } else if (plate.match(/^\d\d\d\d\d\dC$/)) {
+              this.setLicensePlate({
+                plate: `T${plate}`,
+                licenseState,
+              });
+            }
+            // Commented out due to https://github.com/josephfrazier/Reported-Web/issues/295
+            //
+            // } else if (licenseState !== 'NY') {
+            //   this.setLicensePlate({
+            //     plate,
+            //     licenseState: 'NY',
+            //   });
+            // }
+          }
+        });
+    }
+
+    if (plate && !cachedViolationSummaryComponent) {
+      debouncedGetViolations({ plate, licenseState })
+        .then(({ apiUrl, response: { data: responseData } }) => {
           const vehicle =
             responseData.data &&
             responseData.data[0] &&
@@ -999,30 +1010,53 @@ class Home extends React.Component {
           const color = firstViolation?.vehicle_color ?? '';
           const body = firstViolation?.sanitized?.vehicle_body_type ?? '';
 
-          this.setState({
-            violationSummaryComponent: (
-              <React.Fragment>
-                {totalViolations} violation
-                {totalViolations !== 1 ? 's' : ''} found{' '}
-                {make && `(Maybe: ${color} ${make} ${body})`} — $
-                {fined.toFixed(2)} fined, ${outstanding.toFixed(2)} outstanding
-                {' ('}
-                <a href={detailsUrl} target="_blank" rel="noopener noreferrer">
-                  more details
-                </a>
-                {', or '}
-                <a href={apiUrl} target="_blank" rel="noopener noreferrer">
-                  full API response
-                </a>
-                )
-              </React.Fragment>
-            ),
+          const violationSummaryComponent = (
+            <React.Fragment>
+              {totalViolations} violation
+              {totalViolations !== 1 ? 's' : ''} found{' '}
+              {make && `(Maybe: ${color} ${make} ${body})`} — $
+              {fined.toFixed(2)} fined, ${outstanding.toFixed(2)} outstanding
+              {' ('}
+              <a href={detailsUrl} target="_blank" rel="noopener noreferrer">
+                more details
+              </a>
+              {', or '}
+              <a href={apiUrl} target="_blank" rel="noopener noreferrer">
+                full API response
+              </a>
+              )
+            </React.Fragment>
+          );
+          this.cachePlateLookup({
+            plate,
+            licenseState,
+            violationSummaryComponent,
           });
+
+          if (plate !== this.state.plate) {
+            return;
+          }
+
+          this.setState({ violationSummaryComponent });
         })
         .catch(err => {
           console.error(err);
         });
     }
+  };
+
+  cachePlateLookup = ({
+    plate,
+    licenseState,
+    vehicleInfoComponent,
+    violationSummaryComponent,
+  }) => {
+    const cacheKey = `${plate}:${licenseState}`;
+    this.plateLookupCache.set(cacheKey, {
+      ...this.plateLookupCache.get(cacheKey),
+      ...(vehicleInfoComponent && { vehicleInfoComponent }),
+      ...(violationSummaryComponent && { violationSummaryComponent }),
+    });
   };
 
   // adapted from https://github.com/ngokevin/react-file-reader-input/tree/f970257f271b8c3bba9d529ffdbfa4f4731e0799#usage

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -84,6 +84,9 @@ const debouncedGeosearch = debounce(async ({ latitude, longitude }) => {
   return data;
 }, 500);
 
+const howsmydrivingApiUrl = ({ plate, licenseState }) =>
+  `https://api.howsmydrivingny.nyc/api/v1/?plate=${plate}:${licenseState}`;
+
 const debouncedGetVehicleType = debounce(
   ({ plate, licenseState }) =>
     axios.get(`/getVehicleType/${plate}/${licenseState}`),
@@ -91,10 +94,11 @@ const debouncedGetVehicleType = debounce(
 );
 
 const debouncedGetViolations = debounce(async ({ plate, licenseState }) => {
-  const apiUrl = `https://api.howsmydrivingny.nyc/api/v1/?plate=${plate}:${licenseState}`;
-  const response = await axios.get(apiUrl);
+  const response = await axios.get(
+    howsmydrivingApiUrl({ plate, licenseState }),
+  );
 
-  return { apiUrl, response };
+  return response;
 }, 1000);
 
 const debouncedSavePersistentStateToCookie = debounce(self => {
@@ -411,6 +415,92 @@ class Home extends React.Component {
       return 'https://upload.wikimedia.org/wikipedia/commons/3/38/Honda.svg';
     }
     return `https://img.logo.dev/${vehicleMake}.com?token=pk_dUmX4e3CQxqMliLAmNRIqA`;
+  }
+
+  // Render the make/model/year for a plate from a LookupAPlate response.
+  static buildVehicleInfoComponent({
+    plate,
+    licenseState,
+    vehicleInfoResponse,
+  }) {
+    const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
+      vehicleInfoResponse.result;
+    return (
+      <React.Fragment>
+        <a
+          href={vehicleTypeUrl({ licensePlate: plate, licenseState })}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {plate} in {usStateNames[licenseState]}: {vehicleYear} {vehicleMake}{' '}
+          {vehicleModel} ({vehicleBody})
+        </a>
+        <img
+          src={Home.getVehicleMakeLogoUrl({ vehicleMake })}
+          alt={`${vehicleMake} logo`}
+          style={{
+            display: 'block',
+            maxWidth: '250px',
+          }}
+        />
+      </React.Fragment>
+    );
+  }
+
+  // Render the violation summary for a plate from a howsmydriving response,
+  // or null when the response has no vehicle data.
+  static buildViolationSummaryComponent({
+    plate,
+    licenseState,
+    violationsResponse,
+  }) {
+    const vehicle =
+      violationsResponse.data &&
+      violationsResponse.data[0] &&
+      violationsResponse.data[0].vehicle;
+
+    if (!vehicle || !vehicle.violations || !vehicle.fines) {
+      return null;
+    }
+
+    const totalViolations = vehicle.violations.length;
+    const { total_fined: fined, total_outstanding: outstanding } =
+      vehicle.fines;
+
+    const lastTweetPart =
+      vehicle.tweet_parts &&
+      vehicle.tweet_parts[vehicle.tweet_parts.length - 1];
+    const urlMatch = lastTweetPart && lastTweetPart.match(/https?:\/\/\S+/);
+    const detailsUrl = urlMatch
+      ? urlMatch[0].replace(/\.$/, '')
+      : 'https://howsmydrivingny.nyc/';
+
+    const firstViolation = vehicle.violations[0];
+    const make = firstViolation?.vehicle_make ?? '';
+    const color = firstViolation?.vehicle_color ?? '';
+    const body = firstViolation?.sanitized?.vehicle_body_type ?? '';
+
+    return (
+      <React.Fragment>
+        {totalViolations} violation
+        {totalViolations !== 1 ? 's' : ''} found{' '}
+        {make && `(Maybe: ${color} ${make} ${body})`} — ${fined.toFixed(2)}{' '}
+        fined, ${outstanding.toFixed(2)} outstanding
+        {' ('}
+        <a href={detailsUrl} target="_blank" rel="noopener noreferrer">
+          more details
+        </a>
+        {', or '}
+        <a
+          href={howsmydrivingApiUrl({ plate, licenseState })}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          full API response
+        </a>
+        )
+      </React.Fragment>
+    );
   }
 
   static handleAxiosError(error) {
@@ -844,27 +934,35 @@ class Home extends React.Component {
       return;
     }
 
-    // Lookups are cached per plate+state, so re-selecting a plate that was
-    // looked up earlier restores its results without hitting the APIs again.
+    // HTTP responses are cached per plate+state, so re-selecting a plate that
+    // was looked up earlier re-renders its results without hitting the APIs
+    // again.
     const cacheKey = `${plate}:${licenseState}`;
     const cachedLookup = plate && this.plateLookupCache.get(cacheKey);
-    const cachedVehicleInfoComponent = cachedLookup?.vehicleInfoComponent;
-    const cachedViolationSummaryComponent =
-      cachedLookup?.violationSummaryComponent;
+    const cachedVehicleInfoResponse = cachedLookup?.vehicleInfoResponse;
+    const cachedViolationsResponse = cachedLookup?.violationsResponse;
 
     this.setState({
       plate,
       licenseState,
-      vehicleInfoComponent:
-        cachedVehicleInfoComponent ||
-        (plate
+      vehicleInfoComponent: cachedVehicleInfoResponse
+        ? Home.buildVehicleInfoComponent({
+            plate,
+            licenseState,
+            vehicleInfoResponse: cachedVehicleInfoResponse,
+          })
+        : plate
           ? `Looking up make/model for ${plate} in ${usStateNames[licenseState]}`
-          : null),
-      violationSummaryComponent:
-        cachedViolationSummaryComponent ||
-        (plate
+          : null,
+      violationSummaryComponent: cachedViolationsResponse
+        ? Home.buildViolationSummaryComponent({
+            plate,
+            licenseState,
+            violationsResponse: cachedViolationsResponse,
+          })
+        : plate
           ? `Looking up violations for ${plate} in ${usStateNames[licenseState]}`
-          : null),
+          : null,
     });
 
     const selectedDate = new Date(this.state.CreateDate);
@@ -893,7 +991,7 @@ class Home extends React.Component {
       );
     }
 
-    if (!cachedVehicleInfoComponent) {
+    if (!cachedVehicleInfoResponse) {
       debouncedGetVehicleType({ plate, licenseState })
         .then(({ data }) => {
           // Don't cache stale responses: the debounced lookup resolves every
@@ -906,28 +1004,26 @@ class Home extends React.Component {
 
           const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
             data.result;
-          const vehicleInfoComponent = (
-            <React.Fragment>
-              <a
-                href={vehicleTypeUrl({ licensePlate: plate, licenseState })}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {plate} in {usStateNames[licenseState]}: {vehicleYear}{' '}
-                {vehicleMake} {vehicleModel} ({vehicleBody})
-              </a>
-              <img
-                src={Home.getVehicleMakeLogoUrl({ vehicleMake })}
-                alt={`${vehicleMake} logo`}
-                style={{
-                  display: 'block',
-                  maxWidth: '250px',
-                }}
-              />
-            </React.Fragment>
-          );
-          this.cachePlateLookup({ plate, licenseState, vehicleInfoComponent });
-          this.setState({ vehicleInfoComponent });
+          // LookupAPlate returns an empty result for plates without vehicle
+          // records (e.g. partial plates typed one character at a time).
+          // Don't cache those; the error path below renders a manual lookup
+          // link instead of "undefined" make/model fields.
+          if (!vehicleYear && !vehicleMake && !vehicleModel && !vehicleBody) {
+            throw new Error(`No vehicle data for ${plate}`);
+          }
+
+          this.cachePlateLookup({
+            plate,
+            licenseState,
+            vehicleInfoResponse: data,
+          });
+          this.setState({
+            vehicleInfoComponent: Home.buildVehicleInfoComponent({
+              plate,
+              licenseState,
+              vehicleInfoResponse: data,
+            }),
+          });
         })
         .catch(err => {
           console.error(err);
@@ -986,9 +1082,9 @@ class Home extends React.Component {
         });
     }
 
-    if (plate && !cachedViolationSummaryComponent) {
+    if (plate && !cachedViolationsResponse) {
       debouncedGetViolations({ plate, licenseState })
-        .then(({ apiUrl, response: { data: responseData } }) => {
+        .then(({ data: responseData }) => {
           // Don't cache stale responses: the debounced lookup resolves every
           // selection made while it was pending with the LAST plate's data,
           // so only the last plate's response belongs in the cache.
@@ -1005,47 +1101,18 @@ class Home extends React.Component {
             return;
           }
 
-          const totalViolations = vehicle.violations.length;
-          const { total_fined: fined, total_outstanding: outstanding } =
-            vehicle.fines;
-
-          const lastTweetPart =
-            vehicle.tweet_parts &&
-            vehicle.tweet_parts[vehicle.tweet_parts.length - 1];
-          const urlMatch =
-            lastTweetPart && lastTweetPart.match(/https?:\/\/\S+/);
-          const detailsUrl = urlMatch
-            ? urlMatch[0].replace(/\.$/, '')
-            : 'https://howsmydrivingny.nyc/';
-
-          const firstViolation = vehicle.violations[0];
-          const make = firstViolation?.vehicle_make ?? '';
-          const color = firstViolation?.vehicle_color ?? '';
-          const body = firstViolation?.sanitized?.vehicle_body_type ?? '';
-
-          const violationSummaryComponent = (
-            <React.Fragment>
-              {totalViolations} violation
-              {totalViolations !== 1 ? 's' : ''} found{' '}
-              {make && `(Maybe: ${color} ${make} ${body})`} — $
-              {fined.toFixed(2)} fined, ${outstanding.toFixed(2)} outstanding
-              {' ('}
-              <a href={detailsUrl} target="_blank" rel="noopener noreferrer">
-                more details
-              </a>
-              {', or '}
-              <a href={apiUrl} target="_blank" rel="noopener noreferrer">
-                full API response
-              </a>
-              )
-            </React.Fragment>
-          );
           this.cachePlateLookup({
             plate,
             licenseState,
-            violationSummaryComponent,
+            violationsResponse: responseData,
           });
-          this.setState({ violationSummaryComponent });
+          this.setState({
+            violationSummaryComponent: Home.buildViolationSummaryComponent({
+              plate,
+              licenseState,
+              violationsResponse: responseData,
+            }),
+          });
         })
         .catch(err => {
           console.error(err);
@@ -1056,14 +1123,14 @@ class Home extends React.Component {
   cachePlateLookup = ({
     plate,
     licenseState,
-    vehicleInfoComponent,
-    violationSummaryComponent,
+    vehicleInfoResponse,
+    violationsResponse,
   }) => {
     const cacheKey = `${plate}:${licenseState}`;
     this.plateLookupCache.set(cacheKey, {
       ...this.plateLookupCache.get(cacheKey),
-      ...(vehicleInfoComponent && { vehicleInfoComponent }),
-      ...(violationSummaryComponent && { violationSummaryComponent }),
+      ...(vehicleInfoResponse && { vehicleInfoResponse }),
+      ...(violationsResponse && { violationsResponse }),
     });
   };
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -442,6 +442,15 @@ class Home extends React.Component {
     return `https://img.logo.dev/${vehicleMake}.com?token=pk_dUmX4e3CQxqMliLAmNRIqA`;
   }
 
+  // Whether a LookupAPlate response contains any vehicle data. Empty results
+  // are returned for plates without vehicle records (e.g. partial plates
+  // typed one character at a time).
+  static vehicleInfoResponseHasData(vehicleInfoResponse) {
+    const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
+      vehicleInfoResponse?.result || {};
+    return !!(vehicleYear || vehicleMake || vehicleModel || vehicleBody);
+  }
+
   // Render the make/model/year for a plate from a LookupAPlate response.
   static buildVehicleInfoComponent({
     plate,
@@ -468,6 +477,30 @@ class Home extends React.Component {
             maxWidth: '250px',
           }}
         />
+      </React.Fragment>
+    );
+  }
+
+  // Render the error state for a plate whose vehicle could not be looked up.
+  static buildVehicleLookupErrorComponent({ plate, licenseState }) {
+    return (
+      <React.Fragment>
+        Could not look up make/model of {plate} in {usStateNames[licenseState]},{' '}
+        <a
+          href="https://github.com/josephfrazier/Reported-Web/issues/295"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          click here for details
+        </a>
+        <br />
+        <a
+          href="https://www.lookupaplate.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Click here to manually look it up
+        </a>
       </React.Fragment>
     );
   }
@@ -959,18 +992,43 @@ class Home extends React.Component {
       return;
     }
 
-    // The debounced lookups cache their HTTP responses per plate+state, so
-    // re-selecting a plate that was looked up earlier resolves them without
-    // hitting the APIs again.
+    // The debounced lookups cache their HTTP responses per plate+state (see
+    // getVehicleType/getViolations), so render a previously-looked-up plate
+    // from the cache immediately, without waiting out the debounce.
+    const cacheKey = `${plate}:${licenseState}`;
+    const cachedLookup = plate && this.plateLookupCache.get(cacheKey);
+    const cachedVehicleInfoResponse = cachedLookup?.vehicleInfoResponse;
+    const cachedViolationsResponse = cachedLookup?.violationsResponse;
+    const cachedVehicleInfoComponent =
+      cachedVehicleInfoResponse &&
+      (Home.vehicleInfoResponseHasData(cachedVehicleInfoResponse)
+        ? Home.buildVehicleInfoComponent({
+            plate,
+            licenseState,
+            vehicleInfoResponse: cachedVehicleInfoResponse,
+          })
+        : Home.buildVehicleLookupErrorComponent({ plate, licenseState }));
+    const cachedViolationSummaryComponent =
+      cachedViolationsResponse &&
+      Home.buildViolationSummaryComponent({
+        plate,
+        licenseState,
+        violationsResponse: cachedViolationsResponse,
+      });
+
     this.setState({
       plate,
       licenseState,
-      vehicleInfoComponent: plate
-        ? `Looking up make/model for ${plate} in ${usStateNames[licenseState]}`
-        : null,
-      violationSummaryComponent: plate
-        ? `Looking up violations for ${plate} in ${usStateNames[licenseState]}`
-        : null,
+      vehicleInfoComponent:
+        cachedVehicleInfoComponent ||
+        (plate
+          ? `Looking up make/model for ${plate} in ${usStateNames[licenseState]}`
+          : null),
+      violationSummaryComponent:
+        cachedViolationSummaryComponent ||
+        (plate
+          ? `Looking up violations for ${plate} in ${usStateNames[licenseState]}`
+          : null),
     });
 
     const selectedDate = new Date(this.state.CreateDate);
@@ -999,95 +1057,78 @@ class Home extends React.Component {
       );
     }
 
-    debouncedGetVehicleType({
-      plate,
-      licenseState,
-      cache: this.plateLookupCache,
-    })
-      .then(vehicleInfoResponse => {
-        // Ignore responses for plates the user has moved on from: the
-        // debounced lookup resolves every selection made while it was
-        // pending with the LAST plate's data.
-        if (plate !== this.state.plate) {
-          console.info('ignoring stale plate:', plate);
-          return;
-        }
-
-        const { vehicleYear, vehicleMake, vehicleModel, vehicleBody } =
-          vehicleInfoResponse.result;
-        // LookupAPlate returns an empty result for plates without vehicle
-        // records (e.g. partial plates typed one character at a time). Fall
-        // through to the error path, which renders a manual lookup link
-        // instead of "undefined" make/model fields.
-        if (!vehicleYear && !vehicleMake && !vehicleModel && !vehicleBody) {
-          throw new Error(`No vehicle data for ${plate}`);
-        }
-
-        this.setState({
-          vehicleInfoComponent: Home.buildVehicleInfoComponent({
-            plate,
-            licenseState,
-            vehicleInfoResponse,
-          }),
-        });
+    if (!cachedVehicleInfoComponent) {
+      debouncedGetVehicleType({
+        plate,
+        licenseState,
+        cache: this.plateLookupCache,
       })
-      .catch(err => {
-        console.error(err);
-
-        if (plate !== this.state.plate) {
-          console.info('ignoring stale plate:', plate);
-          return;
-        }
-
-        if (plate) {
-          this.setState({
-            vehicleInfoComponent: (
-              <React.Fragment>
-                Could not look up make/model of {plate} in{' '}
-                {usStateNames[licenseState]},{' '}
-                <a
-                  href="https://github.com/josephfrazier/Reported-Web/issues/295"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  click here for details
-                </a>
-                <br />
-                <a
-                  href="https://www.lookupaplate.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Click here to manually look it up
-                </a>
-              </React.Fragment>
-            ),
-          });
-
-          // autocorrect common license plate typos from ALPR/OCR
-          if (plate.match(/^1\d\d\d\d\d\dC$/)) {
-            this.setLicensePlate({
-              plate: plate.replace('1', 'T'),
-              licenseState,
-            });
-          } else if (plate.match(/^\d\d\d\d\d\dC$/)) {
-            this.setLicensePlate({
-              plate: `T${plate}`,
-              licenseState,
-            });
+        .then(vehicleInfoResponse => {
+          // Ignore responses for plates the user has moved on from: the
+          // debounced lookup resolves every selection made while it was
+          // pending with the LAST plate's data.
+          if (plate !== this.state.plate) {
+            console.info('ignoring stale plate:', plate);
+            return;
           }
-          // Commented out due to https://github.com/josephfrazier/Reported-Web/issues/295
-          //
-          // } else if (licenseState !== 'NY') {
-          //   this.setLicensePlate({
-          //     plate,
-          //     licenseState: 'NY',
-          //   });
-          // }
-        }
-      });
 
-    if (plate) {
+          // LookupAPlate returns an empty result for plates without vehicle
+          // records (e.g. partial plates typed one character at a time). Fall
+          // through to the error path, which renders a manual lookup link
+          // instead of "undefined" make/model fields.
+          if (!Home.vehicleInfoResponseHasData(vehicleInfoResponse)) {
+            throw new Error(`No vehicle data for ${plate}`);
+          }
+
+          this.setState({
+            vehicleInfoComponent: Home.buildVehicleInfoComponent({
+              plate,
+              licenseState,
+              vehicleInfoResponse,
+            }),
+          });
+        })
+        .catch(err => {
+          console.error(err);
+
+          if (plate !== this.state.plate) {
+            console.info('ignoring stale plate:', plate);
+            return;
+          }
+
+          if (plate) {
+            this.setState({
+              vehicleInfoComponent: Home.buildVehicleLookupErrorComponent({
+                plate,
+                licenseState,
+              }),
+            });
+
+            // autocorrect common license plate typos from ALPR/OCR
+            if (plate.match(/^1\d\d\d\d\d\dC$/)) {
+              this.setLicensePlate({
+                plate: plate.replace('1', 'T'),
+                licenseState,
+              });
+            } else if (plate.match(/^\d\d\d\d\d\dC$/)) {
+              this.setLicensePlate({
+                plate: `T${plate}`,
+                licenseState,
+              });
+            }
+            // Commented out due to https://github.com/josephfrazier/Reported-Web/issues/295
+            //
+            // } else if (licenseState !== 'NY') {
+            //   this.setLicensePlate({
+            //     plate,
+            //     licenseState: 'NY',
+            //   });
+            // }
+          }
+        });
+    }
+
+    if (plate && !cachedViolationSummaryComponent) {
       debouncedGetViolations({
         plate,
         licenseState,

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -565,6 +565,162 @@ describe('Home', () => {
     global.URL.createObjectURL = originalCreateObjectURL;
   });
 
+  test('does not cache results under plates typed while a lookup was pending', async () => {
+    jest.useFakeTimers();
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+    const axiosGet = jest.spyOn(axios, 'get').mockImplementation(url => {
+      if (url.startsWith('/getVehicleType/')) {
+        return Promise.resolve({
+          data: {
+            result: {
+              vehicleYear: 2020,
+              vehicleMake: 'Toyota',
+              vehicleModel: 'Camry',
+              vehicleBody: 'Sedan',
+            },
+          },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          data: [
+            {
+              vehicle: {
+                violations: [
+                  {
+                    vehicle_make: 'Toyota',
+                    vehicle_color: 'Blue',
+                    sanitized: { vehicle_body_type: 'Sedan' },
+                  },
+                ],
+                fines: { total_fined: 10, total_outstanding: 20 },
+                tweet_parts: [],
+              },
+            },
+          ],
+        },
+      });
+    });
+    const axiosPost = jest
+      .spyOn(axios, 'post')
+      .mockResolvedValue({ data: { features: [{ properties: {} }] } });
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ homeRef });
+    });
+
+    // Type TEST quickly: the debounced lookups fire once, for TEST, but the
+    // intermediate T/TE/TES selections share that lookup's promise.
+    for (const plate of ['T', 'TE', 'TES', 'TEST']) {
+      renderer.act(() => {
+        homeRef.current.setLicensePlate({ plate, licenseState: 'NY' });
+      });
+    }
+    await renderer.act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    expect(homeRef.current.plateLookupCache.has('TEST:NY')).toBe(true);
+    expect(homeRef.current.plateLookupCache.has('TES:NY')).toBe(false);
+    expect(homeRef.current.plateLookupCache.has('TE:NY')).toBe(false);
+    expect(homeRef.current.plateLookupCache.has('T:NY')).toBe(false);
+
+    // Deleting back through the intermediate plates shows "Looking up..."
+    // instead of restoring TEST's results.
+    renderer.act(() => {
+      homeRef.current.setLicensePlate({ plate: 'TES', licenseState: 'NY' });
+    });
+    expect(homeRef.current.state.vehicleInfoComponent).toBe(
+      'Looking up make/model for TES in New York',
+    );
+    expect(homeRef.current.state.violationSummaryComponent).toBe(
+      'Looking up violations for TES in New York',
+    );
+
+    jest.useRealTimers();
+    axiosGet.mockRestore();
+    axiosPost.mockRestore();
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
+  test('does not cache vehicle lookups that return no vehicle data', async () => {
+    jest.useFakeTimers();
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+    const axiosGet = jest.spyOn(axios, 'get').mockImplementation(url => {
+      if (url.startsWith('/getVehicleType/')) {
+        const licensePlate = url.split('/')[2];
+        if (licensePlate === 'TEST') {
+          return Promise.resolve({
+            data: {
+              result: {
+                vehicleYear: 2020,
+                vehicleMake: 'Toyota',
+                vehicleModel: 'Camry',
+                vehicleBody: 'Sedan',
+              },
+            },
+          });
+        }
+        // Like the real LookupAPlate API, plates without vehicle records
+        // (e.g. partial plates typed one character at a time) return an
+        // empty result instead of an error.
+        return Promise.resolve({ data: { result: {} } });
+      }
+      // Like the real howsmydriving API, partial plates return no vehicle.
+      return Promise.resolve({ data: { data: [] } });
+    });
+    const axiosPost = jest
+      .spyOn(axios, 'post')
+      .mockResolvedValue({ data: { features: [{ properties: {} }] } });
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ homeRef });
+    });
+
+    // Type TEST one character at a time, pausing after each so that every
+    // intermediate plate is looked up.
+    for (const plate of ['T', 'TE', 'TES', 'TEST']) {
+      renderer.act(() => {
+        homeRef.current.setLicensePlate({ plate, licenseState: 'NY' });
+      });
+      // eslint-disable-next-line no-await-in-loop -- each plate's lookup must complete before the next keystroke, to mimic slow typing.
+      await renderer.act(async () => {
+        jest.advanceTimersByTime(1500);
+      });
+    }
+
+    // Only TEST returned vehicle data, so deleting back through the
+    // intermediate plates must not restore saved results for them.
+    expect(homeRef.current.plateLookupCache.has('TEST:NY')).toBe(true);
+    expect(homeRef.current.plateLookupCache.has('TES:NY')).toBe(false);
+    expect(homeRef.current.plateLookupCache.has('TE:NY')).toBe(false);
+    expect(homeRef.current.plateLookupCache.has('T:NY')).toBe(false);
+
+    renderer.act(() => {
+      homeRef.current.setLicensePlate({ plate: 'TES', licenseState: 'NY' });
+    });
+    expect(homeRef.current.state.vehicleInfoComponent).toBe(
+      'Looking up make/model for TES in New York',
+    );
+
+    jest.useRealTimers();
+    axiosGet.mockRestore();
+    axiosPost.mockRestore();
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
   test('positions plate overlays with the uploaded image dimensions', () => {
     // Three sizes are in play for one photo, and only one of them is the space
     // `box` is measured in:

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -617,14 +617,17 @@ describe('Home', () => {
 
     axiosGet.mockClear();
 
-    // ...but selecting a previously-looked-up plate again shows "Looking
-    // up..." until the debounced call resolves from the cache, without
-    // hitting the APIs.
+    // ...but selecting a previously-looked-up plate again restores its
+    // results immediately from the cache, without waiting out the debounce
+    // or hitting the APIs.
     renderer.act(() => {
       homeRef.current.setLicensePlate({ plate: 'ABC123', licenseState: 'NY' });
     });
-    expect(homeRef.current.state.vehicleInfoComponent).toBe(
-      'Looking up make/model for ABC123 in New York',
+    expect(homeRef.current.state.vehicleInfoComponent).toEqual(
+      vehicleInfoComponent,
+    );
+    expect(homeRef.current.state.violationSummaryComponent).toEqual(
+      violationSummaryComponent,
     );
 
     await renderer.act(async () => {

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -577,6 +577,35 @@ describe('Home', () => {
       'Looking up violations for ABC123 in New York',
     );
 
+    // The cache stores the raw HTTP responses, not rendered components.
+    expect(homeRef.current.plateLookupCache.get('ABC123:NY')).toEqual({
+      vehicleInfoResponse: {
+        result: {
+          vehicleYear: 2020,
+          vehicleMake: 'Toyota',
+          vehicleModel: 'Camry',
+          vehicleBody: 'Sedan',
+        },
+      },
+      violationsResponse: {
+        data: [
+          {
+            vehicle: {
+              violations: [
+                {
+                  vehicle_make: 'Toyota',
+                  vehicle_color: 'Blue',
+                  sanitized: { vehicle_body_type: 'Sedan' },
+                },
+              ],
+              fines: { total_fined: 10, total_outstanding: 20 },
+              tweet_parts: [],
+            },
+          },
+        ],
+      },
+    });
+
     // Selecting a different plate still fires fresh lookups...
     renderer.act(() => {
       homeRef.current.setLicensePlate({ plate: 'XYZ789', licenseState: 'NY' });
@@ -593,10 +622,10 @@ describe('Home', () => {
     renderer.act(() => {
       homeRef.current.setLicensePlate({ plate: 'ABC123', licenseState: 'NY' });
     });
-    expect(homeRef.current.state.vehicleInfoComponent).toBe(
+    expect(homeRef.current.state.vehicleInfoComponent).toEqual(
       vehicleInfoComponent,
     );
-    expect(homeRef.current.state.violationSummaryComponent).toBe(
+    expect(homeRef.current.state.violationSummaryComponent).toEqual(
       violationSummaryComponent,
     );
 

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -465,6 +465,106 @@ describe('Home', () => {
     global.URL.createObjectURL = originalCreateObjectURL;
   });
 
+  test('restores cached vehicle/violations results when re-selecting a previously-looked-up plate', async () => {
+    jest.useFakeTimers();
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+    const axiosGet = jest.spyOn(axios, 'get').mockImplementation(url => {
+      if (url.startsWith('/getVehicleType/')) {
+        return Promise.resolve({
+          data: {
+            result: {
+              vehicleYear: 2020,
+              vehicleMake: 'Toyota',
+              vehicleModel: 'Camry',
+              vehicleBody: 'Sedan',
+            },
+          },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          data: [
+            {
+              vehicle: {
+                violations: [
+                  {
+                    vehicle_make: 'Toyota',
+                    vehicle_color: 'Blue',
+                    sanitized: { vehicle_body_type: 'Sedan' },
+                  },
+                ],
+                fines: { total_fined: 10, total_outstanding: 20 },
+                tweet_parts: [],
+              },
+            },
+          ],
+        },
+      });
+    });
+    const axiosPost = jest
+      .spyOn(axios, 'post')
+      .mockResolvedValue({ data: { features: [{ properties: {} }] } });
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ homeRef });
+    });
+
+    renderer.act(() => {
+      homeRef.current.setLicensePlate({ plate: 'ABC123', licenseState: 'NY' });
+    });
+    await renderer.act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    const { vehicleInfoComponent, violationSummaryComponent } =
+      homeRef.current.state;
+    expect(vehicleInfoComponent).not.toBe(
+      'Looking up make/model for ABC123 in New York',
+    );
+    expect(violationSummaryComponent).not.toBe(
+      'Looking up violations for ABC123 in New York',
+    );
+
+    // Selecting a different plate still fires fresh lookups...
+    renderer.act(() => {
+      homeRef.current.setLicensePlate({ plate: 'XYZ789', licenseState: 'NY' });
+    });
+    await renderer.act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(axiosGet).toHaveBeenCalledWith('/getVehicleType/XYZ789/NY');
+
+    axiosGet.mockClear();
+
+    // ...but selecting a previously-looked-up plate again restores its
+    // results without hitting the APIs.
+    renderer.act(() => {
+      homeRef.current.setLicensePlate({ plate: 'ABC123', licenseState: 'NY' });
+    });
+    expect(homeRef.current.state.vehicleInfoComponent).toBe(
+      vehicleInfoComponent,
+    );
+    expect(homeRef.current.state.violationSummaryComponent).toBe(
+      violationSummaryComponent,
+    );
+
+    await renderer.act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(axiosGet).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+    axiosGet.mockRestore();
+    axiosPost.mockRestore();
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
   test('positions plate overlays with the uploaded image dimensions', () => {
     // Three sizes are in play for one photo, and only one of them is the space
     // `box` is measured in:

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -617,22 +617,26 @@ describe('Home', () => {
 
     axiosGet.mockClear();
 
-    // ...but selecting a previously-looked-up plate again restores its
-    // results without hitting the APIs.
+    // ...but selecting a previously-looked-up plate again shows "Looking
+    // up..." until the debounced call resolves from the cache, without
+    // hitting the APIs.
     renderer.act(() => {
       homeRef.current.setLicensePlate({ plate: 'ABC123', licenseState: 'NY' });
     });
-    expect(homeRef.current.state.vehicleInfoComponent).toEqual(
-      vehicleInfoComponent,
-    );
-    expect(homeRef.current.state.violationSummaryComponent).toEqual(
-      violationSummaryComponent,
+    expect(homeRef.current.state.vehicleInfoComponent).toBe(
+      'Looking up make/model for ABC123 in New York',
     );
 
     await renderer.act(async () => {
       jest.advanceTimersByTime(1500);
     });
     expect(axiosGet).not.toHaveBeenCalled();
+    expect(homeRef.current.state.vehicleInfoComponent).toEqual(
+      vehicleInfoComponent,
+    );
+    expect(homeRef.current.state.violationSummaryComponent).toEqual(
+      violationSummaryComponent,
+    );
 
     jest.useRealTimers();
     axiosGet.mockRestore();
@@ -725,7 +729,7 @@ describe('Home', () => {
     global.URL.createObjectURL = originalCreateObjectURL;
   });
 
-  test('does not cache vehicle lookups that return no vehicle data', async () => {
+  test('reuses the cached empty vehicle response when re-selecting a partial plate', async () => {
     jest.useFakeTimers();
 
     const originalCreateObjectURL = global.URL.createObjectURL;
@@ -776,17 +780,23 @@ describe('Home', () => {
       });
     }
 
-    // Only TEST returned vehicle data, so deleting back through the
-    // intermediate plates must not restore saved results for them.
-    expect(homeRef.current.plateLookupCache.has('TEST:NY')).toBe(true);
-    expect(homeRef.current.plateLookupCache.has('TES:NY')).toBe(false);
-    expect(homeRef.current.plateLookupCache.has('TE:NY')).toBe(false);
-    expect(homeRef.current.plateLookupCache.has('T:NY')).toBe(false);
+    // Empty responses are cached like any other response...
+    expect(
+      homeRef.current.plateLookupCache.get('TES:NY').vehicleInfoResponse,
+    ).toEqual({ result: {} });
 
+    axiosGet.mockClear();
+
+    // ...so deleting back through a partial plate re-renders the error UI
+    // without hitting the API again.
     renderer.act(() => {
       homeRef.current.setLicensePlate({ plate: 'TES', licenseState: 'NY' });
     });
-    expect(homeRef.current.state.vehicleInfoComponent).toBe(
+    await renderer.act(async () => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(axiosGet).not.toHaveBeenCalled();
+    expect(homeRef.current.state.vehicleInfoComponent).not.toBe(
       'Looking up make/model for TES in New York',
     );
 


### PR DESCRIPTION
Re-selecting a plate that was looked up earlier renders its vehicle info and
violation summary instantly from the cached HTTP responses, with no duplicate
network requests.

Cache writes live inside the plain functions debounce() wraps, so the cache is
only ever written with the plate the request was actually made for — plates
typed while a lookup was pending can't pollute it. Empty responses (plates
without vehicle records, e.g. partial plates typed one character at a time) are
cached too and re-render the lookup-error state instantly. The render and
error-state markup are shared static builders used by both the fresh-lookup and
cache-restore paths.

Co-Authored-By: Claude Code with DeepSeek