### PR TITLE
Change `No vehicle data` error to `No make/model data` warning

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1077,7 +1077,7 @@ class Home extends React.Component {
           // through to the error path, which renders a manual lookup link
           // instead of "undefined" make/model fields.
           if (!Home.vehicleInfoResponseHasData(vehicleInfoResponse)) {
-            throw new Error(`No vehicle data for ${plate}`);
+            throw new Error(`No make/model data for ${plate}`);
           }
 
           this.setState({
@@ -1089,7 +1089,7 @@ class Home extends React.Component {
           });
         })
         .catch(err => {
-          console.error(err);
+          console.warn(err);
 
           if (plate !== this.state.plate) {
             console.info('ignoring stale plate:', plate);


### PR DESCRIPTION
A user mentioned on Slack that they saw the console error in their
developer tools, so let's calm it down a bit and not make it seem more
serious than it is.

https://reportedcab.slack.com/archives/C9VNM3DL4/p1788116130412709