### PR TITLE
fix: handle empty Plate Recognizer results

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -340,6 +340,14 @@ async function extractPlate({
     });
     const { results } = data;
 
+    // Plate Recognizer returns an empty results array when no plate is
+    // detected. Without this guard, `result` stays undefined and setting
+    // `result.licenseState` below crashes with a TypeError instead of taking
+    // the "Could not extract the license plate" path.
+    if (!results || results.length === 0) {
+      throw new Error('No license plate detected');
+    }
+
     // Choose first result with T######C plate if it exists, see https://github.com/josephfrazier/reported-web/issues/584
     let result = results.filter(r =>
       r.plate?.toUpperCase().match(/^T\d\d\d\d\d\dC$/),

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -340,10 +340,6 @@ async function extractPlate({
     });
     const { results } = data;
 
-    // Plate Recognizer returns an empty results array when no plate is
-    // detected. Without this guard, `result` stays undefined and setting
-    // `result.licenseState` below crashes with a TypeError instead of taking
-    // the "Could not extract the license plate" path.
     if (!results || results.length === 0) {
       throw new Error('No license plate detected');
     }


### PR DESCRIPTION
Plate Recognizer returns an empty results array when no plate is
detected, leaving `result` undefined so `result.licenseState = ...`
throws a TypeError in both branches of the try/catch. Fail fast with a
clear error so the user gets the existing "Could not extract the
license plate" warning instead of a console TypeError.

Co-Authored-By: Claude Code with DeepSeek