### PR TITLE
fix: silence `React.createFactory()` deprecation warning

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -2905,6 +2905,17 @@ MyMapComponentPure.propTypes = {
   onPlacesChanged: PropTypes.func.isRequired,
 };
 
+// recompose@0.26.0 and react-google-maps@9.4.5 (both unmaintained) call
+// the deprecated `React.createFactory()` when the map HOCs are composed
+// below, logging a warning once per page load. React implements
+// `createFactory` as `createElement.bind(null, type)` plus the `.type`
+// property, so reimplement it here without the deprecation warning.
+React.createFactory = type => {
+  const factory = React.createElement.bind(null, type);
+  factory.type = type;
+  return factory;
+};
+
 const MyMapComponent = compose(
   withProps({
     googleMapURL: `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&v=3.exp&libraries=geometry,drawing,places`,


### PR DESCRIPTION
The app logs "Warning: `React.createFactory()` is deprecated and will
be removed in a future major release" once per page load. It fires when
`src/routes/home/Home.js` composes the reporting-form map, because
`recompose`'s `withProps` (via `mapProps`) and `react-google-maps`'
`withScriptjs`/`withGoogleMap` all build element factories with
`React.createFactory()` at HOC-application time, i.e. when the module
loads.

Both packages are unmaintained (2017/2018) and never released a
`createFactory`-free version, so the call sites can't be upgraded away,
and replacing the HOCs outright would mean reimplementing their
script-loading and map-mounting logic. Since the warning is dev-only,
this instead reimplements `createFactory` itself, minus the warning.
React defines it as `createElementWithValidation.bind(null, type)` and
also exposes the element type as `factory.type`, so

```js
React.createFactory = type => {
  const factory = React.createElement.bind(null, type);
  factory.type = type;
  return factory;
};
```

is behavior-identical in both dev and production builds. It runs
before the HOC composition below, so the deprecated implementation
(and its warning) is never reached in the browser, the SSR bundle, or
Jest.

Alternatives considered: patch-package patches to the two packages
(rejected as heavy machinery for a dev-only warning) and a local
reimplementation of the two HOCs (rejected as too much code).

Co-Authored-By: Claude Code with DeepSeek