### PR TITLE
fix: lint only git-tracked files in lint-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     }
   },
   "scripts": {
-    "lint-js": "eslint --cache --ignore-pattern \"!**/.*\" .",
+    "lint-js": "eslint --cache $(git ls-files '*.js')",
     "lint-css": "stylelint \"src/**/*.{css,less,styl,scss,sass,sss}\"",
     "lint": "yarn run lint-js && yarn run lint-css",
     "fix-js": "yarn run lint-js --fix",


### PR DESCRIPTION
`eslint ... .` lints every .js file in the working tree, so untracked
scratch files (e.g. reported-google-apps-script.js) break `yarn lint-js`
even though they aren't part of the project. Feed eslint the git-tracked
files instead: `eslint --cache $(git ls-files '*.js')`.

Removing the `.` alone doesn't work: with no file arguments ESLint falls
back to linting the current directory, so it still reads the untracked
file. Dropping `--ignore-pattern "!**/.*"` is safe because explicitly
passed paths bypass ESLint's default dotfile ignoring, and the root
config files (.eslintrc.js, .prettierrc.js, .stylelintrc.js) are
included by `git ls-files '*.js'`. This also means `$(...)` is only
portable to POSIX shells, but CI (ubuntu) and local dev (macOS) both
run sh.

Verified: lint-js exits 0 with the untracked files present, an
untracked file with a parse error inside src/ is skipped, a parse error
in a tracked file still fails, and yarn fix-js (--fix appended after the
file list) still works.

Co-Authored-By: Claude Code with DeepSeek