### PR TITLE
test: remove vestigial @babel/polyfill import from SubmissionDetails.test.js

### DIFF
--- a/src/components/SubmissionDetails.test.js
+++ b/src/components/SubmissionDetails.test.js
@@ -1,4 +1,3 @@
-import '@babel/polyfill';
 import React from 'react';
 import renderer from 'react-test-renderer';
 import App from './App.js';


### PR DESCRIPTION
The import dated from May 2018 (https://github.com/josephfrazier/reported-web/commit/ff3ddf92fdb56698a03a5a733442a1e3ca7d89c5), when the Node/Jest of the time needed core-js 2 + regenerator-runtime to run the transpiled app code. `babel.config.js` now targets `node: 'current'`, and Jest 30 on Node 24 provides everything natively, so the import is a no-op for modern features.

Verified with the full test suite.

Co-Authored-By: Claude Code with DeepSeek