### PR TITLE
fix: render plate overlays on uploaded videos

### DIFF
--- a/src/alpr.downscale.test.js
+++ b/src/alpr.downscale.test.js
@@ -69,4 +69,59 @@ describe('downscaleForPlateRecognizer', () => {
     expect(data.uploadWidth).toBe(2048);
     expect(data.uploadHeight).toBe(2731);
   }, 15000);
+
+  test('converts an oversized PNG video frame to JPEG so Plate Recognizer accepts it', async () => {
+    // Video screenshots arrive as PNG (capture-frame's default), and a
+    // lossless PNG of a 3024x4032 frame is ~29MB -- large enough to still
+    // exceed the upload limit after resizing, since the format was inferred
+    // from the input. Forcing JPEG fixes the 413 this caused.
+    const attachmentBuffer = await sharp(readFileSync(photoPath))
+      .png()
+      .toBuffer();
+    expect(attachmentBuffer.length).toBeGreaterThan(2411654);
+
+    const { uploaded, data } = await captureUpload({ attachmentBuffer });
+
+    const metadata = await sharp(uploaded).metadata();
+    expect(metadata.format).toBe('jpeg');
+    expect({ width: metadata.width, height: metadata.height }).toEqual({
+      width: 2048,
+      height: 2731,
+    });
+    expect(uploaded.length).toBeLessThan(2411654);
+
+    expect(data.uploadWidth).toBe(2048);
+    expect(data.uploadHeight).toBe(2731);
+  }, 15000);
+
+  test('converts an oversized PNG frame narrower than 2048 without resizing it', async () => {
+    // A 1080p/1920-wide video frame: both downscale passes skip because the
+    // width is already under their targets, but the PNG is still ~12MB. The
+    // JPEG conversion alone must bring it under the upload limit.
+    const attachmentBuffer = await sharp(readFileSync(photoPath))
+      .resize({ width: 1920 })
+      .png()
+      .toBuffer();
+    expect(attachmentBuffer.length).toBeGreaterThan(2411654);
+
+    const { uploaded, logs, data } = await captureUpload({ attachmentBuffer });
+
+    expect(logs).toContainEqual(
+      expect.stringContaining('skipping scale down to width of 4096'),
+    );
+    expect(logs).not.toContainEqual(
+      expect.stringContaining('attempting to scale down'),
+    );
+
+    const metadata = await sharp(uploaded).metadata();
+    expect(metadata.format).toBe('jpeg');
+    expect({ width: metadata.width, height: metadata.height }).toEqual({
+      width: 1920,
+      height: 2560,
+    });
+    expect(uploaded.length).toBeLessThan(2411654);
+
+    expect(data.uploadWidth).toBe(1920);
+    expect(data.uploadHeight).toBe(2560);
+  }, 15000);
 });

--- a/src/alpr.js
+++ b/src/alpr.js
@@ -37,22 +37,53 @@ const downscaleForPlateRecognizer = async ({ buffer, targetWidth }) => {
     return buffer;
   }
 
+  // Video screenshots arrive as PNG, and a lossless PNG of a photo-like
+  // frame is large enough to trip Plate Recognizer's upload limit even
+  // after resizing (a 2048-wide one measured 13.8MB). Convert oversized
+  // non-JPEG uploads to JPEG: the bytes are POSTed as image/jpeg either
+  // way, and JPEG shrinks them below the limit. JPEGs are left alone here
+  // -- re-encoding them would add a generation of loss the 2048 pass is
+  // going to resize anyway.
+  const toJpeg = () =>
+    sharp(buffer)
+      .jpeg()
+      .toBuffer()
+      .catch(error => {
+        console.error('could not convert to JPEG, using unconverted image', {
+          error,
+        });
+        return buffer;
+      })
+      // sharp v0.35+ always returns a Buffer from toBuffer(), but guard
+      // against the old Uint8Array bug without an unnecessary copy.
+      .then(jpegBuffer =>
+        Buffer.isBuffer(jpegBuffer) ? jpegBuffer : Buffer.from(jpegBuffer),
+      );
+
   // sharp's resize() enlarges by default, so a photo narrower than targetWidth
   // gets blown up here only for the next, smaller pass to shrink it again --
   // two resamples, a bigger intermediate buffer, and a generation of JPEG loss
   // to end up at the same size. Leave it for that pass to handle instead.
-  const { width } = await sharp(buffer)
+  const { width, format } = await sharp(buffer)
     .metadata()
     // A buffer sharp cannot read falls through to the resize below, which
     // already handles that by returning the image unscaled.
     .catch(() => ({}));
 
-  if (width && width <= targetWidth) {
+  if (width && width <= targetWidth && format === 'jpeg') {
     // eslint-disable-next-line no-console
     console.log(
       `image is only ${width}px wide, skipping scale down to width of ${targetWidth}`,
     );
     return buffer;
+  }
+
+  if (width && width <= targetWidth) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `image is only ${width}px wide, skipping scale down to width of ${targetWidth}, converting to JPEG instead`,
+    );
+    return toJpeg();
   }
 
   // eslint-disable-next-line no-console
