### PR TITLE
fix: render CSV download link only after mount

### DIFF
--- a/src/components/PreviousSubmissionsList.js
+++ b/src/components/PreviousSubmissionsList.js
@@ -7,13 +7,30 @@ const objectMap = (obj, fn) =>
   Object.fromEntries(Object.entries(obj).map(([k, v], i) => [k, fn(v, k, i)]));
 
 class PreviousSubmissionsList extends React.Component {
-  shouldComponentUpdate(nextProps) {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      // react-csv's CSVLink computes its href (a blob URL) during render on
+      // the client, so rendering it during SSR/hydration produces an href=""
+      // on the server and a blob: URL on the client, causing a hydration
+      // mismatch warning. Render it only after the component mounts.
+      isMounted: false,
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ isMounted: true });
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
     return (
       this.props.submissions !== nextProps.submissions ||
       this.props.onDeleteSubmission !== nextProps.onDeleteSubmission ||
       this.props.isLoading !== nextProps.isLoading ||
       this.props.hasLoadedPreviousSubmissions !==
-        nextProps.hasLoadedPreviousSubmissions
+        nextProps.hasLoadedPreviousSubmissions ||
+      this.state.isMounted !== nextState.isMounted
     );
   }
 
@@ -37,16 +54,18 @@ class PreviousSubmissionsList extends React.Component {
 
     return (
       <>
-        <CSVLink
-          separator="	"
-          data={submissions.map(submission =>
-            objectMap(submission, value =>
-              typeof value === 'object' ? JSON.stringify(value) : value,
-            ),
-          )}
-        >
-          Download as CSV
-        </CSVLink>
+        {this.state.isMounted && (
+          <CSVLink
+            separator="	"
+            data={submissions.map(submission =>
+              objectMap(submission, value =>
+                typeof value === 'object' ? JSON.stringify(value) : value,
+              ),
+            )}
+          >
+            Download as CSV
+          </CSVLink>
+        )}
         <ul>
           {submissions.map(submission => (
             <li key={submission.objectId}>

--- a/src/components/PreviousSubmissionsList.test.js
+++ b/src/components/PreviousSubmissionsList.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import ReactDOMServer from 'react-dom/server';
+import { CSVLink } from 'react-csv';
+import App from './App.js';
+import PreviousSubmissionsList from './PreviousSubmissionsList.js';
+
+describe('PreviousSubmissionsList', () => {
+  const props = {
+    isLoading: false,
+    hasLoadedPreviousSubmissions: true,
+    submissions: [
+      {
+        objectId: 'objectId',
+        reqnumber: 'reqnumber',
+        timeofreport: new Date(Date.now()).toISOString(),
+      },
+    ],
+    onDeleteSubmission: () => {},
+  };
+
+  const wrap = children => (
+    <App context={{ insertCss: () => {}, fetch: () => {}, pathname: '' }}>
+      {children}
+    </App>
+  );
+
+  test('does not render the CSV link on the server', () => {
+    // react-csv computes its href (a blob URL) only on the client, so it must
+    // not render during SSR or React warns about an href mismatch during
+    // hydration.
+    const html = ReactDOMServer.renderToString(
+      wrap(<PreviousSubmissionsList {...props} />),
+    );
+    expect(html).not.toContain('Download as CSV');
+  });
+
+  test('renders the CSV link after mounting on the client', () => {
+    const tree = renderer.create(wrap(<PreviousSubmissionsList {...props} />));
+    expect(tree.root.findAllByType(CSVLink)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
`react-csv`'s `CSVLink` computes its `href` (a blob URL) during render on the client, so it renders `href=""` during SSR and a `blob:` URL during the client's hydration render. React warns about the mismatch:

> Warning: Prop `href` did not match. Server: "" Client: "blob:..."

Gate the `CSVLink` behind an `isMounted` state flag set in `componentDidMount`, so the server and the client's initial render both omit the link and hydration matches. `shouldComponentUpdate` now also compares `isMounted` — its previous props-only comparison would have swallowed the mount state update and the link would never appear.

Alternatives considered and rejected:

- Rendering a placeholder anchor in the initial render would mean duplicating `react-csv`'s rendered attributes to match the server markup, so omitting the link until mount is simpler.

Tests: two new tests cover that the server HTML omits the link and that the mounted client render includes it.

Co-Authored-By: Claude Code with DeepSeek