### PR TITLE
fix: close the map modal on Escape

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -817,6 +817,11 @@ class Home extends React.Component {
       return confirmationMessage; // Webkit, Safari, Chrome etc.
     });
 
+    // react-modal only handles Escape when focus is inside the modal
+    // content, but the map modal's Google Maps search box captures focus,
+    // so listen at the document level instead.
+    document.addEventListener('keydown', this.handleDocumentKeyDown);
+
     this.forceUpdate(); // force "Create/Edit User" fields to render persisted value after load
 
     if (this.state.isLoadPreviousSubmissionsEnabled) {
@@ -845,6 +850,10 @@ class Home extends React.Component {
         if (ref.current) ref.current.focus();
       });
     }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleDocumentKeyDown);
   }
 
   onDeleteSubmission = ({ objectId }) => {
@@ -1437,6 +1446,12 @@ class Home extends React.Component {
 
   closeAuthModal = () => {
     this.setState({ isAuthModalOpen: false, authError: null });
+  };
+
+  handleDocumentKeyDown = event => {
+    if (event.key === 'Escape' && this.state.isMapOpen) {
+      this.setState({ isMapOpen: false });
+    }
   };
 
   switchAuthTab = tab => {

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -266,6 +266,49 @@ describe('Home', () => {
     tree.unmount();
   });
 
+  test('closes the map modal on Escape', () => {
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+    };
+
+    const originalCreateObjectURL = global.URL.createObjectURL;
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ initialState, homeRef });
+    });
+    renderer.act(() => {
+      homeRef.current.setState({
+        attachmentData: [
+          new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+        ],
+        isMapOpen: true,
+      });
+    });
+
+    const closeButton = tree.root.findAll(
+      node => node.type === 'button' && node.props.children === 'Close',
+    );
+    expect(closeButton).toHaveLength(1);
+
+    renderer.act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(homeRef.current.state.isMapOpen).toBe(false);
+    expect(
+      tree.root.findAll(
+        node => node.type === 'button' && node.props.children === 'Close',
+      ),
+    ).toHaveLength(0);
+
+    tree.unmount();
+    global.URL.createObjectURL = originalCreateObjectURL;
+  });
+
   test('focuses the map search input once it is in the document', () => {
     jest.useFakeTimers();
     const input = document.createElement('input');


### PR DESCRIPTION
`react-modal` only handles Escape when focus is inside the modal content,
but the map modal's Google Maps search box captures focus (and the
"Where" button that opens it keeps focus outside the modal), so Escape
never reaches its `onKeyDown` handler. Listen for `keydown` at the
document level instead, and close the map modal on Escape when it is
open.

**Tried first:** `react-modal`'s `shouldCloseOnEsc`, which is already
the default but does not fire because its keydown listener is attached
to the modal content element rather than the document, so focus must
already be inside the modal. Since the Places autocomplete search box
takes focus once the map loads, a document-level listener was needed.

Co-Authored-By: Claude Code with DeepSeek