### PR TITLE
feat: select the plate under a click made before ALPR results arrive

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -768,6 +768,12 @@ class Home extends React.Component {
       submissions: [],
       addressProvenance: '',
 
+      // Per-attachment plate-recognizer responses, keyed by attachment name.
+      // The value is the response data, or null once the extraction has
+      // settled without results: the key's presence alone then says "no
+      // overlays will ever exist for this attachment", which stops clicks
+      // from being recorded (see handleAttachmentClick). A missing key means
+      // the extraction is still pending.
       plateDataByAttachmentName: {},
 
       isAuthModalOpen: false,
@@ -792,11 +798,6 @@ class Home extends React.Component {
     // keyed by attachment name, in the same percentage coordinates the
     // overlays use. See handleAttachmentClick/findPlateResultAtClick.
     this.pendingPlateClicks = {};
-    // Attachment names whose ALPR extraction has settled (success or
-    // failure). Once settled, further clicks are not recorded: either the
-    // overlays now handle their own clicks, or the extraction failed and
-    // overlays will never exist (see handleAttachmentClick).
-    this.settledAttachmentExtractions = new Set();
     this.plateLookupCache = new Map();
     this.plateRef = React.createRef();
     this.plateLabelRef = React.createRef();
@@ -1121,12 +1122,13 @@ class Home extends React.Component {
   // ignored: the former never produce overlays, a settled extraction either
   // already renders overlays (whose buttons select the plate themselves and,
   // as siblings of the <a> this handler lives on, don't reach it) or failed
-  // so overlays will never exist for this attachment.
+  // so overlays will never exist for this attachment. Both settled outcomes
+  // leave a key in plateDataByAttachmentName (the data, or null on failure),
+  // so the key's presence is the settled marker.
   handleAttachmentClick = ({ attachmentName, event }) => {
     if (
       !this.state.isAlprEnabled ||
-      this.state.plateDataByAttachmentName[attachmentName] ||
-      this.settledAttachmentExtractions.has(attachmentName)
+      this.state.plateDataByAttachmentName[attachmentName] !== undefined
     ) {
       return;
     }
@@ -1438,10 +1440,22 @@ class Home extends React.Component {
                   // failed/were empty so it never can be. Either way it must
                   // not leak into a later resolution.
                   delete this.pendingPlateClicks[attachmentFile.name];
-                  // No overlays will ever appear for this attachment if they
-                  // haven't already: stop recording clicks on it.
-                  this.settledAttachmentExtractions.add(attachmentFile.name);
-                  this.setState({ isAlprLoading: false });
+                  this.setState(state => ({
+                    isAlprLoading: false,
+                    // Mark the extraction settled even when it produced no
+                    // data: a null entry means "no overlays will ever exist
+                    // for this attachment", and its key's presence stops
+                    // clicks from being recorded. The success path above
+                    // stores the real data instead, so leave that in place.
+                    plateDataByAttachmentName: state.plateDataByAttachmentName[
+                      attachmentFile.name
+                    ]
+                      ? state.plateDataByAttachmentName
+                      : {
+                          ...state.plateDataByAttachmentName,
+                          [attachmentFile.name]: null,
+                        },
+                  }));
                 }),
               extractDate({
                 attachmentFile,
@@ -1761,7 +1775,8 @@ class Home extends React.Component {
     let bestPlateCropDataUrl = null;
     let bestResolution = -1;
     for (const data of Object.values(this.state.plateDataByAttachmentName)) {
-      for (const result of data.results || []) {
+      // Entries whose extraction settled without results are null.
+      for (const result of data?.results || []) {
         if (
           result.plate?.toUpperCase() === this.state.plate?.toUpperCase() &&
           result.plateCropDataUrl
@@ -2369,10 +2384,10 @@ class Home extends React.Component {
                       }));
                       // Pending clicks were recorded against attachments that
                       // no longer exist; a late-resolving extraction must not
-                      // select a plate from them. The settled markers go too,
-                      // so files re-added under the same names record clicks.
+                      // select a plate from them. (plateDataByAttachmentName
+                      // was reset above, so files re-added under the same
+                      // names record clicks.)
                       this.pendingPlateClicks = {};
-                      this.settledAttachmentExtractions.clear();
                       this.setLicensePlate({ plate: '', licenseState: 'NY' });
                       this.setCoords({
                         latitude: defaultLatitude,
@@ -2537,14 +2552,12 @@ class Home extends React.Component {
                                 onClick={() => {
                                   // A pending click on a deleted attachment
                                   // must not select a plate when that
-                                  // attachment's extraction resolves. The
-                                  // settled marker goes too, so a different
-                                  // file re-added under the same name still
+                                  // attachment's extraction resolves. Its
+                                  // plateDataByAttachmentName entry is
+                                  // omitted below, so a different file
+                                  // re-added under the same name still
                                   // records clicks.
                                   delete this.pendingPlateClicks[name];
-                                  this.settledAttachmentExtractions.delete(
-                                    name,
-                                  );
                                   this.setState(state => {
                                     const attachmentData =
                                       state.attachmentData.filter(

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -233,6 +233,81 @@ function getLicenseStateFromPlateResult(result) {
   }
 }
 
+// The overlay coordinates for a plate result, as percentages of the
+// attachment's rendered size, or null when the result/plate data lacks what
+// positioning needs. Shared between renderPlateOverlays (which positions the
+// overlay buttons) and findPlateResultAtClick (which hit-tests clicks that
+// were recorded before the overlays existed), so a pending click is matched
+// against exactly where the overlay would have been.
+//
+// `box` is in pixels of the image src/alpr.js uploaded to Plate
+// Recognizer, so `uploadWidth`/`uploadHeight` are the denominators that
+// turn it into a fraction of the picture. Percentages are
+// scale-invariant, so that fraction is right however large the browser
+// renders the original file -- do NOT reach for the <img>'s
+// naturalWidth/naturalHeight, which is the pre-downscale size.
+//
+// image_width/image_height are only a fallback for plate data cached
+// before uploadWidth existed. They are NOT interchangeable: Plate
+// Recognizer resizes uploads before processing and reports the resized
+// size (a 2048x2731 upload comes back as 1919x2560), so dividing by them
+// stretches every percentage ~6.7% down and to the right.
+function plateResultBoxPercentages({ result, attachmentPlateData }) {
+  const { box } = result;
+  const {
+    image_width: imageWidth,
+    image_height: imageHeight,
+    uploadWidth,
+    uploadHeight,
+  } = attachmentPlateData || {};
+  const boxWidth = uploadWidth || imageWidth;
+  const boxHeight = uploadHeight || imageHeight;
+  if (!box || !boxWidth || !boxHeight) {
+    return null;
+  }
+  const left = (box.xmin / boxWidth) * 100;
+  const top = (box.ymin / boxHeight) * 100;
+  const width = ((box.xmax - box.xmin) / boxWidth) * 100;
+  const height = ((box.ymax - box.ymin) / boxHeight) * 100;
+  return {
+    left,
+    top,
+    width,
+    height,
+    // The rendered overlay spans [left, left+width] x [top, top+height] of
+    // the wrapper, so hit-test against those bounds rather than recomputing
+    // the far edges from the raw box, which can differ by a float rounding
+    // from where the overlay actually renders.
+    right: left + width,
+    bottom: top + height,
+  };
+}
+
+// Find the detected plate whose overlay would cover a click at the given
+// percentage coordinates, matching how renderPlateOverlays positions them.
+// Overlays render in results order, so the LAST matching result is the one
+// drawn on top and the one an overlay click would have hit.
+function findPlateResultAtClick({ attachmentPlateData, click }) {
+  const { x, y } = click;
+  const matchingResults = (attachmentPlateData?.results || []).filter(
+    result => {
+      if (!result.plate) {
+        return false;
+      }
+      const boxPercentages = plateResultBoxPercentages({
+        result,
+        attachmentPlateData,
+      });
+      if (!boxPercentages) {
+        return false;
+      }
+      const { left, top, right, bottom } = boxPercentages;
+      return x >= left && x <= right && y >= top && y <= bottom;
+    },
+  );
+  return matchingResults[matchingResults.length - 1];
+}
+
 const urlRegex = /(https?:\/\/\S+)/;
 
 // Turn bare URLs in a string into clickable React <a> elements.
@@ -713,6 +788,15 @@ class Home extends React.Component {
     this.initialStatePerSubmission = initialStatePerSubmission;
     this.initialStatePersistent = initialStatePersistent;
     this.isDragging = false;
+    // Clicks on attachments recorded while their ALPR results are pending,
+    // keyed by attachment name, in the same percentage coordinates the
+    // overlays use. See handleAttachmentClick/findPlateResultAtClick.
+    this.pendingPlateClicks = {};
+    // Attachment names whose ALPR extraction has settled (success or
+    // failure). Once settled, further clicks are not recorded: either the
+    // overlays now handle their own clicks, or the extraction failed and
+    // overlays will never exist (see handleAttachmentClick).
+    this.settledAttachmentExtractions = new Set();
     this.plateLookupCache = new Map();
     this.plateRef = React.createRef();
     this.plateLabelRef = React.createRef();
@@ -985,29 +1069,12 @@ class Home extends React.Component {
 
   renderPlateOverlays = ({ attachmentPlateData }) =>
     attachmentPlateData?.results?.map(result => {
-      const { box } = result;
       const plate = result.plate?.toUpperCase();
-      // `box` is in pixels of the image src/alpr.js uploaded to Plate
-      // Recognizer, so `uploadWidth`/`uploadHeight` are the denominators that
-      // turn it into a fraction of the picture. Percentages are
-      // scale-invariant, so that fraction is right however large the browser
-      // renders the original file -- do NOT reach for the <img>'s
-      // naturalWidth/naturalHeight, which is the pre-downscale size.
-      //
-      // image_width/image_height are only a fallback for plate data cached
-      // before uploadWidth existed. They are NOT interchangeable: Plate
-      // Recognizer resizes uploads before processing and reports the resized
-      // size (a 2048x2731 upload comes back as 1919x2560), so dividing by them
-      // stretches every percentage ~6.7% down and to the right.
-      const {
-        image_width: imageWidth,
-        image_height: imageHeight,
-        uploadWidth,
-        uploadHeight,
-      } = attachmentPlateData;
-      const boxWidth = uploadWidth || imageWidth;
-      const boxHeight = uploadHeight || imageHeight;
-      if (!box || !plate || !boxWidth || !boxHeight) {
+      const boxPercentages = plateResultBoxPercentages({
+        result,
+        attachmentPlateData,
+      });
+      if (!boxPercentages || !plate) {
         return null;
       }
       const licenseState = getLicenseStateFromPlateResult(result);
@@ -1015,13 +1082,13 @@ class Home extends React.Component {
       return (
         <button
           type="button"
-          key={`${plate}-${box.xmin}-${box.ymin}`}
+          key={`${plate}-${result.box.xmin}-${result.box.ymin}`}
           className={homeStyles['plate-overlay']}
           style={{
-            left: `${(box.xmin / boxWidth) * 100}%`,
-            top: `${(box.ymin / boxHeight) * 100}%`,
-            width: `${((box.xmax - box.xmin) / boxWidth) * 100}%`,
-            height: `${((box.ymax - box.ymin) / boxHeight) * 100}%`,
+            left: `${boxPercentages.left}%`,
+            top: `${boxPercentages.top}%`,
+            width: `${boxPercentages.width}%`,
+            height: `${boxPercentages.height}%`,
           }}
           aria-label={`Select license plate ${plate}`}
           onClick={() => {
@@ -1043,6 +1110,37 @@ class Home extends React.Component {
         </button>
       );
     });
+
+  // A click on an attachment whose ALPR results aren't back yet can't hit an
+  // overlay, because overlays only exist once results arrive. Remember the
+  // click as a percentage of the attachment's rendered size, so that when
+  // results DO arrive, handleAttachmentData can select the plate under the
+  // click as if its overlay had already been there.
+  //
+  // Clicks when ALPR is disabled or the extraction has already settled are
+  // ignored: the former never produce overlays, a settled extraction either
+  // already renders overlays (whose buttons select the plate themselves and,
+  // as siblings of the <a> this handler lives on, don't reach it) or failed
+  // so overlays will never exist for this attachment.
+  handleAttachmentClick = ({ attachmentName, event }) => {
+    if (
+      !this.state.isAlprEnabled ||
+      this.state.plateDataByAttachmentName[attachmentName] ||
+      this.settledAttachmentExtractions.has(attachmentName)
+    ) {
+      return;
+    }
+
+    // Stop the surrounding <a href> from opening the attachment in a new
+    // tab: the click is an attempt to select a plate, not to view the file.
+    event.preventDefault();
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    this.pendingPlateClicks[attachmentName] = {
+      x: ((event.clientX - rect.left) / rect.width) * 100,
+      y: ((event.clientY - rect.top) / rect.height) * 100,
+    };
+  };
 
   setLicensePlate = ({ plate, licenseState }) => {
     licenseState = licenseState || this.state.licenseState; // eslint-disable-line no-param-reassign
@@ -1302,7 +1400,24 @@ class Home extends React.Component {
                 password: this.state.password,
               })
                 .then(result => {
-                  if (
+                  const pendingClick =
+                    this.pendingPlateClicks[attachmentFile.name];
+                  const clickedResult =
+                    pendingClick &&
+                    findPlateResultAtClick({
+                      attachmentPlateData: result.allPlateData,
+                      click: pendingClick,
+                    });
+                  if (clickedResult) {
+                    // The user clicked this attachment before its overlays
+                    // existed; select the plate they clicked on, as if they
+                    // had clicked its overlay.
+                    this.setLicensePlate({
+                      plate: clickedResult.plate?.toUpperCase(),
+                      licenseState:
+                        getLicenseStateFromPlateResult(clickedResult),
+                    });
+                  } else if (
                     this.state.plate === '' &&
                     document.activeElement !== this.plateRef.current
                   ) {
@@ -1319,6 +1434,13 @@ class Home extends React.Component {
                   }));
                 })
                 .finally(() => {
+                  // The pending click has been resolved, or the results
+                  // failed/were empty so it never can be. Either way it must
+                  // not leak into a later resolution.
+                  delete this.pendingPlateClicks[attachmentFile.name];
+                  // No overlays will ever appear for this attachment if they
+                  // haven't already: stop recording clicks on it.
+                  this.settledAttachmentExtractions.add(attachmentFile.name);
                   this.setState({ isAlprLoading: false });
                 }),
               extractDate({
@@ -2245,6 +2367,12 @@ class Home extends React.Component {
                         violationSummaryComponent: null,
                         reportDescription: '',
                       }));
+                      // Pending clicks were recorded against attachments that
+                      // no longer exist; a late-resolving extraction must not
+                      // select a plate from them. The settled markers go too,
+                      // so files re-added under the same names record clicks.
+                      this.pendingPlateClicks = {};
+                      this.settledAttachmentExtractions.clear();
                       this.setLicensePlate({ plate: '', licenseState: 'NY' });
                       this.setCoords({
                         latitude: defaultLatitude,
@@ -2354,6 +2482,12 @@ class Home extends React.Component {
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   style={{ display: 'block' }}
+                                  onClick={event =>
+                                    this.handleAttachmentClick({
+                                      attachmentName: name,
+                                      event,
+                                    })
+                                  }
                                 >
                                   {isImg ? (
                                     <img
@@ -2401,6 +2535,16 @@ class Home extends React.Component {
                                   background: 'white',
                                 }}
                                 onClick={() => {
+                                  // A pending click on a deleted attachment
+                                  // must not select a plate when that
+                                  // attachment's extraction resolves. The
+                                  // settled marker goes too, so a different
+                                  // file re-added under the same name still
+                                  // records clicks.
+                                  delete this.pendingPlateClicks[name];
+                                  this.settledAttachmentExtractions.delete(
+                                    name,
+                                  );
                                   this.setState(state => {
                                     const attachmentData =
                                       state.attachmentData.filter(

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -1675,13 +1675,12 @@ describe('Home', () => {
     });
 
     test('does not record clicks once the attachment has plate data', async () => {
-      const { homeRef, settleWithoutResults, cleanup } =
+      const { homeRef, deliverPlateData, cleanup } =
         renderWithPendingPlateData();
-      renderer.act(() => {
-        homeRef.current.setState({
-          plateDataByAttachmentName: { 'photo.jpg': makePlateData() },
-        });
-      });
+
+      // The extraction settles with results: the overlays are rendered now
+      // and handle their own clicks.
+      await deliverPlateData(makePlateData());
 
       const event = clickEvent({ x: 60, y: 90 });
       homeRef.current.handleAttachmentClick({
@@ -1689,11 +1688,9 @@ describe('Home', () => {
         event,
       });
 
-      // The overlays are rendered now and handle their own clicks.
       expect(event.preventDefault).not.toHaveBeenCalled();
       expect(homeRef.current.pendingPlateClicks).toEqual({});
 
-      await settleWithoutResults();
       await waitOutPlateLookups();
       cleanup();
     });
@@ -1701,7 +1698,8 @@ describe('Home', () => {
     test('does not record clicks after the attachment extraction has settled without results', async () => {
       const { homeRef, settleWithoutResults, cleanup } =
         renderWithPendingPlateData();
-      homeRef.current.settledAttachmentExtractions.add('photo.jpg');
+
+      await settleWithoutResults();
 
       const event = clickEvent({ x: 60, y: 90 });
       homeRef.current.handleAttachmentClick({
@@ -1714,7 +1712,6 @@ describe('Home', () => {
       expect(event.preventDefault).not.toHaveBeenCalled();
       expect(homeRef.current.pendingPlateClicks).toEqual({});
 
-      await settleWithoutResults();
       await waitOutPlateLookups();
       cleanup();
     });

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -1425,4 +1425,298 @@ describe('Home', () => {
       cleanup();
     });
   });
+
+  describe('clicking an attachment before its ALPR results arrive', () => {
+    // A click event on the attachment's <a>, at coordinates relative to a
+    // stand-in 400x200 rendered size.
+    const clickEvent = ({ x, y }) => ({
+      clientX: x,
+      clientY: y,
+      preventDefault: jest.fn(),
+      currentTarget: {
+        getBoundingClientRect: () => ({
+          left: 0,
+          top: 0,
+          width: 400,
+          height: 200,
+        }),
+      },
+    });
+
+    const makePlateData = () => ({
+      results: [
+        {
+          plate: 'abc123',
+          region: { code: 'us-ny' },
+          // 10%-30% x 40%-50% of the 1000x500 uploaded image.
+          box: { xmin: 100, ymin: 200, xmax: 300, ymax: 250 },
+        },
+      ],
+      uploadWidth: 1000,
+      uploadHeight: 500,
+    });
+
+    // Renders Home, adds photo.jpg, and holds the plate-recognition response
+    // open so the caller can click the attachment before the results arrive
+    // and then deliver them.
+    function renderWithPendingPlateData() {
+      const initialState = {
+        email: 'test@example.com',
+        loginSuccessful: true,
+      };
+
+      const originalCreateObjectURL = global.URL.createObjectURL;
+      global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+      let resolvePlateRecognizer;
+      let plateRecognizerCalled = false;
+      const plateRecognizerResponse = new Promise(resolve => {
+        resolvePlateRecognizer = resolve;
+      });
+
+      const axiosGet = jest.spyOn(axios, 'get').mockResolvedValue({ data: {} });
+      const axiosPost = jest.spyOn(axios, 'post').mockImplementation(url => {
+        if (url === '/platerecognizer') {
+          plateRecognizerCalled = true;
+          return plateRecognizerResponse;
+        }
+        return Promise.resolve({ data: { features: [{ properties: {} }] } });
+      });
+      const toastWarn = jest
+        .spyOn(toast, 'warn')
+        .mockImplementation(() => null);
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      let tree;
+      const homeRef = React.createRef();
+      renderer.act(() => {
+        tree = renderHome({ initialState, homeRef });
+      });
+
+      // Real image bytes, so detectFromBuffer classifies the file as an
+      // image and extractPlate proceeds to the plate-recognizer request.
+      // (Garbage bytes detect as text/plain, which extractPlate rejects
+      // before any request is made.)
+      const photo = new File(
+        [
+          Buffer.from(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+            'base64',
+          ),
+        ],
+        'photo.jpg',
+        { type: 'image/jpeg' },
+      );
+      renderer.act(() => {
+        // Don't await here: the extraction parks on the pending
+        // plate-recognizer response until deliverPlateData or
+        // settleWithoutResults runs.
+        homeRef.current.handleAttachmentData({ attachmentData: [photo] });
+      });
+
+      const attachmentLink = tree.root.findAllByProps({ href: 'blob:mock' })[0];
+
+      // handleAttachmentData's own promise settles before the extraction
+      // pipeline it starts in a setState callback does, so wait for the
+      // pipeline's end instead: the plate-recognizer request has been made
+      // and its results applied (isAlprLoading flips off in the pipeline's
+      // last step).
+      const awaitExtractionSettled = async (attempts = 0) => {
+        if (attempts >= 100) {
+          throw new Error('timed out waiting for extraction to settle');
+        }
+        if (plateRecognizerCalled && !homeRef.current.state.isAlprLoading) {
+          return;
+        }
+        await new Promise(resolve => setImmediate(resolve));
+        await awaitExtractionSettled(attempts + 1);
+      };
+
+      return {
+        homeRef,
+        clickAttachment: ({ x, y }) => {
+          const event = clickEvent({ x, y });
+          renderer.act(() => {
+            attachmentLink.props.onClick(event);
+          });
+          return event;
+        },
+        deliverPlateData: plateData =>
+          renderer.act(async () => {
+            resolvePlateRecognizer({ data: plateData });
+            await awaitExtractionSettled();
+          }),
+        // Settle the parked extraction with no detections (what a photo
+        // without a visible plate produces), so tests that don't exercise
+        // the results can finish without leaving it dangling.
+        settleWithoutResults: () =>
+          renderer.act(async () => {
+            resolvePlateRecognizer({ data: { results: [] } });
+            await awaitExtractionSettled();
+          }),
+        cleanup: () => {
+          tree.unmount();
+          axiosGet.mockRestore();
+          axiosPost.mockRestore();
+          toastWarn.mockRestore();
+          consoleError.mockRestore();
+          global.URL.createObjectURL = originalCreateObjectURL;
+        },
+      };
+    }
+
+    // Wait out the debounced vehicle/violation lookups that a plate
+    // selection schedules, so they don't fire against the real network
+    // after the mocks are restored.
+    const waitOutPlateLookups = () =>
+      renderer.act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 1100));
+      });
+
+    test('selects the plate under a click made before the results arrive', async () => {
+      const { homeRef, clickAttachment, deliverPlateData, cleanup } =
+        renderWithPendingPlateData();
+
+      const event = clickAttachment({ x: 60, y: 90 }); // 15%, 45% of the image
+      // The click interrupted the attachment's open-in-new-tab default and
+      // was recorded against the attachment's name.
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(homeRef.current.pendingPlateClicks['photo.jpg']).toEqual({
+        x: 15,
+        y: 45,
+      });
+
+      // The click is inside the single detected box, so its plate gets
+      // selected even though the user clicked before the overlay existed.
+      await deliverPlateData(makePlateData());
+
+      expect(homeRef.current.state.plate).toBe('ABC123');
+      expect(homeRef.current.state.licenseState).toBe('NY');
+      // The click was consumed, so it can't select the plate twice.
+      expect(homeRef.current.pendingPlateClicks['photo.jpg']).toBeUndefined();
+
+      await waitOutPlateLookups();
+      cleanup();
+    });
+
+    test('selects the clicked plate even when the auto-selection would have chosen a different one', async () => {
+      const { homeRef, clickAttachment, deliverPlateData, cleanup } =
+        renderWithPendingPlateData();
+
+      clickAttachment({ x: 60, y: 90 }); // 15%, 45% of the image
+
+      await deliverPlateData({
+        results: [
+          {
+            // The T######C plate extractPlate prefers to auto-select,
+            // positioned away from the click.
+            plate: 't123456c',
+            region: { code: 'us-ny' },
+            box: { xmin: 600, ymin: 600, xmax: 800, ymax: 800 },
+          },
+          {
+            // 10%-30% x 40%-50% of the 1000x1000 uploaded image: the plate
+            // under the click.
+            plate: 'abc123',
+            region: { code: 'us-ny' },
+            box: { xmin: 100, ymin: 400, xmax: 300, ymax: 500 },
+          },
+        ],
+        uploadWidth: 1000,
+        uploadHeight: 1000,
+      });
+
+      // The click wins over the auto-selected T######C plate.
+      expect(homeRef.current.state.plate).toBe('ABC123');
+      expect(homeRef.current.state.licenseState).toBe('NY');
+
+      await waitOutPlateLookups();
+      cleanup();
+    });
+
+    test('falls back to the default auto-selected plate when the click misses every overlay', async () => {
+      const { homeRef, clickAttachment, deliverPlateData, cleanup } =
+        renderWithPendingPlateData();
+
+      clickAttachment({ x: 160, y: 180 }); // 40%, 90% — outside the box
+
+      await deliverPlateData(makePlateData());
+
+      // No overlay would have covered the click, so the pre-existing
+      // behavior (select the first detected plate) still applies.
+      expect(homeRef.current.state.plate).toBe('ABC123');
+      expect(homeRef.current.pendingPlateClicks['photo.jpg']).toBeUndefined();
+
+      await waitOutPlateLookups();
+      cleanup();
+    });
+
+    test('does not record clicks when ALPR is disabled', async () => {
+      const { homeRef, cleanup } = renderWithPendingPlateData();
+      renderer.act(() => {
+        homeRef.current.setState({ isAlprEnabled: false });
+      });
+
+      const event = clickEvent({ x: 60, y: 90 });
+      homeRef.current.handleAttachmentClick({
+        attachmentName: 'photo.jpg',
+        event,
+      });
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(homeRef.current.pendingPlateClicks).toEqual({});
+
+      // The extraction skips the plate-recognizer request entirely (ALPR is
+      // off), so just wait out the pipeline and its debounces.
+      await waitOutPlateLookups();
+      cleanup();
+    });
+
+    test('does not record clicks once the attachment has plate data', async () => {
+      const { homeRef, settleWithoutResults, cleanup } =
+        renderWithPendingPlateData();
+      renderer.act(() => {
+        homeRef.current.setState({
+          plateDataByAttachmentName: { 'photo.jpg': makePlateData() },
+        });
+      });
+
+      const event = clickEvent({ x: 60, y: 90 });
+      homeRef.current.handleAttachmentClick({
+        attachmentName: 'photo.jpg',
+        event,
+      });
+
+      // The overlays are rendered now and handle their own clicks.
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(homeRef.current.pendingPlateClicks).toEqual({});
+
+      await settleWithoutResults();
+      await waitOutPlateLookups();
+      cleanup();
+    });
+
+    test('does not record clicks after the attachment extraction has settled without results', async () => {
+      const { homeRef, settleWithoutResults, cleanup } =
+        renderWithPendingPlateData();
+      homeRef.current.settledAttachmentExtractions.add('photo.jpg');
+
+      const event = clickEvent({ x: 60, y: 90 });
+      homeRef.current.handleAttachmentClick({
+        attachmentName: 'photo.jpg',
+        event,
+      });
+
+      // No overlays will ever exist for this attachment, so the click should
+      // keep its default behavior (opening the attachment in a new tab).
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(homeRef.current.pendingPlateClicks).toEqual({});
+
+      await settleWithoutResults();
+      await waitOutPlateLookups();
+      cleanup();
+    });
+  });
 });

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -1252,6 +1252,7 @@ exports[`Home renders submission form and Previous Submissions when logged in wi
               >
                 <a
                   href="blob:mock"
+                  onClick={[Function]}
                   rel="noopener noreferrer"
                   style={
                     {
@@ -1940,6 +1941,7 @@ exports[`Home renders with allPlateResults entry missing plate and photos 1`] = 
               >
                 <a
                   href="blob:mock"
+                  onClick={[Function]}
                   rel="noopener noreferrer"
                   style={
                     {
@@ -2628,6 +2630,7 @@ exports[`Home renders with undefined allPlateResults and photos 1`] = `
               >
                 <a
                   href="blob:mock"
+                  onClick={[Function]}
                   rel="noopener noreferrer"
                   style={
                     {


### PR DESCRIPTION
Users can now upload photos and immediately click a license plate to select it, without waiting for Plate Recognizer to finish. Previously, overlays only existed once the results arrived, so an early click just opened the image in a new tab.

How it works
- A click on an attachment whose extraction is still pending is recorded (in `handleAttachmentClick`) as a percentage of the rendered image, and `preventDefault()` stops the surrounding `<a>` from opening the file in a new tab mid-selection.
- When the results arrive, the recorded click is hit-tested against the detected plate boxes with the same math that renders the overlays (`plateResultBoxPercentages`, extracted from `renderPlateOverlays` so the two can't drift apart — including the `uploadWidth`/`image_width` fallback). The last matching result wins, mirroring how overlays stack.
- A matching click selects the plate exactly as an overlay click would, even when the auto-selection would have picked a different plate (e.g. the preferred T######C one). A click that misses every overlay falls back to the existing auto-selection. The pending click is consumed either way.
- Clicks stop being recorded once the extraction settles: either the overlays now exist and handle their own clicks, or the extraction failed and overlays will never exist.

Single structure for the extraction lifecycle
- `plateDataByAttachmentName` now doubles as the settled marker: an absent key means the extraction is pending, a data value renders the overlays, and a `null` value means the extraction settled without results. This replaces the separate `settledAttachmentExtractions` Set.
- `handleAttachmentClick` treats key presence as the settled marker (comparing against `undefined`, since `null` is falsy), `findMatchingPlateThumbnail` skips the `null` entries, and the delete/submit cleanups lose their Set operations.

Tests
- Five new tests in `Home.test.js` cover: a pre-results click selecting its plate, the clicked plate overriding the auto-selected one, falling back to auto-selection when the click misses, and clicks being ignored when ALPR is disabled or the extraction has settled (with or without results).

Tried and didn't work
- Recomputed the overlay's far edge from the raw box for hit-testing: float rounding differs from where the overlay actually renders, so the bounds are derived from the rendered left/top/width/height instead.
- Attached the click handler to the positioning wrapper `<div>`: fails jsx-a11y `click-events-have-key-events`/`no-static-element-interactions`, so it lives on the attachment's `<a>`, which is already keyboard-accessible.
- Used truthiness or the `in` operator for the settled key-presence check: `null` is falsy by design, and `in` would treat a file named "toString" as always settled via the prototype chain.
- Test files of garbage bytes detect as `text/plain`, making `extractPlate` bail before the plate-recognizer request, so the tests use a real 1×1 PNG.
- Awaiting `handleAttachmentData`'s own promise in tests: it settles before the extraction pipeline (which runs in a `setState` callback), so the tests wait for the pipeline's end state instead.

---

Commits at PR open:

* feat: select the plate under a click made before ALPR results arrive

  Users can now click a plate on a just-uploaded image while ALPR is still
  running. The click is recorded as a percentage of the rendered image, and
  when the results arrive it is hit-tested against the overlay boxes using the
  same math that renders them, selecting the matching plate as if its overlay
  had already been there — even when the auto-selection would have picked a
  different plate. A click that misses every overlay falls back to the existing
  auto-selection, clicks stop being recorded once an extraction settles (a
  failed extraction never produces overlays), and preventDefault keeps the
  image from opening in a new tab mid-selection.

  Tried and didn't work:
  - recomputing the overlay's far edge from the raw box for hit-testing: float
    rounding differs from where the overlay actually renders, so the bounds are
    derived from the rendered left/top/width/height instead
  - attaching the click handler to the positioning wrapper div: fails jsx-a11y
    click-events-have-key-events/no-static-element-interactions, so it lives on
    the attachment's <a>, which is already keyboard-accessible
  - test files of garbage bytes detect as text/plain, making extractPlate bail
    before the plate-recognizer request, so the new tests use a real 1x1 PNG
  - awaiting handleAttachmentData's own promise in tests: it settles before the
    extraction pipeline (which runs in a setState callback), so the tests wait
    for the pipeline's end state instead

  Co-Authored-By: Claude Code with DeepSeek

* refactor: fold the settled-extraction marker into plateDataByAttachmentName

  plateDataByAttachmentName and settledAttachmentExtractions tracked the same
  per-attachment extraction lifecycle from two places. The Set existed only so
  clicks on attachments whose extraction settled without results could be
  distinguished from attachments whose extraction is still pending. Instead,
  plateDataByAttachmentName now uses a null value as the settled-without-
  results marker: an absent key means the extraction is pending, a data value
  renders the overlays, and null means no overlays will ever exist.
  handleAttachmentClick treats the key's presence as the settled marker,
  findMatchingPlateThumbnail skips the null entries, and the delete/submit
  cleanups lose their Set operations, since removing the key or resetting the
  map clears both meanings.

  Tried and didn't work:
  - truthiness as the settled check: null is falsy by design, so the guard
    compares against undefined instead
  - the `in` operator for the key-presence check: a file named "toString"
    would always appear settled via the prototype chain

  Co-Authored-By: Claude Code with DeepSeek