@@ -63,6 +94,7 @@ const downscaleForPlateRecognizer = async ({ buffer, targetWidth }) => {
   return (
     sharp(buffer)
       .resize({ width: targetWidth })
+      .jpeg()
       .toBuffer()
       .catch(error => {
         console.error('could not scale down, using unscaled image', { error });

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -2242,13 +2242,30 @@ class Home extends React.Component {
                                     />
                                   ) : (
                                     /* eslint-disable-next-line jsx-a11y/media-has-caption */
-                                    <video src={src} alt={name} />
+                                    <video
+                                      src={src}
+                                      alt={name}
+                                      // The position:relative wrapper shrink-
+                                      // wraps its content, and plate overlays
+                                      // are percentage-positioned against that
+                                      // wrapper, so the video must fill it
+                                      // exactly like the img above does:
+                                      // display:block closes the inline
+                                      // baseline gap, and max-width:100%
+                                      // (which marx-css gives img but not
+                                      // video) keeps the video from
+                                      // overflowing the wrapper when it is
+                                      // wider than the container.
+                                      style={{
+                                        display: 'block',
+                                        maxWidth: '100%',
+                                      }}
+                                    />
                                   )}
                                 </a>
-                                {isImg &&
-                                  this.renderPlateOverlays({
-                                    attachmentPlateData,
-                                  })}
+                                {this.renderPlateOverlays({
+                                  attachmentPlateData,
+                                })}
                               </div>
 
                               <button

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -204,7 +204,11 @@ async function getVideoScreenshot({ attachmentFile }) {
   video.currentTime = 0; // TODO let user choose time?
   await pEvent(video, 'seeked');
 
-  const buf = captureFrame(video).image;
+  // JPEG, not the default PNG: a lossless PNG frame of a high-res video is
+  // tens of megabytes, which trips Plate Recognizer's upload limit even
+  // after the server scales it down (see src/alpr.js). JPEG is a fraction
+  // of that size and what the API expects anyway.
+  const buf = captureFrame(video, 'jpeg').image;
 
   // unload video element, to prevent memory leaks
   video.pause();

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -374,6 +374,65 @@ describe('Home', () => {
     global.URL.createObjectURL = originalCreateObjectURL;
   });
 
+  test('renders plate overlays on uploaded videos and selects plate on click', () => {
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+    };
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ initialState, homeRef });
+    });
+    renderer.act(() => {
+      homeRef.current.setState({
+        attachmentData: [
+          new File(['video'], 'video.mp4', { type: 'video/mp4' }),
+        ],
+        plateDataByAttachmentName: {
+          'video.mp4': {
+            results: [
+              {
+                plate: 'abc123',
+                region: { code: 'us-ny' },
+                box: { xmin: 100, ymin: 200, xmax: 300, ymax: 250 },
+              },
+            ],
+            // uploadWidth/uploadHeight are the screenshot frame's pixel
+            // dimensions (the video's intrinsic size), so box coordinates
+            // turn into percentages the same way they do for images.
+            uploadWidth: 1000,
+            uploadHeight: 500,
+          },
+        },
+      });
+    });
+
+    const overlay = tree.root.findByProps({
+      'aria-label': 'Select license plate ABC123',
+    });
+    expect(overlay.props.className).toBe('plate-overlay');
+    expect(overlay.props.style).toEqual({
+      left: '10%',
+      top: '40%',
+      width: '20%',
+      height: '10%',
+    });
+
+    renderer.act(() => {
+      overlay.props.onClick();
+    });
+    expect(homeRef.current.state.plate).toBe('ABC123');
+    expect(homeRef.current.state.licenseState).toBe('NY');
+
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
   test('scrolls the License/Medallion label into view when a plate overlay is clicked', () => {
     const initialState = {
       email: 'test@example.com',


### PR DESCRIPTION
(Slack context: [the algorithm recognizes plates on videos, but does not put an overlay on them](https://reportedcab.slack.com/archives/C9VNM3DL4/p1788117637457709?thread_ts=1786403291.425809&cid=C9VNM3DL4))

Plate recognition already works for videos -- fetchPlateResults() sends a
screenshot of the first frame to Plate Recognizer and stores the results
per attachment -- but renderPlateOverlays() was only called when the
attachment was an image, so videos never showed the clickable overlay.

Render the overlay for both, and give the `<video>` the same shrink-to-fit
styling the `<img>` has: `display:block` closes the inline baseline gap in the
`position:relative` wrapper the overlays are percentage-positioned against,
and `max-width:100%` (which marx-css provides for img but not video) keeps
the video from overflowing that wrapper when it is wider than the
container. The screenshot is captured at the video's intrinsic dimensions,
so the plate boxes divide into the same scale-invariant percentages as
image overlays.

Co-Authored-By: Claude Code with DeepSeek