### PR TITLE
fix: only preload scripts in production

### DIFF
--- a/src/components/Html.js
+++ b/src/components/Html.js
@@ -45,9 +45,10 @@ class Html extends React.Component {
           <meta name="description" content={description} />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="theme-color" content="#008000" />
-          {scripts.map(script => (
-            <link key={script} rel="preload" href={script} as="script" />
-          ))}
+          {process.env.NODE_ENV === 'production' &&
+            scripts.map(script => (
+              <link key={script} rel="preload" href={script} as="script" />
+            ))}
           <link rel="manifest" href="/site.webmanifest" />
           <link rel="apple-touch-icon" href="/icon.png" />
           {styles.map(style => (


### PR DESCRIPTION
Firefox warns "The resource at ... preloaded with link preload was not
used within a few seconds" for the route chunk scripts when running
`yarn start`. webpack-dev-middleware serves dev assets without cache
headers, so Firefox can't store the preloaded responses; when the
async chunks are later fetched by script tags (both the runtime-
injected ones and the SSR-rendered ones at the end of `<body>`), the
preload entries can't be reused and are reported as unused. In
production, express.static serves assets with ETags, so the preloads
are reusable and consumed there.

Since every script is also rendered as a parser-inserted `<script>`
tag, the preloads only provide a head start while the 155KB document
body is being parsed - which is meaningless on localhost - so render
the preload `<link>`s only in production, matching the existing
`process.env.NODE_ENV === 'production'` check for service worker
registration.

Verified with playwright against a local `yarn start`: Firefox emitted
the 4 warnings before the change and none after, while the production
render still includes the preload links.

Co-Authored-By: Claude Code with DeepSeek