### PR TITLE
fix: serve a stub source map for React DevTools' installHook.js

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -673,6 +673,23 @@ app.get('/api/submissions-in-polygon', (req, res) => {
 });
 
 //
+// Firefox with the React DevTools browser extension installed injects
+// `installHook.js` into the page, then tries to fetch the script's source
+// map relative to the page's origin (`/installHook.js.map`). Without this
+// route, that request falls through to the SSR catch-all below and gets a
+// 404 page, filling the browser console with:
+//   Source map error: Error: request failed with status 404
+// Serve a valid empty source map to silence it, as suggested in:
+// https://github.com/facebook/react/issues/32339
+// -----------------------------------------------------------------------------
+app.get('/installHook.js.map', (req, res) => {
+  res.type('application/json');
+  res.send(
+    '{"version":3,"file":"installHook.js","sources":["installHook.js"],"sourcesContent":[""],"mappings":""}',
+  );
+});
+
+//
 // Register server-side rendering middleware
 // -----------------------------------------------------------------------------
 app.get('*', async (req, res, next) => {

--- a/tools/test-dev-server-smoke.js
+++ b/tools/test-dev-server-smoke.js
@@ -110,6 +110,8 @@ const run = async () => {
     const home = await request(`${BASE_URL}/`);
     const favicon = await request(`${BASE_URL}/favicon.ico`);
     const submissionsMap = await request(`${BASE_URL}/submissions-map`);
+    const installHookMap = await request(`${BASE_URL}/installHook.js.map`);
+    const unknownPath = await request(`${BASE_URL}/this-page-does-not-exist`);
 
     // The SSR HTML references the client bundle compiled by
     // webpack-dev-middleware; request it to prove that middleware is
@@ -145,6 +147,30 @@ const run = async () => {
           submissionsMap.status === 200 &&
           submissionsMap.body.includes('id="tab-paste"'),
         detail: `status ${submissionsMap.status}, body starts: ${submissionsMap.body.slice(0, 80)}`,
+      },
+      {
+        // Firefox fetches this after the React DevTools extension injects
+        // `installHook.js` into the page; a 404 here spams the console with
+        // "Source map error: request failed with status 404".
+        // https://github.com/facebook/react/issues/32339
+        name: 'GET /installHook.js.map serves a stub source map',
+        ok:
+          installHookMap.status === 200 &&
+          (() => {
+            try {
+              return JSON.parse(installHookMap.body).version === 3;
+            } catch {
+              return false;
+            }
+          })(),
+        detail: `status ${installHookMap.status}, body starts: ${installHookMap.body.slice(0, 80)}`,
+      },
+      {
+        // Unknown paths must still 404 via the SSR catch-all, rather than
+        // being served the stub above.
+        name: 'unknown paths still 404 via the SSR catch-all',
+        ok: unknownPath.status === 404,
+        detail: `status ${unknownPath.status}`,
       },
       {
         name: 'GET of the client bundle in /assets/ is served by webpack-dev-middleware',


### PR DESCRIPTION
Firefox with the React DevTools browser extension installed injects
`installHook.js` into the page, then tries to fetch its source map from
the page's origin (`/installHook.js.map`). Without this route, that
request falls through to the SSR catch-all and gets the 404 page,
spamming the browser console with:

    Source map error: Error: request failed with status 404

https://github.com/facebook/react/issues/32339

Serve a valid empty source map at that path before the SSR catch-all
runs, in every environment — the same console error appears when
debugging the production site with the extension installed. Cover it
with the dev-server smoke test. The upstream workaround of dropping a
stub file into `public/` was rejected because a bare JSON file can't
carry the comment explaining why it exists.

Co-Authored-By: Claude Code with DeepSeek