### PR TITLE
fix: tie-break previous submissions by when they were submitted

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -237,7 +237,12 @@ async function getSubmissions(req) {
     emailQuery.limit(Number.MAX_SAFE_INTEGER);
 
     const query = Parse.Query.or(usernameQuery, emailQuery);
-    query.descending('timeofreport');
+    // Sort by when the photo was taken (timeofreport), newest first, and break
+    // ties by when the submission was created (createdAt), newest first, so a
+    // later submission appears before an earlier one with the same photo
+    // timestamp. NOTE: ParseQuery.descending() resets _order each call, so both
+    // keys must be passed together.
+    query.descending(['timeofreport', 'createdAt']);
     query.limit(Number.MAX_SAFE_INTEGER);
     return query.find();
   });


### PR DESCRIPTION
The previous-submissions list is sorted by `timeofreport` (photo timestamp)
descending, but submissions whose photos share a timestamp appeared in an
unspecified order (e.g. two photos both taken at 2:58:00 PM). Sort by
`timeofreport` first, then by `createdAt` (when the submission was created),
both newest-first, so the most recently submitted one always comes first
among ties.

Tried first: chaining `descending('timeofreport').descending('createdAt')` —
but ParseQuery.descending() resets the query's `_order` on each call, so the
second call alone would have dropped the timeofreport key entirely. Both keys
are therefore passed in a single `descending([...])` call; verified against
both node and browser builds of parse@2.10.0 that `_order` becomes
`["-timeofreport","-createdAt"]`.

Co-Authored-By: Claude Code with DeepSeek