### PR TITLE
Move preference settings out of the submission form into Edit Profile and a new Preferences panel

### DIFF
--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1840,6 +1840,18 @@ class Home extends React.Component {
                     by phone.
                   </label>
 
+                  <label htmlFor="can_be_shared_publicly">
+                    <input
+                      id="can_be_shared_publicly"
+                      type="checkbox"
+                      checked={this.state.can_be_shared_publicly}
+                      name="can_be_shared_publicly"
+                      onChange={this.handleInputChange}
+                    />{' '}
+                    Allow the photos/videos, description, category, and location
+                    to be publicly displayed
+                  </label>
+
                   <h3>Preferences</h3>
 
                   <label htmlFor="isAlprEnabled">
@@ -1862,18 +1874,6 @@ class Home extends React.Component {
                       onChange={this.handleInputChange}
                     />{' '}
                     Automatically read addresses from pictures/videos
-                  </label>
-
-                  <label htmlFor="can_be_shared_publicly">
-                    <input
-                      id="can_be_shared_publicly"
-                      type="checkbox"
-                      checked={this.state.can_be_shared_publicly}
-                      name="can_be_shared_publicly"
-                      onChange={this.handleInputChange}
-                    />{' '}
-                    Allow the photos/videos, description, category, and location
-                    to be publicly displayed
                   </label>
 
                   <label htmlFor="isLoadPreviousSubmissionsEnabled">

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -698,6 +698,7 @@ class Home extends React.Component {
       isAuthModalOpen: false,
       authModalTab: 'login',
       isEditProfileOpen: false,
+      isPreferencesOpen: false,
       authError: null,
     };
 
@@ -1551,6 +1552,7 @@ class Home extends React.Component {
         testify: false,
         submissions: [],
         isEditProfileOpen: false,
+        isPreferencesOpen: false,
         hasLoadedPreviousSubmissions: false,
         loginSuccessful: false,
       },
@@ -1750,10 +1752,23 @@ class Home extends React.Component {
                       onClick={() =>
                         this.setState(state => ({
                           isEditProfileOpen: !state.isEditProfileOpen,
+                          isPreferencesOpen: false,
                         }))
                       }
                     >
                       {this.state.isEditProfileOpen ? 'Cancel' : 'Edit Profile'}
+                    </button>
+                    <button
+                      type="button"
+                      className={homeStyles['status-bar-btn']}
+                      onClick={() =>
+                        this.setState(state => ({
+                          isPreferencesOpen: !state.isPreferencesOpen,
+                          isEditProfileOpen: false,
+                        }))
+                      }
+                    >
+                      {this.state.isPreferencesOpen ? 'Cancel' : 'Preferences'}
                     </button>
                     <button
                       type="button"
@@ -1852,41 +1867,6 @@ class Home extends React.Component {
                     to be publicly displayed
                   </label>
 
-                  <h3>Preferences</h3>
-
-                  <label htmlFor="isAlprEnabled">
-                    <input
-                      id="isAlprEnabled"
-                      type="checkbox"
-                      checked={this.state.isAlprEnabled}
-                      name="isAlprEnabled"
-                      onChange={this.handleInputChange}
-                    />{' '}
-                    Automatically read license plates from pictures/videos
-                  </label>
-
-                  <label htmlFor="isReverseGeocodingEnabled">
-                    <input
-                      id="isReverseGeocodingEnabled"
-                      type="checkbox"
-                      checked={this.state.isReverseGeocodingEnabled}
-                      name="isReverseGeocodingEnabled"
-                      onChange={this.handleInputChange}
-                    />{' '}
-                    Automatically read addresses from pictures/videos
-                  </label>
-
-                  <label htmlFor="isLoadPreviousSubmissionsEnabled">
-                    <input
-                      id="isLoadPreviousSubmissionsEnabled"
-                      type="checkbox"
-                      checked={this.state.isLoadPreviousSubmissionsEnabled}
-                      name="isLoadPreviousSubmissionsEnabled"
-                      onChange={this.handleInputChange}
-                    />{' '}
-                    Load previous submissions on page load
-                  </label>
-
                   <button
                     type="submit"
                     className={homeStyles['auth-submit-btn']}
@@ -1897,6 +1877,49 @@ class Home extends React.Component {
                   </button>
                 </fieldset>
               </form>
+            )}
+
+            {/* Preferences (shown inline when toggled). Unlike the Edit
+                Profile form above, nothing here needs saving: these toggles
+                affect only how the page behaves, not what is submitted, so
+                they persist to the cookie as they change. */}
+            {this.state.isPreferencesOpen && (
+              <div className={homeStyles['edit-profile-section']}>
+                <h3>Preferences</h3>
+
+                <label htmlFor="isAlprEnabled">
+                  <input
+                    id="isAlprEnabled"
+                    type="checkbox"
+                    checked={this.state.isAlprEnabled}
+                    name="isAlprEnabled"
+                    onChange={this.handleInputChange}
+                  />{' '}
+                  Automatically read license plates from pictures/videos
+                </label>
+
+                <label htmlFor="isReverseGeocodingEnabled">
+                  <input
+                    id="isReverseGeocodingEnabled"
+                    type="checkbox"
+                    checked={this.state.isReverseGeocodingEnabled}
+                    name="isReverseGeocodingEnabled"
+                    onChange={this.handleInputChange}
+                  />{' '}
+                  Automatically read addresses from pictures/videos
+                </label>
+
+                <label htmlFor="isLoadPreviousSubmissionsEnabled">
+                  <input
+                    id="isLoadPreviousSubmissionsEnabled"
+                    type="checkbox"
+                    checked={this.state.isLoadPreviousSubmissionsEnabled}
+                    name="isLoadPreviousSubmissionsEnabled"
+                    onChange={this.handleInputChange}
+                  />{' '}
+                  Load previous submissions on page load
+                </label>
+              </div>
             )}
 
             {/* Auth Modal */}
@@ -2184,612 +2207,620 @@ class Home extends React.Component {
                 </p>
               </div>
             )}
-            {this.isLoggedIn() && !this.state.isEditProfileOpen && (
-              <form
-                onSubmit={async e => {
-                  e.preventDefault();
+            {this.isLoggedIn() &&
+              !this.state.isEditProfileOpen &&
+              !this.state.isPreferencesOpen && (
+                <form
+                  onSubmit={async e => {
+                    e.preventDefault();
 
-                  if (
-                    this.state.latitude === defaultLatitude &&
-                    this.state.longitude === defaultLongitude
-                  ) {
-                    Home.notifyError(
-                      'Please provide the location of the incident',
-                    );
-                    return;
-                  }
-
-                  this.setState({
-                    isSubmitting: true,
-                  });
-
-                  // Collect pre-uploaded IDs for all attachment files
-                  const attachmentIds = await Promise.all(
-                    this.state.attachmentData.map(async file => {
-                      const uploadPromise = fileUploadPromises.get(file);
-                      if (!uploadPromise) return null;
-                      try {
-                        return await uploadPromise;
-                      } catch (_err) {
-                        console.error(
-                          'Background attachment upload failed:',
-                          _err,
-                        );
-                        return null;
-                      }
-                    }),
-                  );
-                  const hasAllIds =
-                    attachmentIds.length > 0 &&
-                    attachmentIds.every(id => id !== null);
-
-                  axios
-                    .post(
-                      '/submit',
-                      serialize(
-                        hasAllIds
-                          ? {
-                              ...this.getPerSubmissionState(),
-                              attachmentIds: JSON.stringify(attachmentIds),
-                              CreateDate: new Date(
-                                this.state.CreateDate,
-                              ).toISOString(),
-                            }
-                          : {
-                              ...this.getPerSubmissionState(),
-                              attachmentData: this.state.attachmentData,
-                              CreateDate: new Date(
-                                this.state.CreateDate,
-                              ).toISOString(),
-                            },
-                        { allowEmptyArrays: true },
-                      ),
-                      {
-                        onUploadProgress: progressEvent => {
-                          const {
-                            loaded: submitProgressValue,
-                            total: submitProgressMax,
-                          } = progressEvent;
-
-                          this.setState({
-                            submitProgressValue,
-                            submitProgressMax,
-                          });
-                        },
-
-                        onDownloadProgress: progressEvent => {
-                          const {
-                            loaded: submitProgressValue,
-                            total: submitProgressMax,
-                          } = progressEvent;
-
-                          this.setState({
-                            submitProgressValue,
-                            submitProgressMax,
-                          });
-                        },
-                      },
-                    )
-                    .then(({ data }) => {
-                      const { submission } = data;
-                      document.querySelector(`.${homeStyles.root}`).scrollTo({
-                        top: 100,
-                        left: 100,
-                        behavior: 'smooth',
-                      });
-                      console.info(
-                        `submitted successfully. Returned data: ${JSON.stringify(
-                          data,
-                          null,
-                          2,
-                        )}`,
+                    if (
+                      this.state.latitude === defaultLatitude &&
+                      this.state.longitude === defaultLongitude
+                    ) {
+                      Home.notifyError(
+                        'Please provide the location of the incident',
                       );
-                      this.setState(state => ({
-                        attachmentData: [],
-                        submissions: [submission].concat(state.submissions),
-                        allPlateData: null,
-                        plateDataByAttachmentName: {},
-                        vehicleInfoComponent: null,
-                        violationSummaryComponent: null,
-                        reportDescription: '',
-                      }));
-                      this.setLicensePlate({ plate: '', licenseState: 'NY' });
-                      this.setCoords({
-                        latitude: defaultLatitude,
-                        longitude: defaultLongitude,
-                      });
-                      Home.notifySuccess(
-                        <React.Fragment>
-                          <p>Thanks for your submission!</p>
-                          <p>
-                            Your information has been submitted to Reported. It
-                            may take up to 24 hours for it to be processed.
-                          </p>
+                      return;
+                    }
 
-                          {/*
+                    this.setState({
+                      isSubmitting: true,
+                    });
+
+                    // Collect pre-uploaded IDs for all attachment files
+                    const attachmentIds = await Promise.all(
+                      this.state.attachmentData.map(async file => {
+                        const uploadPromise = fileUploadPromises.get(file);
+                        if (!uploadPromise) return null;
+                        try {
+                          return await uploadPromise;
+                        } catch (_err) {
+                          console.error(
+                            'Background attachment upload failed:',
+                            _err,
+                          );
+                          return null;
+                        }
+                      }),
+                    );
+                    const hasAllIds =
+                      attachmentIds.length > 0 &&
+                      attachmentIds.every(id => id !== null);
+
+                    axios
+                      .post(
+                        '/submit',
+                        serialize(
+                          hasAllIds
+                            ? {
+                                ...this.getPerSubmissionState(),
+                                attachmentIds: JSON.stringify(attachmentIds),
+                                CreateDate: new Date(
+                                  this.state.CreateDate,
+                                ).toISOString(),
+                              }
+                            : {
+                                ...this.getPerSubmissionState(),
+                                attachmentData: this.state.attachmentData,
+                                CreateDate: new Date(
+                                  this.state.CreateDate,
+                                ).toISOString(),
+                              },
+                          { allowEmptyArrays: true },
+                        ),
+                        {
+                          onUploadProgress: progressEvent => {
+                            const {
+                              loaded: submitProgressValue,
+                              total: submitProgressMax,
+                            } = progressEvent;
+
+                            this.setState({
+                              submitProgressValue,
+                              submitProgressMax,
+                            });
+                          },
+
+                          onDownloadProgress: progressEvent => {
+                            const {
+                              loaded: submitProgressValue,
+                              total: submitProgressMax,
+                            } = progressEvent;
+
+                            this.setState({
+                              submitProgressValue,
+                              submitProgressMax,
+                            });
+                          },
+                        },
+                      )
+                      .then(({ data }) => {
+                        const { submission } = data;
+                        document.querySelector(`.${homeStyles.root}`).scrollTo({
+                          top: 100,
+                          left: 100,
+                          behavior: 'smooth',
+                        });
+                        console.info(
+                          `submitted successfully. Returned data: ${JSON.stringify(
+                            data,
+                            null,
+                            2,
+                          )}`,
+                        );
+                        this.setState(state => ({
+                          attachmentData: [],
+                          submissions: [submission].concat(state.submissions),
+                          allPlateData: null,
+                          plateDataByAttachmentName: {},
+                          vehicleInfoComponent: null,
+                          violationSummaryComponent: null,
+                          reportDescription: '',
+                        }));
+                        this.setLicensePlate({ plate: '', licenseState: 'NY' });
+                        this.setCoords({
+                          latitude: defaultLatitude,
+                          longitude: defaultLongitude,
+                        });
+                        Home.notifySuccess(
+                          <React.Fragment>
+                            <p>Thanks for your submission!</p>
+                            <p>
+                              Your information has been submitted to Reported.
+                              It may take up to 24 hours for it to be processed.
+                            </p>
+
+                            {/*
                         <p>objectId: {data.submission.objectId}</p>
                         */}
-                        </React.Fragment>,
-                      );
-                    })
-                    .catch(Home.handleAxiosError)
-                    .then(() => {
-                      this.setState({
-                        isSubmitting: false,
-                        submitProgressValue: null,
-                        submitProgressMax: null,
+                          </React.Fragment>,
+                        );
+                      })
+                      .catch(Home.handleAxiosError)
+                      .then(() => {
+                        this.setState({
+                          isSubmitting: false,
+                          submitProgressValue: null,
+                          submitProgressMax: null,
+                        });
+                      })
+                      .then(() => {
+                        this.savePersistentStateToCookie();
                       });
-                    })
-                    .then(() => {
-                      this.savePersistentStateToCookie();
-                    });
-                }}
-              >
-                <fieldset disabled={this.state.isSubmitting}>
-                  <FileReaderInput
-                    multiple
-                    as="buffer"
-                    onChange={this.handleAttachmentInput}
-                    style={{
-                      float: 'left',
-                      margin: '1px',
-                    }}
-                  >
-                    <button type="button" style={{ whiteSpace: 'wrap' }}>
-                      Add pictures/videos (up to 3 each, 20MB max each)
-                    </button>
-                  </FileReaderInput>
+                  }}
+                >
+                  <fieldset disabled={this.state.isSubmitting}>
+                    <FileReaderInput
+                      multiple
+                      as="buffer"
+                      onChange={this.handleAttachmentInput}
+                      style={{
+                        float: 'left',
+                        margin: '1px',
+                      }}
+                    >
+                      <button type="button" style={{ whiteSpace: 'wrap' }}>
+                        Add pictures/videos (up to 3 each, 20MB max each)
+                      </button>
+                    </FileReaderInput>
 
-                  <div style={{ clear: 'both' }} />
+                    <div style={{ clear: 'both' }} />
 
-                  {this.state.attachmentData.length > 0 && (
-                    <React.Fragment>
-                      <div
-                        style={{
-                          display: 'flex',
-                          flexWrap: 'wrap',
-                        }}
-                      >
-                        {this.state.attachmentData.map(attachmentFile => {
-                          const { name } = attachmentFile;
-                          const ext = fileExtension(name);
-                          const isImg = isImage({ ext });
-                          const src = getBlobUrl(attachmentFile);
-                          const attachmentPlateData =
-                            this.state.plateDataByAttachmentName[name];
-
-                          return (
-                            <div
-                              key={name}
-                              style={{
-                                width: '33%',
-                                margin: '0.1%',
-                                flexGrow: 1,
-                                position: 'relative',
-                              }}
-                            >
-                              <div
-                                style={{
-                                  position: 'relative',
-                                  display: 'inline-block',
-                                  maxWidth: '100%',
-                                }}
-                              >
-                                <a
-                                  href={src}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  style={{ display: 'block' }}
-                                >
-                                  {isImg ? (
-                                    <img
-                                      src={src}
-                                      alt={name}
-                                      style={{ display: 'block' }}
-                                    />
-                                  ) : (
-                                    /* eslint-disable-next-line jsx-a11y/media-has-caption */
-                                    <video
-                                      src={src}
-                                      alt={name}
-                                      // The position:relative wrapper shrink-
-                                      // wraps its content, and plate overlays
-                                      // are percentage-positioned against that
-                                      // wrapper, so the video must fill it
-                                      // exactly like the img above does:
-                                      // display:block closes the inline
-                                      // baseline gap, and max-width:100%
-                                      // (which marx-css gives img but not
-                                      // video) keeps the video from
-                                      // overflowing the wrapper when it is
-                                      // wider than the container.
-                                      style={{
-                                        display: 'block',
-                                        maxWidth: '100%',
-                                      }}
-                                    />
-                                  )}
-                                </a>
-                                {this.renderPlateOverlays({
-                                  attachmentPlateData,
-                                })}
-                              </div>
-
-                              <button
-                                type="button"
-                                style={{
-                                  position: 'absolute',
-                                  top: 0,
-                                  right: 0,
-                                  padding: 0,
-                                  margin: '1px',
-                                  color: 'red', // Ubuntu Chrome shows black otherwise
-                                  background: 'white',
-                                }}
-                                onClick={() => {
-                                  this.setState(state => {
-                                    const attachmentData =
-                                      state.attachmentData.filter(
-                                        file => file.name !== name,
-                                      );
-                                    if (attachmentData.length === 0) {
-                                      this.setCoords({
-                                        latitude: defaultLatitude,
-                                        longitude: defaultLongitude,
-                                      });
-                                      this.setCreateDate({
-                                        millisecondsSinceEpoch: Date.now(),
-                                      });
-                                      return {
-                                        attachmentData,
-                                        plate: '',
-                                        licenseState: 'NY',
-                                        allPlateData: null,
-                                        plateDataByAttachmentName: {},
-                                        vehicleInfoComponent: null,
-                                        violationSummaryComponent: null,
-                                      };
-                                    }
-                                    return {
-                                      attachmentData,
-                                      plateDataByAttachmentName: omit(
-                                        state.plateDataByAttachmentName,
-                                        name,
-                                      ),
-                                    };
-                                  });
-                                }}
-                              >
-                                <span
-                                  role="img"
-                                  aria-label="Delete photo/video"
-                                >
-                                  ❌
-                                </span>
-                              </button>
-                            </div>
-                          );
-                        })}
-                      </div>
-
-                      <label htmlFor="plate" ref={this.plateLabelRef}>
-                        License/Medallion:
-                        {this.state.isAlprLoading && (
-                          <CircularProgress size="1em" />
-                        )}
+                    {this.state.attachmentData.length > 0 && (
+                      <React.Fragment>
                         <div
                           style={{
                             display: 'flex',
                             flexWrap: 'wrap',
-                            alignItems: 'flex-start',
-                            gap: '0.5rem',
                           }}
                         >
-                          <div style={{ minWidth: 0, flex: 1 }}>
-                            <input
-                              required
-                              type="search"
-                              value={this.state.plate}
-                              name="plate"
-                              list="plateSuggestions"
-                              autoComplete="off"
-                              ref={this.plateRef}
-                              placeholder={this.state.allPlateData?.results?.[0]?.plate?.toUpperCase()}
-                              onChange={event => {
-                                const plate = upperCaseInputValueInPlace(
-                                  event.target,
-                                );
-                                const matchedResult =
-                                  this.state.allPlateData?.results?.find(
-                                    r => r.plate?.toUpperCase() === plate,
-                                  );
-                                const licenseState = matchedResult
-                                  ? getLicenseStateFromPlateResult(
-                                      matchedResult,
-                                    )
-                                  : null;
-                                this.setLicensePlate({ plate, licenseState });
-                              }}
-                            />
-                            <datalist id="plateSuggestions">
-                              {this.state.allPlateData?.results?.map(result => (
-                                <option value={result.plate?.toUpperCase()} />
-                              ))}
-                            </datalist>
-                            <select
-                              style={{
-                                marginTop: '0.5rem',
-                              }}
-                              value={this.state.licenseState}
-                              name="licenseState"
-                              onChange={event => {
-                                this.setLicensePlate({
-                                  plate: this.state.plate,
-                                  licenseState: event.target.value,
-                                });
-                              }}
-                            >
-                              {Object.entries(usStateNames)
-                                .sort(([, name1], [, name2]) =>
-                                  name1
-                                    .toUpperCase()
-                                    .localeCompare(name2.toUpperCase()),
-                                )
-                                .map(([abbr, name]) => (
-                                  <option key={abbr} value={abbr}>
-                                    {name}
-                                  </option>
-                                ))}
-                            </select>
-                          </div>
-                          {matchingPlateThumbnail && (
-                            <img
-                              src={matchingPlateThumbnail}
-                              alt="Detected license plate"
-                              style={{
-                                maxHeight: '5rem',
-                                maxWidth: '12rem',
-                                objectFit: 'contain',
-                              }}
-                            />
-                          )}
-                        </div>
-                        <div>{this.state.violationSummaryComponent}</div>
-                        <div>{this.state.vehicleInfoComponent}</div>
-                      </label>
+                          {this.state.attachmentData.map(attachmentFile => {
+                            const { name } = attachmentFile;
+                            const ext = fileExtension(name);
+                            const isImg = isImage({ ext });
+                            const src = getBlobUrl(attachmentFile);
+                            const attachmentPlateData =
+                              this.state.plateDataByAttachmentName[name];
 
-                      <label htmlFor="typeofcomplaint">
-                        Type:{' '}
-                        <select
-                          value={this.state.typeofcomplaint}
-                          name="typeofcomplaint"
-                          onChange={this.handleInputChange}
-                        >
-                          {this.props.typeofcomplaintValues.map(
-                            typeofcomplaint => (
-                              <option
-                                key={typeofcomplaint}
-                                value={typeofcomplaint}
+                            return (
+                              <div
+                                key={name}
+                                style={{
+                                  width: '33%',
+                                  margin: '0.1%',
+                                  flexGrow: 1,
+                                  position: 'relative',
+                                }}
                               >
-                                {typeofcomplaint}
-                              </option>
-                            ),
+                                <div
+                                  style={{
+                                    position: 'relative',
+                                    display: 'inline-block',
+                                    maxWidth: '100%',
+                                  }}
+                                >
+                                  <a
+                                    href={src}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    style={{ display: 'block' }}
+                                  >
+                                    {isImg ? (
+                                      <img
+                                        src={src}
+                                        alt={name}
+                                        style={{ display: 'block' }}
+                                      />
+                                    ) : (
+                                      /* eslint-disable-next-line jsx-a11y/media-has-caption */
+                                      <video
+                                        src={src}
+                                        alt={name}
+                                        // The position:relative wrapper shrink-
+                                        // wraps its content, and plate overlays
+                                        // are percentage-positioned against that
+                                        // wrapper, so the video must fill it
+                                        // exactly like the img above does:
+                                        // display:block closes the inline
+                                        // baseline gap, and max-width:100%
+                                        // (which marx-css gives img but not
+                                        // video) keeps the video from
+                                        // overflowing the wrapper when it is
+                                        // wider than the container.
+                                        style={{
+                                          display: 'block',
+                                          maxWidth: '100%',
+                                        }}
+                                      />
+                                    )}
+                                  </a>
+                                  {this.renderPlateOverlays({
+                                    attachmentPlateData,
+                                  })}
+                                </div>
+
+                                <button
+                                  type="button"
+                                  style={{
+                                    position: 'absolute',
+                                    top: 0,
+                                    right: 0,
+                                    padding: 0,
+                                    margin: '1px',
+                                    color: 'red', // Ubuntu Chrome shows black otherwise
+                                    background: 'white',
+                                  }}
+                                  onClick={() => {
+                                    this.setState(state => {
+                                      const attachmentData =
+                                        state.attachmentData.filter(
+                                          file => file.name !== name,
+                                        );
+                                      if (attachmentData.length === 0) {
+                                        this.setCoords({
+                                          latitude: defaultLatitude,
+                                          longitude: defaultLongitude,
+                                        });
+                                        this.setCreateDate({
+                                          millisecondsSinceEpoch: Date.now(),
+                                        });
+                                        return {
+                                          attachmentData,
+                                          plate: '',
+                                          licenseState: 'NY',
+                                          allPlateData: null,
+                                          plateDataByAttachmentName: {},
+                                          vehicleInfoComponent: null,
+                                          violationSummaryComponent: null,
+                                        };
+                                      }
+                                      return {
+                                        attachmentData,
+                                        plateDataByAttachmentName: omit(
+                                          state.plateDataByAttachmentName,
+                                          name,
+                                        ),
+                                      };
+                                    });
+                                  }}
+                                >
+                                  <span
+                                    role="img"
+                                    aria-label="Delete photo/video"
+                                  >
+                                    ❌
+                                  </span>
+                                </button>
+                              </div>
+                            );
+                          })}
+                        </div>
+
+                        <label htmlFor="plate" ref={this.plateLabelRef}>
+                          License/Medallion:
+                          {this.state.isAlprLoading && (
+                            <CircularProgress size="1em" />
                           )}
-                        </select>
-                      </label>
-
-                      <label htmlFor="where">
-                        Where: {this.state.addressProvenance}
-                        <br />
-                        <button
-                          type="button"
-                          name="where"
-                          onClick={() => this.setState({ isMapOpen: true })}
-                          style={{
-                            width: '100%',
-                          }}
-                        >
-                          {this.state.formatted_address
-                            .split(', ')
-                            .slice(0, 2)
-                            .join(', ')}
-                        </button>
-                      </label>
-
-                      <Modal
-                        parentSelector={() =>
-                          document.querySelector(`.${homeStyles.root}`) ||
-                          document.body
-                        }
-                        isOpen={this.state.isMapOpen}
-                        onRequestClose={() =>
-                          this.setState({ isMapOpen: false })
-                        }
-                        style={{
-                          content: {
-                            padding: 0,
-                          },
-                        }}
-                      >
-                        <MyMapComponent
-                          key="map"
-                          position={{
-                            lat: this.state.latitude,
-                            lng: this.state.longitude,
-                          }}
-                          onRef={mapRef => {
-                            this.mapRef = mapRef;
-                          }}
-                          onCenterChanged={() => {
-                            const latitude = this.mapRef.getCenter().lat();
-                            const longitude = this.mapRef.getCenter().lng();
-                            this.setCoords({
-                              latitude,
-                              longitude,
-                              addressProvenance: '(manually set)',
-                            });
-                          }}
-                          onDragStart={() => {
-                            this.isDragging = true;
-                          }}
-                          onDragEnd={() => {
-                            this.isDragging = false;
-                          }}
-                          onSearchBoxMounted={this.handleSearchBoxMounted}
-                          onSearchInputMounted={Home.handleSearchInputMounted}
-                          onPlacesChanged={() => {
-                            const places = this.searchBox.getPlaces();
-
-                            const nextMarkers = places.map(place => ({
-                              position: place.geometry.location,
-                            }));
-                            const { latitude, longitude } =
-                              nextMarkers.length > 0
-                                ? {
-                                    latitude: nextMarkers[0].position.lat(),
-                                    longitude: nextMarkers[0].position.lng(),
-                                  }
-                                : this.state;
-
-                            this.setCoords({
-                              latitude,
-                              longitude,
-                              addressProvenance: '(manually set)',
-                            });
-                          }}
-                        />
-
-                        <button
-                          type="button"
-                          style={{
-                            float: 'left',
-                          }}
-                          onClick={() => {
-                            geolocate()
-                              .then(
-                                ({
-                                  coords: { latitude, longitude },
-                                  ipProvenance = 'device',
-                                }) => {
-                                  this.setCoords({
-                                    latitude,
-                                    longitude,
-                                    addressProvenance: `(from ${ipProvenance}: ${latitude}, ${longitude})`,
+                          <div
+                            style={{
+                              display: 'flex',
+                              flexWrap: 'wrap',
+                              alignItems: 'flex-start',
+                              gap: '0.5rem',
+                            }}
+                          >
+                            <div style={{ minWidth: 0, flex: 1 }}>
+                              <input
+                                required
+                                type="search"
+                                value={this.state.plate}
+                                name="plate"
+                                list="plateSuggestions"
+                                autoComplete="off"
+                                ref={this.plateRef}
+                                placeholder={this.state.allPlateData?.results?.[0]?.plate?.toUpperCase()}
+                                onChange={event => {
+                                  const plate = upperCaseInputValueInPlace(
+                                    event.target,
+                                  );
+                                  const matchedResult =
+                                    this.state.allPlateData?.results?.find(
+                                      r => r.plate?.toUpperCase() === plate,
+                                    );
+                                  const licenseState = matchedResult
+                                    ? getLicenseStateFromPlateResult(
+                                        matchedResult,
+                                      )
+                                    : null;
+                                  this.setLicensePlate({ plate, licenseState });
+                                }}
+                              />
+                              <datalist id="plateSuggestions">
+                                {this.state.allPlateData?.results?.map(
+                                  result => (
+                                    <option
+                                      value={result.plate?.toUpperCase()}
+                                    />
+                                  ),
+                                )}
+                              </datalist>
+                              <select
+                                style={{
+                                  marginTop: '0.5rem',
+                                }}
+                                value={this.state.licenseState}
+                                name="licenseState"
+                                onChange={event => {
+                                  this.setLicensePlate({
+                                    plate: this.state.plate,
+                                    licenseState: event.target.value,
                                   });
-                                },
-                              )
-                              .catch(err => {
-                                Home.notifyError(err.message);
-                                console.error(err);
-                              });
-                          }}
-                        >
-                          Use current location
-                        </button>
+                                }}
+                              >
+                                {Object.entries(usStateNames)
+                                  .sort(([, name1], [, name2]) =>
+                                    name1
+                                      .toUpperCase()
+                                      .localeCompare(name2.toUpperCase()),
+                                  )
+                                  .map(([abbr, name]) => (
+                                    <option key={abbr} value={abbr}>
+                                      {name}
+                                    </option>
+                                  ))}
+                              </select>
+                            </div>
+                            {matchingPlateThumbnail && (
+                              <img
+                                src={matchingPlateThumbnail}
+                                alt="Detected license plate"
+                                style={{
+                                  maxHeight: '5rem',
+                                  maxWidth: '12rem',
+                                  objectFit: 'contain',
+                                }}
+                              />
+                            )}
+                          </div>
+                          <div>{this.state.violationSummaryComponent}</div>
+                          <div>{this.state.vehicleInfoComponent}</div>
+                        </label>
 
-                        <button
-                          type="button"
-                          onClick={() => this.setState({ isMapOpen: false })}
-                          style={{
-                            float: 'right',
-                          }}
-                        >
-                          Close
-                        </button>
-                      </Modal>
+                        <label htmlFor="typeofcomplaint">
+                          Type:{' '}
+                          <select
+                            value={this.state.typeofcomplaint}
+                            name="typeofcomplaint"
+                            onChange={this.handleInputChange}
+                          >
+                            {this.props.typeofcomplaintValues.map(
+                              typeofcomplaint => (
+                                <option
+                                  key={typeofcomplaint}
+                                  value={typeofcomplaint}
+                                >
+                                  {typeofcomplaint}
+                                </option>
+                              ),
+                            )}
+                          </select>
+                        </label>
 
-                      <label htmlFor="CreateDate">
-                        When:{' '}
-                        <input
-                          required
-                          type="datetime-local"
-                          value={this.state.CreateDate}
-                          name="CreateDate"
-                          onChange={this.handleInputChange}
-                        />
-                      </label>
+                        <label htmlFor="where">
+                          Where: {this.state.addressProvenance}
+                          <br />
+                          <button
+                            type="button"
+                            name="where"
+                            onClick={() => this.setState({ isMapOpen: true })}
+                            style={{
+                              width: '100%',
+                            }}
+                          >
+                            {this.state.formatted_address
+                              .split(', ')
+                              .slice(0, 2)
+                              .join(', ')}
+                          </button>
+                        </label>
 
-                      <label htmlFor="reportDescription">
-                        Description:{' '}
-                        <textarea
-                          value={this.state.reportDescription}
-                          name="reportDescription"
-                          onChange={this.handleInputChange}
-                          autoComplete="off"
-                        />
-                      </label>
-
-                      {this.state.isSubmitting ? (
-                        <progress
-                          max={this.state.submitProgressMax}
-                          value={this.state.submitProgressValue}
-                          style={{
-                            width: '100%',
-                          }}
-                        >
-                          {this.state.submitProgressValue}/
-                          {this.state.submitProgressMax}
-                        </progress>
-                      ) : (
-                        <button
-                          type="submit"
-                          disabled={
-                            this.state.isSubmitting ||
-                            !this.state.coordsAreInNyc
+                        <Modal
+                          parentSelector={() =>
+                            document.querySelector(`.${homeStyles.root}`) ||
+                            document.body
+                          }
+                          isOpen={this.state.isMapOpen}
+                          onRequestClose={() =>
+                            this.setState({ isMapOpen: false })
                           }
                           style={{
-                            width: '100%',
+                            content: {
+                              padding: 0,
+                            },
                           }}
                         >
-                          Submit
-                        </button>
-                      )}
-                    </React.Fragment>
-                  )}
-                </fieldset>
-              </form>
-            )}
+                          <MyMapComponent
+                            key="map"
+                            position={{
+                              lat: this.state.latitude,
+                              lng: this.state.longitude,
+                            }}
+                            onRef={mapRef => {
+                              this.mapRef = mapRef;
+                            }}
+                            onCenterChanged={() => {
+                              const latitude = this.mapRef.getCenter().lat();
+                              const longitude = this.mapRef.getCenter().lng();
+                              this.setCoords({
+                                latitude,
+                                longitude,
+                                addressProvenance: '(manually set)',
+                              });
+                            }}
+                            onDragStart={() => {
+                              this.isDragging = true;
+                            }}
+                            onDragEnd={() => {
+                              this.isDragging = false;
+                            }}
+                            onSearchBoxMounted={this.handleSearchBoxMounted}
+                            onSearchInputMounted={Home.handleSearchInputMounted}
+                            onPlacesChanged={() => {
+                              const places = this.searchBox.getPlaces();
+
+                              const nextMarkers = places.map(place => ({
+                                position: place.geometry.location,
+                              }));
+                              const { latitude, longitude } =
+                                nextMarkers.length > 0
+                                  ? {
+                                      latitude: nextMarkers[0].position.lat(),
+                                      longitude: nextMarkers[0].position.lng(),
+                                    }
+                                  : this.state;
+
+                              this.setCoords({
+                                latitude,
+                                longitude,
+                                addressProvenance: '(manually set)',
+                              });
+                            }}
+                          />
+
+                          <button
+                            type="button"
+                            style={{
+                              float: 'left',
+                            }}
+                            onClick={() => {
+                              geolocate()
+                                .then(
+                                  ({
+                                    coords: { latitude, longitude },
+                                    ipProvenance = 'device',
+                                  }) => {
+                                    this.setCoords({
+                                      latitude,
+                                      longitude,
+                                      addressProvenance: `(from ${ipProvenance}: ${latitude}, ${longitude})`,
+                                    });
+                                  },
+                                )
+                                .catch(err => {
+                                  Home.notifyError(err.message);
+                                  console.error(err);
+                                });
+                            }}
+                          >
+                            Use current location
+                          </button>
+
+                          <button
+                            type="button"
+                            onClick={() => this.setState({ isMapOpen: false })}
+                            style={{
+                              float: 'right',
+                            }}
+                          >
+                            Close
+                          </button>
+                        </Modal>
+
+                        <label htmlFor="CreateDate">
+                          When:{' '}
+                          <input
+                            required
+                            type="datetime-local"
+                            value={this.state.CreateDate}
+                            name="CreateDate"
+                            onChange={this.handleInputChange}
+                          />
+                        </label>
+
+                        <label htmlFor="reportDescription">
+                          Description:{' '}
+                          <textarea
+                            value={this.state.reportDescription}
+                            name="reportDescription"
+                            onChange={this.handleInputChange}
+                            autoComplete="off"
+                          />
+                        </label>
+
+                        {this.state.isSubmitting ? (
+                          <progress
+                            max={this.state.submitProgressMax}
+                            value={this.state.submitProgressValue}
+                            style={{
+                              width: '100%',
+                            }}
+                          >
+                            {this.state.submitProgressValue}/
+                            {this.state.submitProgressMax}
+                          </progress>
+                        ) : (
+                          <button
+                            type="submit"
+                            disabled={
+                              this.state.isSubmitting ||
+                              !this.state.coordsAreInNyc
+                            }
+                            style={{
+                              width: '100%',
+                            }}
+                          >
+                            Submit
+                          </button>
+                        )}
+                      </React.Fragment>
+                    )}
+                  </fieldset>
+                </form>
+              )}
 
             <br />
 
-            {this.isLoggedIn() && !this.state.isEditProfileOpen && (
-              <details
-                onToggle={evt => {
-                  const isPreviousSubmissionsOpen = evt.currentTarget.open;
-                  const shouldLoadPreviousSubmissions =
-                    isPreviousSubmissionsOpen &&
-                    !this.state.isPreviousSubmissionsLoading &&
-                    !this.state.isLoadPreviousSubmissionsEnabled &&
-                    !this.state.hasLoadedPreviousSubmissions;
+            {this.isLoggedIn() &&
+              !this.state.isEditProfileOpen &&
+              !this.state.isPreferencesOpen && (
+                <details
+                  onToggle={evt => {
+                    const isPreviousSubmissionsOpen = evt.currentTarget.open;
+                    const shouldLoadPreviousSubmissions =
+                      isPreviousSubmissionsOpen &&
+                      !this.state.isPreviousSubmissionsLoading &&
+                      !this.state.isLoadPreviousSubmissionsEnabled &&
+                      !this.state.hasLoadedPreviousSubmissions;
 
-                  this.setState(
-                    {
-                      isPreviousSubmissionsOpen,
-                    },
-                    () => {
-                      if (shouldLoadPreviousSubmissions) {
-                        this.loadPreviousSubmissions();
+                    this.setState(
+                      {
+                        isPreviousSubmissionsOpen,
+                      },
+                      () => {
+                        if (shouldLoadPreviousSubmissions) {
+                          this.loadPreviousSubmissions();
+                        }
+                      },
+                    );
+                  }}
+                >
+                  <summary>
+                    Previous Submissions ({previousSubmissionsSummary})
+                  </summary>
+
+                  {this.state.isPreviousSubmissionsOpen && (
+                    <PreviousSubmissionsList
+                      submissions={this.state.submissions}
+                      onDeleteSubmission={this.onDeleteSubmission}
+                      isLoading={this.state.isPreviousSubmissionsLoading}
+                      hasLoadedPreviousSubmissions={
+                        this.state.hasLoadedPreviousSubmissions
                       }
-                    },
-                  );
-                }}
-              >
-                <summary>
-                  Previous Submissions ({previousSubmissionsSummary})
-                </summary>
-
-                {this.state.isPreviousSubmissionsOpen && (
-                  <PreviousSubmissionsList
-                    submissions={this.state.submissions}
-                    onDeleteSubmission={this.onDeleteSubmission}
-                    isLoading={this.state.isPreviousSubmissionsLoading}
-                    hasLoadedPreviousSubmissions={
-                      this.state.hasLoadedPreviousSubmissions
-                    }
-                  />
-                )}
-              </details>
-            )}
+                    />
+                  )}
+                </details>
+              )}
 
             <div style={{ float: 'right' }}>
               <a

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1684,6 +1684,8 @@ class Home extends React.Component {
   render() {
     const matchingPlateThumbnail = this.findMatchingPlateThumbnail();
     const previousSubmissionsSummary = this.getPreviousSubmissionsSummary();
+    const isSettingsPanelOpen =
+      this.state.isEditProfileOpen || this.state.isPreferencesOpen;
 
     return (
       <Dropzone
@@ -2207,620 +2209,612 @@ class Home extends React.Component {
                 </p>
               </div>
             )}
-            {this.isLoggedIn() &&
-              !this.state.isEditProfileOpen &&
-              !this.state.isPreferencesOpen && (
-                <form
-                  onSubmit={async e => {
-                    e.preventDefault();
+            {this.isLoggedIn() && !isSettingsPanelOpen && (
+              <form
+                onSubmit={async e => {
+                  e.preventDefault();
 
-                    if (
-                      this.state.latitude === defaultLatitude &&
-                      this.state.longitude === defaultLongitude
-                    ) {
-                      Home.notifyError(
-                        'Please provide the location of the incident',
-                      );
-                      return;
-                    }
-
-                    this.setState({
-                      isSubmitting: true,
-                    });
-
-                    // Collect pre-uploaded IDs for all attachment files
-                    const attachmentIds = await Promise.all(
-                      this.state.attachmentData.map(async file => {
-                        const uploadPromise = fileUploadPromises.get(file);
-                        if (!uploadPromise) return null;
-                        try {
-                          return await uploadPromise;
-                        } catch (_err) {
-                          console.error(
-                            'Background attachment upload failed:',
-                            _err,
-                          );
-                          return null;
-                        }
-                      }),
+                  if (
+                    this.state.latitude === defaultLatitude &&
+                    this.state.longitude === defaultLongitude
+                  ) {
+                    Home.notifyError(
+                      'Please provide the location of the incident',
                     );
-                    const hasAllIds =
-                      attachmentIds.length > 0 &&
-                      attachmentIds.every(id => id !== null);
+                    return;
+                  }
 
-                    axios
-                      .post(
-                        '/submit',
-                        serialize(
-                          hasAllIds
-                            ? {
-                                ...this.getPerSubmissionState(),
-                                attachmentIds: JSON.stringify(attachmentIds),
-                                CreateDate: new Date(
-                                  this.state.CreateDate,
-                                ).toISOString(),
-                              }
-                            : {
-                                ...this.getPerSubmissionState(),
-                                attachmentData: this.state.attachmentData,
-                                CreateDate: new Date(
-                                  this.state.CreateDate,
-                                ).toISOString(),
-                              },
-                          { allowEmptyArrays: true },
-                        ),
-                        {
-                          onUploadProgress: progressEvent => {
-                            const {
-                              loaded: submitProgressValue,
-                              total: submitProgressMax,
-                            } = progressEvent;
+                  this.setState({
+                    isSubmitting: true,
+                  });
 
-                            this.setState({
-                              submitProgressValue,
-                              submitProgressMax,
-                            });
-                          },
-
-                          onDownloadProgress: progressEvent => {
-                            const {
-                              loaded: submitProgressValue,
-                              total: submitProgressMax,
-                            } = progressEvent;
-
-                            this.setState({
-                              submitProgressValue,
-                              submitProgressMax,
-                            });
-                          },
-                        },
-                      )
-                      .then(({ data }) => {
-                        const { submission } = data;
-                        document.querySelector(`.${homeStyles.root}`).scrollTo({
-                          top: 100,
-                          left: 100,
-                          behavior: 'smooth',
-                        });
-                        console.info(
-                          `submitted successfully. Returned data: ${JSON.stringify(
-                            data,
-                            null,
-                            2,
-                          )}`,
+                  // Collect pre-uploaded IDs for all attachment files
+                  const attachmentIds = await Promise.all(
+                    this.state.attachmentData.map(async file => {
+                      const uploadPromise = fileUploadPromises.get(file);
+                      if (!uploadPromise) return null;
+                      try {
+                        return await uploadPromise;
+                      } catch (_err) {
+                        console.error(
+                          'Background attachment upload failed:',
+                          _err,
                         );
-                        this.setState(state => ({
-                          attachmentData: [],
-                          submissions: [submission].concat(state.submissions),
-                          allPlateData: null,
-                          plateDataByAttachmentName: {},
-                          vehicleInfoComponent: null,
-                          violationSummaryComponent: null,
-                          reportDescription: '',
-                        }));
-                        this.setLicensePlate({ plate: '', licenseState: 'NY' });
-                        this.setCoords({
-                          latitude: defaultLatitude,
-                          longitude: defaultLongitude,
-                        });
-                        Home.notifySuccess(
-                          <React.Fragment>
-                            <p>Thanks for your submission!</p>
-                            <p>
-                              Your information has been submitted to Reported.
-                              It may take up to 24 hours for it to be processed.
-                            </p>
+                        return null;
+                      }
+                    }),
+                  );
+                  const hasAllIds =
+                    attachmentIds.length > 0 &&
+                    attachmentIds.every(id => id !== null);
 
-                            {/*
+                  axios
+                    .post(
+                      '/submit',
+                      serialize(
+                        hasAllIds
+                          ? {
+                              ...this.getPerSubmissionState(),
+                              attachmentIds: JSON.stringify(attachmentIds),
+                              CreateDate: new Date(
+                                this.state.CreateDate,
+                              ).toISOString(),
+                            }
+                          : {
+                              ...this.getPerSubmissionState(),
+                              attachmentData: this.state.attachmentData,
+                              CreateDate: new Date(
+                                this.state.CreateDate,
+                              ).toISOString(),
+                            },
+                        { allowEmptyArrays: true },
+                      ),
+                      {
+                        onUploadProgress: progressEvent => {
+                          const {
+                            loaded: submitProgressValue,
+                            total: submitProgressMax,
+                          } = progressEvent;
+
+                          this.setState({
+                            submitProgressValue,
+                            submitProgressMax,
+                          });
+                        },
+
+                        onDownloadProgress: progressEvent => {
+                          const {
+                            loaded: submitProgressValue,
+                            total: submitProgressMax,
+                          } = progressEvent;
+
+                          this.setState({
+                            submitProgressValue,
+                            submitProgressMax,
+                          });
+                        },
+                      },
+                    )
+                    .then(({ data }) => {
+                      const { submission } = data;
+                      document.querySelector(`.${homeStyles.root}`).scrollTo({
+                        top: 100,
+                        left: 100,
+                        behavior: 'smooth',
+                      });
+                      console.info(
+                        `submitted successfully. Returned data: ${JSON.stringify(
+                          data,
+                          null,
+                          2,
+                        )}`,
+                      );
+                      this.setState(state => ({
+                        attachmentData: [],
+                        submissions: [submission].concat(state.submissions),
+                        allPlateData: null,
+                        plateDataByAttachmentName: {},
+                        vehicleInfoComponent: null,
+                        violationSummaryComponent: null,
+                        reportDescription: '',
+                      }));
+                      this.setLicensePlate({ plate: '', licenseState: 'NY' });
+                      this.setCoords({
+                        latitude: defaultLatitude,
+                        longitude: defaultLongitude,
+                      });
+                      Home.notifySuccess(
+                        <React.Fragment>
+                          <p>Thanks for your submission!</p>
+                          <p>
+                            Your information has been submitted to Reported. It
+                            may take up to 24 hours for it to be processed.
+                          </p>
+
+                          {/*
                         <p>objectId: {data.submission.objectId}</p>
                         */}
-                          </React.Fragment>,
-                        );
-                      })
-                      .catch(Home.handleAxiosError)
-                      .then(() => {
-                        this.setState({
-                          isSubmitting: false,
-                          submitProgressValue: null,
-                          submitProgressMax: null,
-                        });
-                      })
-                      .then(() => {
-                        this.savePersistentStateToCookie();
+                        </React.Fragment>,
+                      );
+                    })
+                    .catch(Home.handleAxiosError)
+                    .then(() => {
+                      this.setState({
+                        isSubmitting: false,
+                        submitProgressValue: null,
+                        submitProgressMax: null,
                       });
-                  }}
-                >
-                  <fieldset disabled={this.state.isSubmitting}>
-                    <FileReaderInput
-                      multiple
-                      as="buffer"
-                      onChange={this.handleAttachmentInput}
-                      style={{
-                        float: 'left',
-                        margin: '1px',
-                      }}
-                    >
-                      <button type="button" style={{ whiteSpace: 'wrap' }}>
-                        Add pictures/videos (up to 3 each, 20MB max each)
-                      </button>
-                    </FileReaderInput>
+                    })
+                    .then(() => {
+                      this.savePersistentStateToCookie();
+                    });
+                }}
+              >
+                <fieldset disabled={this.state.isSubmitting}>
+                  <FileReaderInput
+                    multiple
+                    as="buffer"
+                    onChange={this.handleAttachmentInput}
+                    style={{
+                      float: 'left',
+                      margin: '1px',
+                    }}
+                  >
+                    <button type="button" style={{ whiteSpace: 'wrap' }}>
+                      Add pictures/videos (up to 3 each, 20MB max each)
+                    </button>
+                  </FileReaderInput>
 
-                    <div style={{ clear: 'both' }} />
+                  <div style={{ clear: 'both' }} />
 
-                    {this.state.attachmentData.length > 0 && (
-                      <React.Fragment>
+                  {this.state.attachmentData.length > 0 && (
+                    <React.Fragment>
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexWrap: 'wrap',
+                        }}
+                      >
+                        {this.state.attachmentData.map(attachmentFile => {
+                          const { name } = attachmentFile;
+                          const ext = fileExtension(name);
+                          const isImg = isImage({ ext });
+                          const src = getBlobUrl(attachmentFile);
+                          const attachmentPlateData =
+                            this.state.plateDataByAttachmentName[name];
+
+                          return (
+                            <div
+                              key={name}
+                              style={{
+                                width: '33%',
+                                margin: '0.1%',
+                                flexGrow: 1,
+                                position: 'relative',
+                              }}
+                            >
+                              <div
+                                style={{
+                                  position: 'relative',
+                                  display: 'inline-block',
+                                  maxWidth: '100%',
+                                }}
+                              >
+                                <a
+                                  href={src}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  style={{ display: 'block' }}
+                                >
+                                  {isImg ? (
+                                    <img
+                                      src={src}
+                                      alt={name}
+                                      style={{ display: 'block' }}
+                                    />
+                                  ) : (
+                                    /* eslint-disable-next-line jsx-a11y/media-has-caption */
+                                    <video
+                                      src={src}
+                                      alt={name}
+                                      // The position:relative wrapper shrink-
+                                      // wraps its content, and plate overlays
+                                      // are percentage-positioned against that
+                                      // wrapper, so the video must fill it
+                                      // exactly like the img above does:
+                                      // display:block closes the inline
+                                      // baseline gap, and max-width:100%
+                                      // (which marx-css gives img but not
+                                      // video) keeps the video from
+                                      // overflowing the wrapper when it is
+                                      // wider than the container.
+                                      style={{
+                                        display: 'block',
+                                        maxWidth: '100%',
+                                      }}
+                                    />
+                                  )}
+                                </a>
+                                {this.renderPlateOverlays({
+                                  attachmentPlateData,
+                                })}
+                              </div>
+
+                              <button
+                                type="button"
+                                style={{
+                                  position: 'absolute',
+                                  top: 0,
+                                  right: 0,
+                                  padding: 0,
+                                  margin: '1px',
+                                  color: 'red', // Ubuntu Chrome shows black otherwise
+                                  background: 'white',
+                                }}
+                                onClick={() => {
+                                  this.setState(state => {
+                                    const attachmentData =
+                                      state.attachmentData.filter(
+                                        file => file.name !== name,
+                                      );
+                                    if (attachmentData.length === 0) {
+                                      this.setCoords({
+                                        latitude: defaultLatitude,
+                                        longitude: defaultLongitude,
+                                      });
+                                      this.setCreateDate({
+                                        millisecondsSinceEpoch: Date.now(),
+                                      });
+                                      return {
+                                        attachmentData,
+                                        plate: '',
+                                        licenseState: 'NY',
+                                        allPlateData: null,
+                                        plateDataByAttachmentName: {},
+                                        vehicleInfoComponent: null,
+                                        violationSummaryComponent: null,
+                                      };
+                                    }
+                                    return {
+                                      attachmentData,
+                                      plateDataByAttachmentName: omit(
+                                        state.plateDataByAttachmentName,
+                                        name,
+                                      ),
+                                    };
+                                  });
+                                }}
+                              >
+                                <span
+                                  role="img"
+                                  aria-label="Delete photo/video"
+                                >
+                                  ❌
+                                </span>
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+
+                      <label htmlFor="plate" ref={this.plateLabelRef}>
+                        License/Medallion:
+                        {this.state.isAlprLoading && (
+                          <CircularProgress size="1em" />
+                        )}
                         <div
                           style={{
                             display: 'flex',
                             flexWrap: 'wrap',
+                            alignItems: 'flex-start',
+                            gap: '0.5rem',
                           }}
                         >
-                          {this.state.attachmentData.map(attachmentFile => {
-                            const { name } = attachmentFile;
-                            const ext = fileExtension(name);
-                            const isImg = isImage({ ext });
-                            const src = getBlobUrl(attachmentFile);
-                            const attachmentPlateData =
-                              this.state.plateDataByAttachmentName[name];
-
-                            return (
-                              <div
-                                key={name}
-                                style={{
-                                  width: '33%',
-                                  margin: '0.1%',
-                                  flexGrow: 1,
-                                  position: 'relative',
-                                }}
-                              >
-                                <div
-                                  style={{
-                                    position: 'relative',
-                                    display: 'inline-block',
-                                    maxWidth: '100%',
-                                  }}
-                                >
-                                  <a
-                                    href={src}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    style={{ display: 'block' }}
-                                  >
-                                    {isImg ? (
-                                      <img
-                                        src={src}
-                                        alt={name}
-                                        style={{ display: 'block' }}
-                                      />
-                                    ) : (
-                                      /* eslint-disable-next-line jsx-a11y/media-has-caption */
-                                      <video
-                                        src={src}
-                                        alt={name}
-                                        // The position:relative wrapper shrink-
-                                        // wraps its content, and plate overlays
-                                        // are percentage-positioned against that
-                                        // wrapper, so the video must fill it
-                                        // exactly like the img above does:
-                                        // display:block closes the inline
-                                        // baseline gap, and max-width:100%
-                                        // (which marx-css gives img but not
-                                        // video) keeps the video from
-                                        // overflowing the wrapper when it is
-                                        // wider than the container.
-                                        style={{
-                                          display: 'block',
-                                          maxWidth: '100%',
-                                        }}
-                                      />
-                                    )}
-                                  </a>
-                                  {this.renderPlateOverlays({
-                                    attachmentPlateData,
-                                  })}
-                                </div>
-
-                                <button
-                                  type="button"
-                                  style={{
-                                    position: 'absolute',
-                                    top: 0,
-                                    right: 0,
-                                    padding: 0,
-                                    margin: '1px',
-                                    color: 'red', // Ubuntu Chrome shows black otherwise
-                                    background: 'white',
-                                  }}
-                                  onClick={() => {
-                                    this.setState(state => {
-                                      const attachmentData =
-                                        state.attachmentData.filter(
-                                          file => file.name !== name,
-                                        );
-                                      if (attachmentData.length === 0) {
-                                        this.setCoords({
-                                          latitude: defaultLatitude,
-                                          longitude: defaultLongitude,
-                                        });
-                                        this.setCreateDate({
-                                          millisecondsSinceEpoch: Date.now(),
-                                        });
-                                        return {
-                                          attachmentData,
-                                          plate: '',
-                                          licenseState: 'NY',
-                                          allPlateData: null,
-                                          plateDataByAttachmentName: {},
-                                          vehicleInfoComponent: null,
-                                          violationSummaryComponent: null,
-                                        };
-                                      }
-                                      return {
-                                        attachmentData,
-                                        plateDataByAttachmentName: omit(
-                                          state.plateDataByAttachmentName,
-                                          name,
-                                        ),
-                                      };
-                                    });
-                                  }}
-                                >
-                                  <span
-                                    role="img"
-                                    aria-label="Delete photo/video"
-                                  >
-                                    ❌
-                                  </span>
-                                </button>
-                              </div>
-                            );
-                          })}
-                        </div>
-
-                        <label htmlFor="plate" ref={this.plateLabelRef}>
-                          License/Medallion:
-                          {this.state.isAlprLoading && (
-                            <CircularProgress size="1em" />
-                          )}
-                          <div
-                            style={{
-                              display: 'flex',
-                              flexWrap: 'wrap',
-                              alignItems: 'flex-start',
-                              gap: '0.5rem',
-                            }}
-                          >
-                            <div style={{ minWidth: 0, flex: 1 }}>
-                              <input
-                                required
-                                type="search"
-                                value={this.state.plate}
-                                name="plate"
-                                list="plateSuggestions"
-                                autoComplete="off"
-                                ref={this.plateRef}
-                                placeholder={this.state.allPlateData?.results?.[0]?.plate?.toUpperCase()}
-                                onChange={event => {
-                                  const plate = upperCaseInputValueInPlace(
-                                    event.target,
+                          <div style={{ minWidth: 0, flex: 1 }}>
+                            <input
+                              required
+                              type="search"
+                              value={this.state.plate}
+                              name="plate"
+                              list="plateSuggestions"
+                              autoComplete="off"
+                              ref={this.plateRef}
+                              placeholder={this.state.allPlateData?.results?.[0]?.plate?.toUpperCase()}
+                              onChange={event => {
+                                const plate = upperCaseInputValueInPlace(
+                                  event.target,
+                                );
+                                const matchedResult =
+                                  this.state.allPlateData?.results?.find(
+                                    r => r.plate?.toUpperCase() === plate,
                                   );
-                                  const matchedResult =
-                                    this.state.allPlateData?.results?.find(
-                                      r => r.plate?.toUpperCase() === plate,
-                                    );
-                                  const licenseState = matchedResult
-                                    ? getLicenseStateFromPlateResult(
-                                        matchedResult,
-                                      )
-                                    : null;
-                                  this.setLicensePlate({ plate, licenseState });
-                                }}
-                              />
-                              <datalist id="plateSuggestions">
-                                {this.state.allPlateData?.results?.map(
-                                  result => (
-                                    <option
-                                      value={result.plate?.toUpperCase()}
-                                    />
-                                  ),
-                                )}
-                              </datalist>
-                              <select
-                                style={{
-                                  marginTop: '0.5rem',
-                                }}
-                                value={this.state.licenseState}
-                                name="licenseState"
-                                onChange={event => {
-                                  this.setLicensePlate({
-                                    plate: this.state.plate,
-                                    licenseState: event.target.value,
-                                  });
-                                }}
-                              >
-                                {Object.entries(usStateNames)
-                                  .sort(([, name1], [, name2]) =>
-                                    name1
-                                      .toUpperCase()
-                                      .localeCompare(name2.toUpperCase()),
-                                  )
-                                  .map(([abbr, name]) => (
-                                    <option key={abbr} value={abbr}>
-                                      {name}
-                                    </option>
-                                  ))}
-                              </select>
-                            </div>
-                            {matchingPlateThumbnail && (
-                              <img
-                                src={matchingPlateThumbnail}
-                                alt="Detected license plate"
-                                style={{
-                                  maxHeight: '5rem',
-                                  maxWidth: '12rem',
-                                  objectFit: 'contain',
-                                }}
-                              />
-                            )}
+                                const licenseState = matchedResult
+                                  ? getLicenseStateFromPlateResult(
+                                      matchedResult,
+                                    )
+                                  : null;
+                                this.setLicensePlate({ plate, licenseState });
+                              }}
+                            />
+                            <datalist id="plateSuggestions">
+                              {this.state.allPlateData?.results?.map(result => (
+                                <option value={result.plate?.toUpperCase()} />
+                              ))}
+                            </datalist>
+                            <select
+                              style={{
+                                marginTop: '0.5rem',
+                              }}
+                              value={this.state.licenseState}
+                              name="licenseState"
+                              onChange={event => {
+                                this.setLicensePlate({
+                                  plate: this.state.plate,
+                                  licenseState: event.target.value,
+                                });
+                              }}
+                            >
+                              {Object.entries(usStateNames)
+                                .sort(([, name1], [, name2]) =>
+                                  name1
+                                    .toUpperCase()
+                                    .localeCompare(name2.toUpperCase()),
+                                )
+                                .map(([abbr, name]) => (
+                                  <option key={abbr} value={abbr}>
+                                    {name}
+                                  </option>
+                                ))}
+                            </select>
                           </div>
-                          <div>{this.state.violationSummaryComponent}</div>
-                          <div>{this.state.vehicleInfoComponent}</div>
-                        </label>
+                          {matchingPlateThumbnail && (
+                            <img
+                              src={matchingPlateThumbnail}
+                              alt="Detected license plate"
+                              style={{
+                                maxHeight: '5rem',
+                                maxWidth: '12rem',
+                                objectFit: 'contain',
+                              }}
+                            />
+                          )}
+                        </div>
+                        <div>{this.state.violationSummaryComponent}</div>
+                        <div>{this.state.vehicleInfoComponent}</div>
+                      </label>
 
-                        <label htmlFor="typeofcomplaint">
-                          Type:{' '}
-                          <select
-                            value={this.state.typeofcomplaint}
-                            name="typeofcomplaint"
-                            onChange={this.handleInputChange}
-                          >
-                            {this.props.typeofcomplaintValues.map(
-                              typeofcomplaint => (
-                                <option
-                                  key={typeofcomplaint}
-                                  value={typeofcomplaint}
-                                >
-                                  {typeofcomplaint}
-                                </option>
-                              ),
-                            )}
-                          </select>
-                        </label>
+                      <label htmlFor="typeofcomplaint">
+                        Type:{' '}
+                        <select
+                          value={this.state.typeofcomplaint}
+                          name="typeofcomplaint"
+                          onChange={this.handleInputChange}
+                        >
+                          {this.props.typeofcomplaintValues.map(
+                            typeofcomplaint => (
+                              <option
+                                key={typeofcomplaint}
+                                value={typeofcomplaint}
+                              >
+                                {typeofcomplaint}
+                              </option>
+                            ),
+                          )}
+                        </select>
+                      </label>
 
-                        <label htmlFor="where">
-                          Where: {this.state.addressProvenance}
-                          <br />
-                          <button
-                            type="button"
-                            name="where"
-                            onClick={() => this.setState({ isMapOpen: true })}
-                            style={{
-                              width: '100%',
-                            }}
-                          >
-                            {this.state.formatted_address
-                              .split(', ')
-                              .slice(0, 2)
-                              .join(', ')}
-                          </button>
-                        </label>
+                      <label htmlFor="where">
+                        Where: {this.state.addressProvenance}
+                        <br />
+                        <button
+                          type="button"
+                          name="where"
+                          onClick={() => this.setState({ isMapOpen: true })}
+                          style={{
+                            width: '100%',
+                          }}
+                        >
+                          {this.state.formatted_address
+                            .split(', ')
+                            .slice(0, 2)
+                            .join(', ')}
+                        </button>
+                      </label>
 
-                        <Modal
-                          parentSelector={() =>
-                            document.querySelector(`.${homeStyles.root}`) ||
-                            document.body
-                          }
-                          isOpen={this.state.isMapOpen}
-                          onRequestClose={() =>
-                            this.setState({ isMapOpen: false })
+                      <Modal
+                        parentSelector={() =>
+                          document.querySelector(`.${homeStyles.root}`) ||
+                          document.body
+                        }
+                        isOpen={this.state.isMapOpen}
+                        onRequestClose={() =>
+                          this.setState({ isMapOpen: false })
+                        }
+                        style={{
+                          content: {
+                            padding: 0,
+                          },
+                        }}
+                      >
+                        <MyMapComponent
+                          key="map"
+                          position={{
+                            lat: this.state.latitude,
+                            lng: this.state.longitude,
+                          }}
+                          onRef={mapRef => {
+                            this.mapRef = mapRef;
+                          }}
+                          onCenterChanged={() => {
+                            const latitude = this.mapRef.getCenter().lat();
+                            const longitude = this.mapRef.getCenter().lng();
+                            this.setCoords({
+                              latitude,
+                              longitude,
+                              addressProvenance: '(manually set)',
+                            });
+                          }}
+                          onDragStart={() => {
+                            this.isDragging = true;
+                          }}
+                          onDragEnd={() => {
+                            this.isDragging = false;
+                          }}
+                          onSearchBoxMounted={this.handleSearchBoxMounted}
+                          onSearchInputMounted={Home.handleSearchInputMounted}
+                          onPlacesChanged={() => {
+                            const places = this.searchBox.getPlaces();
+
+                            const nextMarkers = places.map(place => ({
+                              position: place.geometry.location,
+                            }));
+                            const { latitude, longitude } =
+                              nextMarkers.length > 0
+                                ? {
+                                    latitude: nextMarkers[0].position.lat(),
+                                    longitude: nextMarkers[0].position.lng(),
+                                  }
+                                : this.state;
+
+                            this.setCoords({
+                              latitude,
+                              longitude,
+                              addressProvenance: '(manually set)',
+                            });
+                          }}
+                        />
+
+                        <button
+                          type="button"
+                          style={{
+                            float: 'left',
+                          }}
+                          onClick={() => {
+                            geolocate()
+                              .then(
+                                ({
+                                  coords: { latitude, longitude },
+                                  ipProvenance = 'device',
+                                }) => {
+                                  this.setCoords({
+                                    latitude,
+                                    longitude,
+                                    addressProvenance: `(from ${ipProvenance}: ${latitude}, ${longitude})`,
+                                  });
+                                },
+                              )
+                              .catch(err => {
+                                Home.notifyError(err.message);
+                                console.error(err);
+                              });
+                          }}
+                        >
+                          Use current location
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={() => this.setState({ isMapOpen: false })}
+                          style={{
+                            float: 'right',
+                          }}
+                        >
+                          Close
+                        </button>
+                      </Modal>
+
+                      <label htmlFor="CreateDate">
+                        When:{' '}
+                        <input
+                          required
+                          type="datetime-local"
+                          value={this.state.CreateDate}
+                          name="CreateDate"
+                          onChange={this.handleInputChange}
+                        />
+                      </label>
+
+                      <label htmlFor="reportDescription">
+                        Description:{' '}
+                        <textarea
+                          value={this.state.reportDescription}
+                          name="reportDescription"
+                          onChange={this.handleInputChange}
+                          autoComplete="off"
+                        />
+                      </label>
+
+                      {this.state.isSubmitting ? (
+                        <progress
+                          max={this.state.submitProgressMax}
+                          value={this.state.submitProgressValue}
+                          style={{
+                            width: '100%',
+                          }}
+                        >
+                          {this.state.submitProgressValue}/
+                          {this.state.submitProgressMax}
+                        </progress>
+                      ) : (
+                        <button
+                          type="submit"
+                          disabled={
+                            this.state.isSubmitting ||
+                            !this.state.coordsAreInNyc
                           }
                           style={{
-                            content: {
-                              padding: 0,
-                            },
+                            width: '100%',
                           }}
                         >
-                          <MyMapComponent
-                            key="map"
-                            position={{
-                              lat: this.state.latitude,
-                              lng: this.state.longitude,
-                            }}
-                            onRef={mapRef => {
-                              this.mapRef = mapRef;
-                            }}
-                            onCenterChanged={() => {
-                              const latitude = this.mapRef.getCenter().lat();
-                              const longitude = this.mapRef.getCenter().lng();
-                              this.setCoords({
-                                latitude,
-                                longitude,
-                                addressProvenance: '(manually set)',
-                              });
-                            }}
-                            onDragStart={() => {
-                              this.isDragging = true;
-                            }}
-                            onDragEnd={() => {
-                              this.isDragging = false;
-                            }}
-                            onSearchBoxMounted={this.handleSearchBoxMounted}
-                            onSearchInputMounted={Home.handleSearchInputMounted}
-                            onPlacesChanged={() => {
-                              const places = this.searchBox.getPlaces();
-
-                              const nextMarkers = places.map(place => ({
-                                position: place.geometry.location,
-                              }));
-                              const { latitude, longitude } =
-                                nextMarkers.length > 0
-                                  ? {
-                                      latitude: nextMarkers[0].position.lat(),
-                                      longitude: nextMarkers[0].position.lng(),
-                                    }
-                                  : this.state;
-
-                              this.setCoords({
-                                latitude,
-                                longitude,
-                                addressProvenance: '(manually set)',
-                              });
-                            }}
-                          />
-
-                          <button
-                            type="button"
-                            style={{
-                              float: 'left',
-                            }}
-                            onClick={() => {
-                              geolocate()
-                                .then(
-                                  ({
-                                    coords: { latitude, longitude },
-                                    ipProvenance = 'device',
-                                  }) => {
-                                    this.setCoords({
-                                      latitude,
-                                      longitude,
-                                      addressProvenance: `(from ${ipProvenance}: ${latitude}, ${longitude})`,
-                                    });
-                                  },
-                                )
-                                .catch(err => {
-                                  Home.notifyError(err.message);
-                                  console.error(err);
-                                });
-                            }}
-                          >
-                            Use current location
-                          </button>
-
-                          <button
-                            type="button"
-                            onClick={() => this.setState({ isMapOpen: false })}
-                            style={{
-                              float: 'right',
-                            }}
-                          >
-                            Close
-                          </button>
-                        </Modal>
-
-                        <label htmlFor="CreateDate">
-                          When:{' '}
-                          <input
-                            required
-                            type="datetime-local"
-                            value={this.state.CreateDate}
-                            name="CreateDate"
-                            onChange={this.handleInputChange}
-                          />
-                        </label>
-
-                        <label htmlFor="reportDescription">
-                          Description:{' '}
-                          <textarea
-                            value={this.state.reportDescription}
-                            name="reportDescription"
-                            onChange={this.handleInputChange}
-                            autoComplete="off"
-                          />
-                        </label>
-
-                        {this.state.isSubmitting ? (
-                          <progress
-                            max={this.state.submitProgressMax}
-                            value={this.state.submitProgressValue}
-                            style={{
-                              width: '100%',
-                            }}
-                          >
-                            {this.state.submitProgressValue}/
-                            {this.state.submitProgressMax}
-                          </progress>
-                        ) : (
-                          <button
-                            type="submit"
-                            disabled={
-                              this.state.isSubmitting ||
-                              !this.state.coordsAreInNyc
-                            }
-                            style={{
-                              width: '100%',
-                            }}
-                          >
-                            Submit
-                          </button>
-                        )}
-                      </React.Fragment>
-                    )}
-                  </fieldset>
-                </form>
-              )}
+                          Submit
+                        </button>
+                      )}
+                    </React.Fragment>
+                  )}
+                </fieldset>
+              </form>
+            )}
 
             <br />
 
-            {this.isLoggedIn() &&
-              !this.state.isEditProfileOpen &&
-              !this.state.isPreferencesOpen && (
-                <details
-                  onToggle={evt => {
-                    const isPreviousSubmissionsOpen = evt.currentTarget.open;
-                    const shouldLoadPreviousSubmissions =
-                      isPreviousSubmissionsOpen &&
-                      !this.state.isPreviousSubmissionsLoading &&
-                      !this.state.isLoadPreviousSubmissionsEnabled &&
-                      !this.state.hasLoadedPreviousSubmissions;
+            {this.isLoggedIn() && !isSettingsPanelOpen && (
+              <details
+                onToggle={evt => {
+                  const isPreviousSubmissionsOpen = evt.currentTarget.open;
+                  const shouldLoadPreviousSubmissions =
+                    isPreviousSubmissionsOpen &&
+                    !this.state.isPreviousSubmissionsLoading &&
+                    !this.state.isLoadPreviousSubmissionsEnabled &&
+                    !this.state.hasLoadedPreviousSubmissions;
 
-                    this.setState(
-                      {
-                        isPreviousSubmissionsOpen,
-                      },
-                      () => {
-                        if (shouldLoadPreviousSubmissions) {
-                          this.loadPreviousSubmissions();
-                        }
-                      },
-                    );
-                  }}
-                >
-                  <summary>
-                    Previous Submissions ({previousSubmissionsSummary})
-                  </summary>
-
-                  {this.state.isPreviousSubmissionsOpen && (
-                    <PreviousSubmissionsList
-                      submissions={this.state.submissions}
-                      onDeleteSubmission={this.onDeleteSubmission}
-                      isLoading={this.state.isPreviousSubmissionsLoading}
-                      hasLoadedPreviousSubmissions={
-                        this.state.hasLoadedPreviousSubmissions
+                  this.setState(
+                    {
+                      isPreviousSubmissionsOpen,
+                    },
+                    () => {
+                      if (shouldLoadPreviousSubmissions) {
+                        this.loadPreviousSubmissions();
                       }
-                    />
-                  )}
-                </details>
-              )}
+                    },
+                  );
+                }}
+              >
+                <summary>
+                  Previous Submissions ({previousSubmissionsSummary})
+                </summary>
+
+                {this.state.isPreviousSubmissionsOpen && (
+                  <PreviousSubmissionsList
+                    submissions={this.state.submissions}
+                    onDeleteSubmission={this.onDeleteSubmission}
+                    isLoading={this.state.isPreviousSubmissionsLoading}
+                    hasLoadedPreviousSubmissions={
+                      this.state.hasLoadedPreviousSubmissions
+                    }
+                  />
+                )}
+              </details>
+            )}
 
             <div style={{ float: 'right' }}>
               <a

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1841,6 +1841,7 @@ class Home extends React.Component {
                   </label>
 
                   <h3>Preferences</h3>
+
                   <label htmlFor="isAlprEnabled">
                     <input
                       id="isAlprEnabled"
@@ -1851,6 +1852,7 @@ class Home extends React.Component {
                     />{' '}
                     Automatically read license plates from pictures/videos
                   </label>
+
                   <label htmlFor="isReverseGeocodingEnabled">
                     <input
                       id="isReverseGeocodingEnabled"
@@ -1861,6 +1863,7 @@ class Home extends React.Component {
                     />{' '}
                     Automatically read addresses from pictures/videos
                   </label>
+
                   <label htmlFor="can_be_shared_publicly">
                     <input
                       id="can_be_shared_publicly"
@@ -1872,6 +1875,7 @@ class Home extends React.Component {
                     Allow the photos/videos, description, category, and location
                     to be publicly displayed
                   </label>
+
                   <label htmlFor="isLoadPreviousSubmissionsEnabled">
                     <input
                       id="isLoadPreviousSubmissionsEnabled"

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -1839,6 +1839,50 @@ class Home extends React.Component {
                     I&apos;m willing to testify at a hearing, which can be done
                     by phone.
                   </label>
+
+                  <h3>Preferences</h3>
+                  <label htmlFor="isAlprEnabled">
+                    <input
+                      id="isAlprEnabled"
+                      type="checkbox"
+                      checked={this.state.isAlprEnabled}
+                      name="isAlprEnabled"
+                      onChange={this.handleInputChange}
+                    />{' '}
+                    Automatically read license plates from pictures/videos
+                  </label>
+                  <label htmlFor="isReverseGeocodingEnabled">
+                    <input
+                      id="isReverseGeocodingEnabled"
+                      type="checkbox"
+                      checked={this.state.isReverseGeocodingEnabled}
+                      name="isReverseGeocodingEnabled"
+                      onChange={this.handleInputChange}
+                    />{' '}
+                    Automatically read addresses from pictures/videos
+                  </label>
+                  <label htmlFor="can_be_shared_publicly">
+                    <input
+                      id="can_be_shared_publicly"
+                      type="checkbox"
+                      checked={this.state.can_be_shared_publicly}
+                      name="can_be_shared_publicly"
+                      onChange={this.handleInputChange}
+                    />{' '}
+                    Allow the photos/videos, description, category, and location
+                    to be publicly displayed
+                  </label>
+                  <label htmlFor="isLoadPreviousSubmissionsEnabled">
+                    <input
+                      id="isLoadPreviousSubmissionsEnabled"
+                      type="checkbox"
+                      checked={this.state.isLoadPreviousSubmissionsEnabled}
+                      name="isLoadPreviousSubmissionsEnabled"
+                      onChange={this.handleInputChange}
+                    />{' '}
+                    Load previous submissions on page load
+                  </label>
+
                   <button
                     type="submit"
                     className={homeStyles['auth-submit-btn']}
@@ -2294,28 +2338,6 @@ class Home extends React.Component {
 
                   <div style={{ clear: 'both' }} />
 
-                  <label htmlFor="isAlprEnabled">
-                    <input
-                      id="isAlprEnabled"
-                      type="checkbox"
-                      checked={this.state.isAlprEnabled}
-                      name="isAlprEnabled"
-                      onChange={this.handleInputChange}
-                    />{' '}
-                    Automatically read license plates from pictures/videos
-                  </label>
-
-                  <label htmlFor="isReverseGeocodingEnabled">
-                    <input
-                      id="isReverseGeocodingEnabled"
-                      type="checkbox"
-                      checked={this.state.isReverseGeocodingEnabled}
-                      name="isReverseGeocodingEnabled"
-                      onChange={this.handleInputChange}
-                    />{' '}
-                    Automatically read addresses from pictures/videos
-                  </label>
-
                   {this.state.attachmentData.length > 0 && (
                     <React.Fragment>
                       <div
@@ -2693,18 +2715,6 @@ class Home extends React.Component {
                         />
                       </label>
 
-                      <label htmlFor="can_be_shared_publicly">
-                        <input
-                          id="can_be_shared_publicly"
-                          type="checkbox"
-                          checked={this.state.can_be_shared_publicly}
-                          name="can_be_shared_publicly"
-                          onChange={this.handleInputChange}
-                        />{' '}
-                        Allow the photos/videos, description, category, and
-                        location to be publicly displayed
-                      </label>
-
                       {this.state.isSubmitting ? (
                         <progress
                           max={this.state.submitProgressMax}
@@ -2765,33 +2775,14 @@ class Home extends React.Component {
                 </summary>
 
                 {this.state.isPreviousSubmissionsOpen && (
-                  <>
-                    {/* Also show this while cached submissions are being
-                        refreshed in the background. */}
-                    {this.state.hasLoadedPreviousSubmissions && (
-                      <label
-                        htmlFor="isLoadPreviousSubmissionsEnabled"
-                        style={{ display: 'block', marginBottom: '1rem' }}
-                      >
-                        <input
-                          id="isLoadPreviousSubmissionsEnabled"
-                          type="checkbox"
-                          checked={this.state.isLoadPreviousSubmissionsEnabled}
-                          name="isLoadPreviousSubmissionsEnabled"
-                          onChange={this.handleInputChange}
-                        />{' '}
-                        Load previous submissions immediately next time
-                      </label>
-                    )}
-                    <PreviousSubmissionsList
-                      submissions={this.state.submissions}
-                      onDeleteSubmission={this.onDeleteSubmission}
-                      isLoading={this.state.isPreviousSubmissionsLoading}
-                      hasLoadedPreviousSubmissions={
-                        this.state.hasLoadedPreviousSubmissions
-                      }
-                    />
-                  </>
+                  <PreviousSubmissionsList
+                    submissions={this.state.submissions}
+                    onDeleteSubmission={this.onDeleteSubmission}
+                    isLoading={this.state.isPreviousSubmissionsLoading}
+                    hasLoadedPreviousSubmissions={
+                      this.state.hasLoadedPreviousSubmissions
+                    }
+                  />
                 )}
               </details>
             )}

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -1129,6 +1129,70 @@ describe('Home', () => {
     tree.unmount();
   });
 
+  test('renders Preferences UI', () => {
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+    };
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ initialState, homeRef });
+    });
+    renderer.act(() => {
+      homeRef.current.setState({ isPreferencesOpen: true });
+    });
+
+    expect(tree.toJSON()).toMatchSnapshot();
+    expect(tree.root.findByProps({ name: 'isAlprEnabled' })).toBeTruthy();
+    expect(
+      tree.root.findByProps({ name: 'isReverseGeocodingEnabled' }),
+    ).toBeTruthy();
+    expect(
+      tree.root.findByProps({ name: 'isLoadPreviousSubmissionsEnabled' }),
+    ).toBeTruthy();
+    // Nothing from the Edit Profile form leaks into the Preferences panel,
+    // and the main submission form is hidden while the panel is open.
+    expect(tree.root.findAllByType('form')).toHaveLength(0);
+    expect(() => tree.root.findByProps({ name: 'FirstName' })).toThrow();
+
+    tree.unmount();
+  });
+
+  test('opens only one of Edit Profile/Preferences at a time', () => {
+    const initialState = {
+      email: 'test@example.com',
+      loginSuccessful: true,
+    };
+
+    let tree;
+    const homeRef = React.createRef();
+    renderer.act(() => {
+      tree = renderHome({ initialState, homeRef });
+    });
+
+    const preferencesButton = tree.root.findAll(
+      node => node.type === 'button' && node.props.children === 'Preferences',
+    )[0];
+    renderer.act(() => {
+      preferencesButton.props.onClick();
+    });
+    expect(homeRef.current.state.isPreferencesOpen).toBe(true);
+    expect(homeRef.current.state.isEditProfileOpen).toBe(false);
+
+    const editProfileButton = tree.root.findAll(
+      node => node.type === 'button' && node.props.children === 'Edit Profile',
+    )[0];
+    renderer.act(() => {
+      editProfileButton.props.onClick();
+    });
+    expect(homeRef.current.state.isEditProfileOpen).toBe(true);
+    expect(homeRef.current.state.isPreferencesOpen).toBe(false);
+
+    tree.unmount();
+  });
+
   test('shows loading summary when refreshing cached submissions', () => {
     const initialState = {
       email: 'test@example.com',

--- a/src/routes/home/Home.test.js
+++ b/src/routes/home/Home.test.js
@@ -1129,7 +1129,7 @@ describe('Home', () => {
     tree.unmount();
   });
 
-  test('shows loading summary and auto-load checkbox when refreshing cached submissions', () => {
+  test('shows loading summary when refreshing cached submissions', () => {
     const initialState = {
       email: 'test@example.com',
       loginSuccessful: true,
@@ -1149,9 +1149,6 @@ describe('Home', () => {
     expect(homeRef.current.getPreviousSubmissionsSummary()).toBe(
       'at least 2, loading more...',
     );
-    expect(
-      tree.root.findByProps({ id: 'isLoadPreviousSubmissionsEnabled' }),
-    ).toBeTruthy();
 
     renderer.act(() => {
       homeRef.current.setState({ isPreviousSubmissionsLoading: false });

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -70,6 +70,13 @@ exports[`Home hides form fields when logged in with no photos uploaded 1`] = `
             onClick={[Function]}
             type="button"
           >
+            Preferences
+          </button>
+          <button
+            className="status-bar-btn"
+            onClick={[Function]}
+            type="button"
+          >
             Log Out
           </button>
         </div>
@@ -251,6 +258,13 @@ exports[`Home renders Edit Profile UI 1`] = `
             onClick={[Function]}
             type="button"
           >
+            Preferences
+          </button>
+          <button
+            className="status-bar-btn"
+            onClick={[Function]}
+            type="button"
+          >
             Log Out
           </button>
         </div>
@@ -323,35 +337,6 @@ exports[`Home renders Edit Profile UI 1`] = `
              
             I'm willing to testify at a hearing, which can be done by phone.
           </label>
-          <h3>
-            Preferences
-          </h3>
-          <label
-            htmlFor="isAlprEnabled"
-          >
-            <input
-              checked={true}
-              id="isAlprEnabled"
-              name="isAlprEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read license plates from pictures/videos
-          </label>
-          <label
-            htmlFor="isReverseGeocodingEnabled"
-          >
-            <input
-              checked={true}
-              id="isReverseGeocodingEnabled"
-              name="isReverseGeocodingEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read addresses from pictures/videos
-          </label>
           <label
             htmlFor="can_be_shared_publicly"
           >
@@ -364,19 +349,6 @@ exports[`Home renders Edit Profile UI 1`] = `
             />
              
             Allow the photos/videos, description, category, and location to be publicly displayed
-          </label>
-          <label
-            htmlFor="isLoadPreviousSubmissionsEnabled"
-          >
-            <input
-              checked={false}
-              id="isLoadPreviousSubmissionsEnabled"
-              name="isLoadPreviousSubmissionsEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Load previous submissions on page load
           </label>
           <button
             className="auth-submit-btn"
@@ -636,6 +608,183 @@ exports[`Home renders Log In modal UI 1`] = `
            
           to submit a report.
         </p>
+      </div>
+      <br />
+      <div
+        style={
+          {
+            "float": "right",
+          }
+        }
+      >
+        <a
+          href="/submissions-map"
+          style={
+            {
+              "background": "black",
+              "border": "1em solid black",
+              "borderRadius": "2em",
+              "textDecoration": "none",
+            }
+          }
+        >
+          <span
+            aria-label="world map"
+            role="img"
+          >
+            🗺️
+          </span>
+        </a>
+      </div>
+    </main>
+  </div>
+  <input
+    autoComplete="off"
+    disabled={false}
+    multiple={true}
+    onChange={[Function]}
+    style={
+      {
+        "bottom": 0,
+        "left": 0,
+        "opacity": 0.00001,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+    type="file"
+  />
+</div>
+`;
+
+exports[`Home renders Preferences UI 1`] = `
+<div
+  aria-disabled={false}
+  className="root"
+  onClick={[Function]}
+  onDragEnter={[Function]}
+  onDragLeave={[Function]}
+  onDragOver={[Function]}
+  onDragStart={[Function]}
+  onDrop={[Function]}
+  style={
+    {
+      "bottom": 0,
+      "left": 0,
+      "overflowY": "scroll",
+      "position": "fixed",
+      "right": 0,
+      "top": 0,
+    }
+  }
+>
+  <div
+    className="container"
+  >
+    <main>
+      <h1>
+        <a
+          href="https://reportedly.weebly.com/"
+          style={
+            {
+              "textDecoration": "underline",
+            }
+          }
+        >
+          Reported
+        </a>
+      </h1>
+      <div
+        className="Toastify"
+      />
+      <div
+        className="user-status-bar"
+      >
+        <div
+          className="user-greeting"
+        >
+          <span
+            aria-label="user"
+            role="img"
+          >
+            👤
+          </span>
+           
+          test@example.com
+        </div>
+        <div
+          className="user-actions"
+        >
+          <button
+            className="status-bar-btn-primary"
+            onClick={[Function]}
+            type="button"
+          >
+            Edit Profile
+          </button>
+          <button
+            className="status-bar-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="status-bar-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Log Out
+          </button>
+        </div>
+      </div>
+      <div
+        className="edit-profile-section"
+      >
+        <h3>
+          Preferences
+        </h3>
+        <label
+          htmlFor="isAlprEnabled"
+        >
+          <input
+            checked={true}
+            id="isAlprEnabled"
+            name="isAlprEnabled"
+            onChange={[Function]}
+            type="checkbox"
+          />
+           
+          Automatically read license plates from pictures/videos
+        </label>
+        <label
+          htmlFor="isReverseGeocodingEnabled"
+        >
+          <input
+            checked={true}
+            id="isReverseGeocodingEnabled"
+            name="isReverseGeocodingEnabled"
+            onChange={[Function]}
+            type="checkbox"
+          />
+           
+          Automatically read addresses from pictures/videos
+        </label>
+        <label
+          htmlFor="isLoadPreviousSubmissionsEnabled"
+        >
+          <input
+            checked={false}
+            id="isLoadPreviousSubmissionsEnabled"
+            name="isLoadPreviousSubmissionsEnabled"
+            onChange={[Function]}
+            type="checkbox"
+          />
+           
+          Load previous submissions on page load
+        </label>
       </div>
       <br />
       <div
@@ -1170,6 +1319,13 @@ exports[`Home renders submission form and Previous Submissions when logged in wi
             type="button"
           >
             Edit Profile
+          </button>
+          <button
+            className="status-bar-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Preferences
           </button>
           <button
             className="status-bar-btn"
@@ -1825,6 +1981,13 @@ exports[`Home renders with allPlateResults entry missing plate and photos 1`] = 
             onClick={[Function]}
             type="button"
           >
+            Preferences
+          </button>
+          <button
+            className="status-bar-btn"
+            onClick={[Function]}
+            type="button"
+          >
             Log Out
           </button>
         </div>
@@ -2468,6 +2631,13 @@ exports[`Home renders with undefined allPlateResults and photos 1`] = `
             type="button"
           >
             Edit Profile
+          </button>
+          <button
+            className="status-bar-btn"
+            onClick={[Function]}
+            type="button"
+          >
+            Preferences
           </button>
           <button
             className="status-bar-btn"

--- a/src/routes/home/__snapshots__/Home.test.js.snap
+++ b/src/routes/home/__snapshots__/Home.test.js.snap
@@ -120,32 +120,6 @@ exports[`Home hides form fields when logged in with no photos uploaded 1`] = `
               }
             }
           />
-          <label
-            htmlFor="isAlprEnabled"
-          >
-            <input
-              checked={true}
-              id="isAlprEnabled"
-              name="isAlprEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read license plates from pictures/videos
-          </label>
-          <label
-            htmlFor="isReverseGeocodingEnabled"
-          >
-            <input
-              checked={true}
-              id="isReverseGeocodingEnabled"
-              name="isReverseGeocodingEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read addresses from pictures/videos
-          </label>
         </fieldset>
       </form>
       <br />
@@ -348,6 +322,61 @@ exports[`Home renders Edit Profile UI 1`] = `
             />
              
             I'm willing to testify at a hearing, which can be done by phone.
+          </label>
+          <h3>
+            Preferences
+          </h3>
+          <label
+            htmlFor="isAlprEnabled"
+          >
+            <input
+              checked={true}
+              id="isAlprEnabled"
+              name="isAlprEnabled"
+              onChange={[Function]}
+              type="checkbox"
+            />
+             
+            Automatically read license plates from pictures/videos
+          </label>
+          <label
+            htmlFor="isReverseGeocodingEnabled"
+          >
+            <input
+              checked={true}
+              id="isReverseGeocodingEnabled"
+              name="isReverseGeocodingEnabled"
+              onChange={[Function]}
+              type="checkbox"
+            />
+             
+            Automatically read addresses from pictures/videos
+          </label>
+          <label
+            htmlFor="can_be_shared_publicly"
+          >
+            <input
+              checked={false}
+              id="can_be_shared_publicly"
+              name="can_be_shared_publicly"
+              onChange={[Function]}
+              type="checkbox"
+            />
+             
+            Allow the photos/videos, description, category, and location to be publicly displayed
+          </label>
+          <label
+            htmlFor="isLoadPreviousSubmissionsEnabled"
+          >
+            <input
+              checked={false}
+              id="isLoadPreviousSubmissionsEnabled"
+              name="isLoadPreviousSubmissionsEnabled"
+              onChange={[Function]}
+              type="checkbox"
+            />
+             
+            Load previous submissions on page load
           </label>
           <button
             className="auth-submit-btn"
@@ -1197,32 +1226,6 @@ exports[`Home renders submission form and Previous Submissions when logged in wi
               }
             }
           />
-          <label
-            htmlFor="isAlprEnabled"
-          >
-            <input
-              checked={true}
-              id="isAlprEnabled"
-              name="isAlprEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read license plates from pictures/videos
-          </label>
-          <label
-            htmlFor="isReverseGeocodingEnabled"
-          >
-            <input
-              checked={true}
-              id="isReverseGeocodingEnabled"
-              name="isReverseGeocodingEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read addresses from pictures/videos
-          </label>
           <div
             style={
               {
@@ -1679,19 +1682,6 @@ exports[`Home renders submission form and Previous Submissions when logged in wi
               onChange={[Function]}
               value=""
             />
-          </label>
-          <label
-            htmlFor="can_be_shared_publicly"
-          >
-            <input
-              checked={false}
-              id="can_be_shared_publicly"
-              name="can_be_shared_publicly"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Allow the photos/videos, description, category, and location to be publicly displayed
           </label>
           <button
             disabled={false}
@@ -1885,32 +1875,6 @@ exports[`Home renders with allPlateResults entry missing plate and photos 1`] = 
               }
             }
           />
-          <label
-            htmlFor="isAlprEnabled"
-          >
-            <input
-              checked={true}
-              id="isAlprEnabled"
-              name="isAlprEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read license plates from pictures/videos
-          </label>
-          <label
-            htmlFor="isReverseGeocodingEnabled"
-          >
-            <input
-              checked={true}
-              id="isReverseGeocodingEnabled"
-              name="isReverseGeocodingEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read addresses from pictures/videos
-          </label>
           <div
             style={
               {
@@ -2367,19 +2331,6 @@ exports[`Home renders with allPlateResults entry missing plate and photos 1`] = 
               onChange={[Function]}
               value=""
             />
-          </label>
-          <label
-            htmlFor="can_be_shared_publicly"
-          >
-            <input
-              checked={false}
-              id="can_be_shared_publicly"
-              name="can_be_shared_publicly"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Allow the photos/videos, description, category, and location to be publicly displayed
           </label>
           <button
             disabled={false}
@@ -2573,32 +2524,6 @@ exports[`Home renders with undefined allPlateResults and photos 1`] = `
               }
             }
           />
-          <label
-            htmlFor="isAlprEnabled"
-          >
-            <input
-              checked={true}
-              id="isAlprEnabled"
-              name="isAlprEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read license plates from pictures/videos
-          </label>
-          <label
-            htmlFor="isReverseGeocodingEnabled"
-          >
-            <input
-              checked={true}
-              id="isReverseGeocodingEnabled"
-              name="isReverseGeocodingEnabled"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Automatically read addresses from pictures/videos
-          </label>
           <div
             style={
               {
@@ -3055,19 +2980,6 @@ exports[`Home renders with undefined allPlateResults and photos 1`] = `
               onChange={[Function]}
               value=""
             />
-          </label>
-          <label
-            htmlFor="can_be_shared_publicly"
-          >
-            <input
-              checked={false}
-              id="can_be_shared_publicly"
-              name="can_be_shared_publicly"
-              onChange={[Function]}
-              type="checkbox"
-            />
-             
-            Allow the photos/videos, description, category, and location to be publicly displayed
           </label>
           <button
             disabled={false}


### PR DESCRIPTION
The submission form was cluttered with settings. This moves every existing setting out of the main flow and into the user status bar area, split by what each one affects:

**Edit Profile** — settings that change what is submitted to Parse
- First/last name, phone number, and the willingness-to-testify checkbox (as before)
- `can_be_shared_publicly` — previously a checkbox at the bottom of the submission form, now placed next to `testify`, since both are written onto each submission when it is created (testify is snapshotted from the `_User` into the submission at creation time)

**Preferences** — a new panel opened from its own button beside "Edit Profile"
- Automatically read license plates from pictures/videos
- Automatically read addresses from pictures/videos
- Load previous submissions on page load

The Preferences panel groups the three webapp-only toggles, which change how the page behaves but never appear in submission data. Giving them their own button makes it obvious they are a different kind of setting from the per-submission fields in Edit Profile. Opening either panel closes the other, and both hide the submission form while open, matching the existing Edit Profile behavior. All settings keep their existing persistence in the home-state cookie; there is no server or Parse schema change.

The checkbox that previously lived inside the "Previous Submissions" panel ("Load previous submissions immediately next time") is now the "Load previous submissions on page load" preference.

Tests: `Home.test.js` gains coverage for rendering the Preferences panel and for the two panels being mutually exclusive; existing snapshots were updated. The full non-flaky test suite passes and JS/CSS lint are clean.

Tried and didn't work: a separate `/settings` route (with a shared `persistentState.js` cookie module) was built and tested first, but that added a page and new files for what is essentially a move of existing UI, so it was discarded in favor of keeping everything in `Home.js`.

Co-Authored-By: Claude Code with DeepSeek