### PR TITLE
feat: focus the map search field when the map opens

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -2543,6 +2543,17 @@ class Home extends React.Component {
                           }}
                           onSearchBoxMounted={ref => {
                             this.searchBox = ref;
+                            // The SearchBox portal-renders its input into a
+                            // container that only gets attached to the map
+                            // afterwards, in the SearchBox's own
+                            // componentDidMount (which runs after this ref
+                            // callback), so defer focusing the input a frame
+                            // until it is actually in the document.
+                            requestAnimationFrame(() => {
+                              ref.containerElement
+                                .querySelector('input')
+                                .focus();
+                            });
                           }}
                           onPlacesChanged={() => {
                             const places = this.searchBox.getPlaces();

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -612,13 +612,35 @@ class Home extends React.Component {
     if (!input) {
       return;
     }
-    // The SearchBox portal-renders the input into a container and only
-    // moves it into the map's controls afterwards, in the SearchBox's own
-    // componentDidMount (which runs after this ref callback), so defer
-    // focusing it a frame until it is actually in the document. The input
-    // is referenced directly because the SearchBox moves it out of its
-    // container, so querying the container finds nothing by then.
-    requestAnimationFrame(() => input.focus());
+    let attempts = 0;
+    const attemptFocus = () => {
+      if (document.activeElement === input) {
+        return; // focus landed
+      }
+      attempts += 1;
+      if (attempts > 40) {
+        return; // give up after ~4s rather than retrying forever
+      }
+      const { activeElement } = document;
+      // The user interacting with the page (clicking a button or the map
+      // itself) wins over the deferred focus; don't steal it back.
+      const userInteracted =
+        ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'A'].includes(
+          activeElement?.tagName,
+        ) || activeElement?.classList?.contains('gm-style');
+      // The SearchBox portal-renders the input into a container that is
+      // not in the document yet when this ref fires, and Google Maps only
+      // attaches the control containers to the page as the map finishes
+      // initializing. focus() on a detached element is a no-op, so retry
+      // until the input is in the document and the focus sticks.
+      if (!userInteracted && document.contains(input)) {
+        input.focus();
+      }
+      if (document.activeElement !== input) {
+        setTimeout(attemptFocus, 100);
+      }
+    };
+    requestAnimationFrame(attemptFocus);
   }
 
   constructor(props) {

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -607,6 +607,20 @@ class Home extends React.Component {
     return toast.error(notificationContent);
   }
 
+  static handleSearchInputMounted(input) {
+    // Only a real mount passes the input element; unmounts pass null.
+    if (!input) {
+      return;
+    }
+    // The SearchBox portal-renders the input into a container and only
+    // moves it into the map's controls afterwards, in the SearchBox's own
+    // componentDidMount (which runs after this ref callback), so defer
+    // focusing it a frame until it is actually in the document. The input
+    // is referenced directly because the SearchBox moves it out of its
+    // container, so querying the container finds nothing by then.
+    requestAnimationFrame(() => input.focus());
+  }
+
   constructor(props) {
     super(props);
 
@@ -936,20 +950,6 @@ class Home extends React.Component {
 
   handleSearchBoxMounted = ref => {
     this.searchBox = ref;
-    // Ref callbacks fire with null when the SearchBox unmounts; only a
-    // real mount receives the component instance to focus from.
-    if (!ref) {
-      return;
-    }
-    // The SearchBox portal-renders its input into a container that only
-    // gets attached to the map afterwards, in the SearchBox's own
-    // componentDidMount (which runs after this ref callback), so defer
-    // focusing the input a frame until it is actually in the document.
-    // If the map closed before then, the input is gone and the optional
-    // chaining makes this a no-op.
-    requestAnimationFrame(() => {
-      ref.containerElement.querySelector('input')?.focus();
-    });
   };
 
   renderPlateOverlays = ({ attachmentPlateData }) =>
@@ -2567,6 +2567,7 @@ class Home extends React.Component {
                             this.isDragging = false;
                           }}
                           onSearchBoxMounted={this.handleSearchBoxMounted}
+                          onSearchInputMounted={Home.handleSearchInputMounted}
                           onPlacesChanged={() => {
                             const places = this.searchBox.getPlaces();
 
@@ -2808,6 +2809,7 @@ const MyMapComponentPure = props => {
     onDragStart,
     onDragEnd,
     onSearchBoxMounted,
+    onSearchInputMounted,
     onPlacesChanged,
   } = props;
 
@@ -2838,6 +2840,7 @@ const MyMapComponentPure = props => {
         }}
       >
         <input
+          ref={onSearchInputMounted}
           type="text"
           placeholder="Search..."
           style={{
@@ -2870,6 +2873,7 @@ MyMapComponentPure.propTypes = {
   onDragStart: PropTypes.func.isRequired,
   onDragEnd: PropTypes.func.isRequired,
   onSearchBoxMounted: PropTypes.func.isRequired,
+  onSearchInputMounted: PropTypes.func.isRequired,
   onPlacesChanged: PropTypes.func.isRequired,
 };
 

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -934,6 +934,24 @@ class Home extends React.Component {
     });
   };
 
+  handleSearchBoxMounted = ref => {
+    this.searchBox = ref;
+    // Ref callbacks fire with null when the SearchBox unmounts; only a
+    // real mount receives the component instance to focus from.
+    if (!ref) {
+      return;
+    }
+    // The SearchBox portal-renders its input into a container that only
+    // gets attached to the map afterwards, in the SearchBox's own
+    // componentDidMount (which runs after this ref callback), so defer
+    // focusing the input a frame until it is actually in the document.
+    // If the map closed before then, the input is gone and the optional
+    // chaining makes this a no-op.
+    requestAnimationFrame(() => {
+      ref.containerElement.querySelector('input')?.focus();
+    });
+  };
+
   renderPlateOverlays = ({ attachmentPlateData }) =>
     attachmentPlateData?.results?.map(result => {
       const { box } = result;
@@ -2548,20 +2566,7 @@ class Home extends React.Component {
                           onDragEnd={() => {
                             this.isDragging = false;
                           }}
-                          onSearchBoxMounted={ref => {
-                            this.searchBox = ref;
-                            // The SearchBox portal-renders its input into a
-                            // container that only gets attached to the map
-                            // afterwards, in the SearchBox's own
-                            // componentDidMount (which runs after this ref
-                            // callback), so defer focusing the input a frame
-                            // until it is actually in the document.
-                            requestAnimationFrame(() => {
-                              ref.containerElement
-                                .querySelector('input')
-                                .focus();
-                            });
-                          }}
+                          onSearchBoxMounted={this.handleSearchBoxMounted}
                           onPlacesChanged={() => {
                             const places = this.searchBox.getPlaces();
 

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -265,37 +265,52 @@ describe('Home', () => {
     tree.unmount();
   });
 
-  test('focuses the map search input when it mounts', () => {
-    const { requestAnimationFrame } = global;
-    global.requestAnimationFrame = callback => callback();
-    let tree;
-    const homeRef = React.createRef();
-    renderer.act(() => {
-      tree = renderHome({ homeRef });
-    });
-    const input = { focus: jest.fn() };
+  test('focuses the map search input once it is in the document', () => {
+    jest.useFakeTimers();
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    try {
+      Home.handleSearchInputMounted(input);
 
-    Home.handleSearchInputMounted(input);
+      jest.advanceTimersByTime(20);
 
-    expect(input.focus).toHaveBeenCalledTimes(1);
-    global.requestAnimationFrame = requestAnimationFrame;
-    tree.unmount();
+      expect(document.activeElement).toBe(input);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+      document.body.removeChild(input);
+    }
+  });
+
+  test('keeps retrying until the map attaches the search input', () => {
+    jest.useFakeTimers();
+    const input = document.createElement('input');
+    try {
+      Home.handleSearchInputMounted(input);
+
+      jest.advanceTimersByTime(20); // first attempt, input not attached yet
+      expect(document.activeElement).not.toBe(input);
+
+      document.body.appendChild(input);
+      jest.advanceTimersByTime(100); // next retry, input now attached
+
+      expect(document.activeElement).toBe(input);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+      document.body.removeChild(input);
+    }
   });
 
   test('ignores the null ref the search input passes when unmounting', () => {
-    const { requestAnimationFrame } = global;
-    global.requestAnimationFrame = jest.fn();
-    let tree;
-    const homeRef = React.createRef();
-    renderer.act(() => {
-      tree = renderHome({ homeRef });
-    });
+    jest.useFakeTimers();
+    try {
+      Home.handleSearchInputMounted(null);
 
-    Home.handleSearchInputMounted(null);
-
-    expect(global.requestAnimationFrame).not.toHaveBeenCalled();
-    global.requestAnimationFrame = requestAnimationFrame;
-    tree.unmount();
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('renders with undefined allPlateResults and photos', () => {

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -265,6 +265,43 @@ describe('Home', () => {
     tree.unmount();
   });
 
+  test('focuses the map search input when the SearchBox mounts', () => {
+    const { requestAnimationFrame } = global;
+    global.requestAnimationFrame = callback => callback();
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ homeRef });
+    });
+    const input = { focus: jest.fn() };
+    const searchBox = {
+      containerElement: { querySelector: () => input },
+    };
+
+    homeRef.current.handleSearchBoxMounted(searchBox);
+
+    expect(input.focus).toHaveBeenCalledTimes(1);
+    global.requestAnimationFrame = requestAnimationFrame;
+    tree.unmount();
+  });
+
+  test('ignores the null ref the SearchBox passes when unmounting', () => {
+    const { requestAnimationFrame } = global;
+    global.requestAnimationFrame = jest.fn();
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ homeRef });
+    });
+
+    homeRef.current.handleSearchBoxMounted(null);
+
+    expect(global.requestAnimationFrame).not.toHaveBeenCalled();
+    expect(homeRef.current.searchBox).toBeNull();
+    global.requestAnimationFrame = requestAnimationFrame;
+    tree.unmount();
+  });
+
   test('renders with undefined allPlateResults and photos', () => {
     const initialState = {
       email: 'test@example.com',

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -265,7 +265,7 @@ describe('Home', () => {
     tree.unmount();
   });
 
-  test('focuses the map search input when the SearchBox mounts', () => {
+  test('focuses the map search input when it mounts', () => {
     const { requestAnimationFrame } = global;
     global.requestAnimationFrame = callback => callback();
     let tree;
@@ -274,18 +274,15 @@ describe('Home', () => {
       tree = renderHome({ homeRef });
     });
     const input = { focus: jest.fn() };
-    const searchBox = {
-      containerElement: { querySelector: () => input },
-    };
 
-    homeRef.current.handleSearchBoxMounted(searchBox);
+    Home.handleSearchInputMounted(input);
 
     expect(input.focus).toHaveBeenCalledTimes(1);
     global.requestAnimationFrame = requestAnimationFrame;
     tree.unmount();
   });
 
-  test('ignores the null ref the SearchBox passes when unmounting', () => {
+  test('ignores the null ref the search input passes when unmounting', () => {
     const { requestAnimationFrame } = global;
     global.requestAnimationFrame = jest.fn();
     let tree;
@@ -294,10 +291,9 @@ describe('Home', () => {
       tree = renderHome({ homeRef });
     });
 
-    homeRef.current.handleSearchBoxMounted(null);
+    Home.handleSearchInputMounted(null);
 
     expect(global.requestAnimationFrame).not.toHaveBeenCalled();
-    expect(homeRef.current.searchBox).toBeNull();
     global.requestAnimationFrame = requestAnimationFrame;
     tree.unmount();
   });


### PR DESCRIPTION
Clicking the "Where:" button opens the map, but the search field still required
a separate click before typing. Focus the search input automatically so a query
can be typed immediately.

The fix passes a ref callback for the input through MyMapComponent to Home's
`handleSearchInputMounted`. The straightforward approaches don't work, for
reasons discovered while reproducing the issue in a real browser:

- `autoFocus` (and focusing when the ref fires) is a no-op: the SearchBox
  portal-renders the input into a detached container, and `focus()` on an element
  outside the document does nothing.
- Focusing one frame later is also too early: Google Maps only attaches the
  control containers to the page as the map finishes initializing (observed at
  ~2.4s in a headless Chromium), so the input can stay detached well past the
  first frame.
- Querying the SearchBox's container for the input finds nothing, because the
  SearchBox moves the input out of that container and into the map's controls —
  so the input is referenced directly instead.

`handleSearchInputMounted` therefore retries the focus every 100ms for up to
~4s, stopping once the focus sticks or the user starts interacting with
something else (buttons, inputs, or the map itself), so it never steals focus
back.

A previous iteration scheduled the focus from the SearchBox's ref callback, but
an inline callback is re-invoked with null on every re-render (and on unmount,
e.g. under HMR), which crashed. The handlers are stable/static now, and
null refs are ignored.

Tests: three unit tests cover focusing once the input is in the document,
retrying until the map attaches the input, and ignoring null refs. Verified
end-to-end with Playwright in a real Chromium: clicking "Where:" focuses the
search field and keystrokes land in it.