### PR TITLE
test: remove vestigial @babel/polyfill import from Home.test.js

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1249,6 +1249,12 @@ class Home extends React.Component {
               );
               return data.id;
             })();
+            // The submit handler awaits this promise (catching failures so
+            // it can fall back to sending the files directly), so it can sit
+            // unhandled until then. Attach a no-op catch so the test runner
+            // and the browser console don't flag the rejection in the
+            // meantime.
+            uploadPromise.catch(() => {});
             fileUploadPromises.set(attachmentFile, uploadPromise);
           }
         });

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -7,9 +7,10 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import '@babel/polyfill';
 import React from 'react';
 import renderer from 'react-test-renderer';
+// jsdom doesn't provide the setImmediate global, so use Node's directly.
+import { setImmediate } from 'timers';
 import StyleContext from 'isomorphic-style-loader/StyleContext';
 import axios from 'axios';
 import { toast } from 'react-toastify';


### PR DESCRIPTION
The import dated from May 2018 (https://github.com/josephfrazier/reported-web/commit/ff3ddf92fdb56698a03a5a733442a1e3ca7d89c5), when the Node/Jest of the
time needed core-js 2 + regenerator-runtime to run the transpiled app
code. `babel.config.js` now targets `node: 'current'`, and Jest 30 on
Node 24 provides everything natively, so the import is a no-op for
modern features.

Removing it exposed two things it was quietly providing:

- The test used the `setImmediate` global, which jsdom doesn't
  provide. It now imports `setImmediate` from `timers`, keeping Node's
  exact semantics.

- The background-upload promise in `Home.js` rejects as soon as its
  upload fails but is only awaited at submit time. core-js's Promise
  doesn't report unhandled rejections the way the native Promise does,
  so the polyfill was masking the rejection in tests - and the app
  itself never imports the polyfill, so a failed upload also logged
  "Uncaught (in promise)" in the browser console until submit. Attach
  a no-op catch when the promise is created to mark the rejection as
  handled.

Verified with the full suite and three repeat runs of the affected
suite.

Co-Authored-By: Claude Code with DeepSeek