### PR TITLE
fix: silence react-modal "App element is not defined" warning

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -786,6 +786,13 @@ class Home extends React.Component {
     if (this.state.isLoadPreviousSubmissionsEnabled) {
       this.loadPreviousSubmissions();
     }
+
+    // Tell react-modal which element holds the page content, so it can mark
+    // that element aria-hidden while a modal is open (the "App element is
+    // not defined" warning). The element must not contain the modals'
+    // portal, which parentSelector renders as a sibling of the container
+    // inside the root, so use the container div rather than #app.
+    Modal.setAppElement(document.querySelector(`.${homeStyles.container}`));
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -13,15 +13,15 @@ import renderer from 'react-test-renderer';
 import StyleContext from 'isomorphic-style-loader/StyleContext';
 import axios from 'axios';
 import { toast } from 'react-toastify';
+import Modal from 'react-modal';
 import App from '../../components/App.js';
 import Home from './Home.js';
 import boroughBoundariesFeatureCollection from '../../boroughBoundaries.js';
 
-jest.mock(
-  'react-modal',
-  () =>
-    ({ children, isOpen }) =>
-      isOpen ? children : null,
+jest.mock('react-modal', () =>
+  Object.assign(({ children, isOpen }) => (isOpen ? children : null), {
+    setAppElement: jest.fn(),
+  }),
 );
 
 require('timezone-mock').register('US/Eastern');
@@ -249,6 +249,18 @@ describe('Home', () => {
     });
 
     expect(tree.toJSON()).toMatchSnapshot();
+
+    tree.unmount();
+  });
+
+  test('tells react-modal which element holds the page content', () => {
+    Modal.setAppElement.mockClear();
+    let tree;
+    renderer.act(() => {
+      tree = renderHome();
+    });
+
+    expect(Modal.setAppElement).toHaveBeenCalledTimes(1);
 
     tree.unmount();
   });


### PR DESCRIPTION
Set Modal.setAppElement to the page content container so react-modal can
mark it aria-hidden while a modal is open. Using #app would also hide the
open modal from screen readers, since the modals' portal is rendered
inside it (as a sibling of the container), so target the container div
instead.

Also extend the react-modal test mock with setAppElement and cover the
wiring with a test.

Co-Authored-By: Claude Code with DeepSeek