### PR TITLE
fix: silence exifr "Critical dependency" HMR warning

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -270,6 +270,22 @@ const config = {
   // Don't attempt to continue if there are any errors.
   bail: !isDebug,
 
+  // exifr's UMD bundle contains a Node-only fallback that dynamically
+  // requires 'http'/'https' (guarded at runtime by `process.versions.node`,
+  // which is always false in the browser). Webpack's parser still flags the
+  // non-literal require() as a critical dependency, so `yarn start` logs
+  // "Critical dependency: the request of a dependency is an expression" on
+  // every (HMR) recompile. Silencing it here, scoped to that file, instead
+  // of switching to exifr's `lite` build, which can't parse the array form
+  // of `exifr.parse()` options that Home.js uses.
+  ignoreWarnings: [
+    {
+      module: /exifr[/\\]dist[/\\]full\.umd\.js/,
+      message:
+        /Critical dependency: the request of a dependency is an expression/,
+    },
+  ],
+
   cache: isDebug,
 
   // Specify what bundle information gets displayed


### PR DESCRIPTION
`yarn start` logs the following on every client recompile:

    WARNING in ./node_modules/exifr/dist/full.umd.js 1:585-595
    Critical dependency: the request of a dependency is an expression

The offending code is exifr's Node-only fallback that dynamically
`require()`s 'http'/'https' when `fetch` is unavailable. It's guarded at
runtime by a `process.versions.node` check that's always false in the
browser, so it's dead code there — webpack just can't statically resolve
the request, and flags it as critical.

Alternatives considered:
- Importing exifr's `lite` build instead (`full` includes the Node-only
  readers that carry the dynamic require): rejected because `lite`
  throws `undefined is not iterable` for the array form of
  `exifr.parse()` options that `src/routes/home/Home.js` uses
  (`['CreateDate', 'OffsetTimeDigitized']`), and it also lacks exifr's
  PNG parser, so eXIf metadata in PNG uploads would stop being read.
- `module.exprContextCritical: false`: rejected because it's a global
  switch that would hide genuine critical-dependency warnings elsewhere.
- A rule-level `parser.javascript.exprContextCritical: false` scoped to
  the file: rejected because webpack only honors that option at the
  top-level `module` config, not per rule.

So instead this adds an `ignoreWarnings` entry scoped to exifr's
full.umd.js and this specific message, leaving other warnings visible.

Co-Authored-By: Claude Code with DeepSeek